### PR TITLE
Add a more efficient data structure for cycle decomposition

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -6,6 +6,29 @@
 
 ###############################################################################
 #
+#   Cycle Decomposition
+#
+###############################################################################
+
+doc"""
+    CycleDec{T}(ccycles, cptrs)
+> Constructs a cycle decomposition from
+> * `ccycles`: an array of consecutive entries of cycles,
+> * `cptrs`: an array of pointers to the locations where cycles begin
+"""
+struct CycleDec{T}
+   ccycles::Vector{T}
+   cptrs::Vector{Int}
+   n::Int
+
+   function CycleDec(ccycles::Vector{T}, cptrs::Vector{Int}) where T<:Integer
+      push!(cptrs, length(ccycles)+1)
+      return new{T}(ccycles, cptrs, length(cptrs)-1)
+   end
+end
+
+###############################################################################
+#
 #   PermGroup / perm
 #
 ###############################################################################
@@ -30,7 +53,7 @@ end
 
 mutable struct perm{T<:Integer} <: AbstractAlgebra.GroupElem
   d::Array{T, 1}
-  cycles::Vector{Vector{T}}
+  cycles::CycleDec{T}
   parent::PermGroup{T}
 
   function perm(n::T) where T<:Integer


### PR DESCRIPTION
```julia
using AbstractAlgebra
import AbstractAlgebra.Generic: CycleDec, cycledec
using BenchmarkTools
function perm_sample(N::T=1000; samplesize=1000, seed=1234) where T<:Integer
    srand(seed)
    G = PermutationGroup(N)
    return [rand(G) for i in 1:samplesize]
end

ps = perm_sample(N)
function test_pow(ps)
    k = 0
    for p in ps 
        pp = p^6
        k+= (pp)[1]
        cycledec(pp.d)
    end
    k
end
@benchmark test_pow(ps)
```
`N = 1000`,  old:
```
  memory estimate:  25.15 MiB
  allocs estimate:  35408
  --------------
  minimum time:     17.508 ms (7.32% GC)
  median time:      17.784 ms (7.39% GC)
  mean time:        18.480 ms (8.37% GC)
  maximum time:     31.734 ms (17.22% GC)
  --------------
  samples:          271
  evals/sample:     1
```
`N = 1000`, new:
```
  memory estimate:  16.76 MiB
  allocs estimate:  25621
  --------------
  minimum time:     9.265 ms (0.00% GC)
  median time:      11.123 ms (12.76% GC)
  mean time:        10.914 ms (10.17% GC)
  maximum time:     13.668 ms (11.86% GC)
  --------------
  samples:          458
  evals/sample:     1
```
for `N=100` the ratio of medians is `3 (ms) : 2 (ms)`; for `N=10000` it is `177:106`

Tests will follow soon, as I rework the testsuite to run for all (reasonable) integer types.