### PR TITLE
change type of AllPerms.all to Int

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -49,7 +49,7 @@ doc"""
 """
 struct AllPerms{T}
   n::T
-  all::T
+  all::Int
 
   function AllPerms(n::T) where {T<:Integer}
      return new{T}(n, factorial(n))

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -107,6 +107,11 @@ function test_perm_iteration()
    @test length(collect(elements(G))) == 120
    @test length(unique(elements(G))) == 120
 
+   G = PermutationGroup(Int8(6))
+   @test collect(elements(G)) isa Vector{Generic.perm{Int8}}
+   @test length(collect(elements(G))) == 720
+   @test Generic.AllPerms(G.n).all == 720
+
    println("PASS")
 end
 


### PR DESCRIPTION
otherwise we cannot iterate over `elements(PermGroup(Int8(6))`

this is consistent with `Base.factorial(::Int8)` which returns `Int`

This won't work for `n>20`, but If You need to iterate over `S₂₀` then the fix should be elsewhere ;-) 