### PR TITLE
fix typo in matrix view

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -281,7 +281,7 @@ function Base.view(M::AbstractAlgebra.MatElem, rows::UnitRange{Int}, ::Colon)
 end
 
 function Base.view(M::AbstractAlgebra.MatElem, ::Colon, cols::UnitRange{Int})
-  return view(M, 1:rows(x), cols)
+  return view(M, 1:rows(M), cols)
 end
 
 ################################################################################


### PR DESCRIPTION
This only becomes useful once "Make generic matrices view-able" (previously among the Nemo pull requests) is merged, but the commits do not overlap.