### PR TITLE
Fix/perm full parametrisation

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -90,18 +90,18 @@ doc"""
 > Partition represents integer partition into numbers in non-increasing order.
 > It is a thin wrapper over `Vector{Int}`
 """
-mutable struct Partition{T} <: AbstractVector{Integer}
-   n::T
-   part::Vector{T}
+mutable struct Partition <: AbstractVector{Int}
+   n::Int
+   part::Vector{Int}
 
-   function Partition(part::Vector{T}, check::Bool=true) where T
+   function Partition(part::Vector{T}, check::Bool=true) where T<:Integer
       if check
          all(diff(part) .<= zero(T)) || throw("Partition must be decreasing!")
          if length(part) > zero(T)
             part[end] >= one(T) || throw("Found non-positive entry in partition!")
          end
       end
-      return new{T}(sum(part), part)
+      return new(sum(part), part)
    end
 end
 
@@ -110,8 +110,8 @@ doc"""
 > Returns an iterator over all integer `Partition`s of `n`. They come in
 > ascending order. See also `Combinatorics.partitions(n)`.
 """
-struct AllParts{T}
-    n::T
+struct AllParts
+    n::Int
 end
 
 ###############################################################################

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -6,6 +6,29 @@
 
 ###############################################################################
 #
+#   Cycle Decomposition
+#
+###############################################################################
+
+doc"""
+    CycleDec{T}(ccycles, cptrs)
+> Constructs a cycle decomposition from
+> * `ccycles`: an array of consecutive entries of cycles,
+> * `cptrs`: an array of pointers to the locations where cycles begin
+"""
+struct CycleDec{T}
+   ccycles::Vector{T}
+   cptrs::Vector{Int}
+   n::Int
+
+   function CycleDec(ccycles::Vector{T}, cptrs::Vector{Int}) where T<:Integer
+      push!(cptrs, length(ccycles)+1)
+      return new{T}(ccycles, cptrs, length(cptrs)-1)
+   end
+end
+
+###############################################################################
+#
 #   PermGroup / perm
 #
 ###############################################################################
@@ -30,7 +53,7 @@ end
 
 mutable struct perm{T<:Integer} <: AbstractAlgebra.GroupElem
   d::Array{T, 1}
-  cycles::Vector{Vector{T}}
+  cycles::CycleDec{T}
   parent::PermGroup{T}
 
   function perm(n::T) where T<:Integer

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -434,8 +434,8 @@ doc"""
 > Return the permutation matrix representing `a` via natural embedding of the
 > permutation group into general linear group over ZZ
 """
-function matrix_repr(a::perm)
-   A = eye(Int, parent(a).n)
+function matrix_repr(a::perm{T}) where {T}
+   A = eye(T, parent(a).n)
    return A[a.d,:]
 end
 

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -37,18 +37,18 @@ function Base.hash(a::perm, h::UInt)
    return b
 end
 
-function getindex(a::perm{T}, n::S) where {T<:Integer, S<:Integer}
+function getindex(a::perm, n::Integer)
    return a.d[n]
 end
 
-function setindex!(a::perm{T}, v::T, n::S) where {T<:Integer, S<:Integer}
+function setindex!(a::perm, v::Integer, n::Integer)
    a.d[n] = v
 end
 
 Base.promote_rule(::Type{perm{I}}, ::Type{perm{J}}) where {I,J} =
    perm{promote_type(I,J)}
 
-convert(::Type{perm{I}}, p::perm{J}) where {I,J} = (PermGroup(I(parent(p).n)))(p.d, false)
+convert(::Type{perm{T}}, p::perm) where {T} = (PermGroup(T(parent(p).n)))(p.d, false)
 
 ###############################################################################
 #

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -208,9 +208,9 @@ const _perm_display_style = PermDisplayStyle(:array)
 doc"""
     setpermstyle(format::Symbol)
 > Nemo can display (in REPL or in general as string) permutations by either
-> array of integers whose `n`-th position represents value at `n`, or as
-> disjoint cycles, where the value of permutation at `n` is represented as the
-> entry immediately following `n` in the cycle.
+> array of integers whose `n`-th position represents the value at `n`, or as
+> disjoint cycles, where the value of the permutation at `n` is represented as
+> the entry immediately following `n` in a cycle.
 > The style can be switched by calling `setpermstyle` with `:array` or
 > `:cycles` argument.
 """

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -12,7 +12,7 @@ length(p::Partition) = length(p.part)
 
 size(p::Partition) = size(p.part)
 
-Base.IndexStyle(::Type{T}) where T<:Partition = Base.IndexLinear()
+Base.IndexStyle(::Type{Partition}) = Base.IndexLinear()
 
 getindex(p::Partition, i::T) where T<:Integer = p.part[i]
 

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -16,15 +16,13 @@ Base.IndexStyle(::Type{T}) where T<:Partition = Base.IndexLinear()
 
 getindex(p::Partition, i::T) where T<:Integer = p.part[i]
 
-function setindex!(p::Partition{T}, v::T, i::T) where T<:Integer
+function setindex!(p::Partition, v::Integer, i::Int)
    prev = Inf
    nex = 1
-   if i == length(p)
+   if i != 1
       prev = p[i-1]
-   elseif i == 1
-      nex = p[2]
-   elseif 1 < i < length(p)
-      prev = p[i-1]
+   end
+   if i != length(p)
       nex = p[i+1]
    end
    nex <= v <= prev || throw("Partition must be positive and non-increasing")

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -202,8 +202,7 @@ doc"""
 >     "The computational complexity of rules for the character table of Sn"
 >     _Journal of Symbolic Computation_, 37(6), 2004, p. 727-748.
 """
-function MN1inner(R::BitVector, mu::Partition, t::Integer,
-   charvals=Dict{Tuple{BitVector,Vector{Int}}, BigInt}())
+function MN1inner(R::BitVector, mu::Partition, t::Integer, charvals)
    if t > length(mu)
       chi = 1
    elseif mu[t] > length(R)

--- a/test/Groups-test.jl
+++ b/test/Groups-test.jl
@@ -2,6 +2,6 @@ include("generic/YoungTabs-test.jl")
 include("generic/Perm-test.jl")
 
 function test_groups()
-   test_ytabs()
+   test_youngtabs()
    test_perm()
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -220,7 +220,10 @@ function test_characters()
 
    N = 4
    G = PermutationGroup(N)
+
    ps = Partition.([[1,1,1,1], [2,1,1], [2,2], [3,1], [4]])
+   @test Set(AllParts(N)) == Set(ps)
+
    l = Partition([1,1,1,1])
    @test [character(l, m) for m in ps] == [ 1,-1, 1, 1,-1]
    l = Partition([2,1,1])

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -196,6 +196,8 @@ function test_misc_functions(types)
       @test order(G()) isa (T == BigInt ? BigInt : Int)
       @test order(G()) == 1
       @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
+      @test Generic.permtype(a) isa Vector{Int}
+      @test Generic.permtype(a) == [6,3,1]
       @test cycles(a)[1] isa Vector{T}
       @test cycles(a)[1] == T[1,2,3,5,6,7]
       @test cycles(a)[2] == T[4]
@@ -209,12 +211,16 @@ function test_misc_functions(types)
       p = G([9,5,4,7,3,8,2,10,1,6])
 
       @test collect(cycles(p)) == [T[1,9],T[2,5,3,4,7],T[6,8,10]]
+      @test Generic.permtype(p) == [5, 3, 2]
       @test order(p) == 30
       @test collect(cycles(p^2)) == [T[1], T[2,3,7,5,4], T[6,10,8], T[9]]
+      @test Generic.permtype(p^2) == [5, 3, 1, 1]
       @test order(p^2) == 15
       @test collect(cycles(p^3)) == [T[1,9], T[2,4,5,7,3], T[6], T[8], T[10]]
+      @test Generic.permtype(p^3) == [5, 2, 1, 1, 1]
       @test order(p^3) == 10
       @test collect(cycles(p^5)) == [T[1,9], T[2], T[3], T[4], T[5], T[6,10,8], T[7]]
+      @test Generic.permtype(p^5) == [3, 2, 1, 1, 1, 1, 1]
       @test order(p^5) == 6
 
       @test matrix_repr(a) isa Matrix{T}

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -8,9 +8,7 @@ function test_perm_abstract_types()
    println("PASS")
 end
 
-types = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt]
-
-function test_perm_constructors()
+function test_perm_constructors(types)
    print(rpad("perm.constructors...", 30))
 
    for T in types
@@ -40,7 +38,7 @@ function test_perm_constructors()
    println("PASS")
 end
 
-function test_perm_printing()
+function test_perm_printing(types)
    print(rpad("perm.printing...", 30))
 
    for T in types
@@ -59,7 +57,7 @@ function test_perm_printing()
    println("PASS")
 end
 
-function test_perm_basic_manipulation()
+function test_perm_basic_manipulation(types)
    print(rpad("perm.basic_manipulation...", 30))
 
    for T in types
@@ -86,7 +84,7 @@ function test_perm_basic_manipulation()
    println("PASS")
 end
 
-function test_perm_iteration()
+function test_perm_iteration(types)
    print(rpad("perm.iteration...", 30))
    for T in types
       print("$T ")
@@ -96,17 +94,19 @@ function test_perm_iteration()
       @test_skip order(G) isa Int
       @test order(G) == 720
 
-      @test collect(elements(G))[1] == G()
+      @test collect(elements(G)) isa Vector{perm{T}}
 
-      @test length(collect(elements(G))) == 720
-      @test length(unique(elements(G))) == 720
+      elts = collect(elements(G))
 
+      @test collect(elts)[1] == G()
+      @test length(elts) == 720
+      @test length(unique(elts)) == 720
    end
 
    println("PASS")
 end
 
-function test_perm_binary_ops()
+function test_perm_binary_ops(types)
    print(rpad("perm.binary_ops...", 30))
 
    for T in types
@@ -144,7 +144,7 @@ function test_perm_binary_ops()
    println("PASS")
 end
 
-function test_perm_mixed_binary_ops()
+function test_perm_mixed_binary_ops(types)
    print(rpad("perm.mixed_binary_ops...", 30))
       G = PermutationGroup(6)
       for T in types
@@ -163,7 +163,7 @@ function test_perm_mixed_binary_ops()
    println("PASS")
 end
 
-function test_perm_inversion()
+function test_perm_inversion(types)
    print(rpad("perm.inversion...", 30))
    for T in types
       print("$T ")
@@ -183,7 +183,7 @@ function test_perm_inversion()
    println("PASS")
 end
 
-function test_misc_functions()
+function test_misc_functions(types)
    print(rpad("perm.misc...", 30))
 
    for T in types
@@ -227,7 +227,7 @@ function test_misc_functions()
    println("PASS")
 end
 
-function test_characters()
+function test_characters(types)
    print(rpad("perm.characters...",30))
 
    for T in types
@@ -242,7 +242,7 @@ function test_characters()
    G = PermutationGroup(N)
    ps = Partition.([T[1,1,1], T[2,1], T[3]])
    l = Partition(T[1,1,1])
-   @test [character(l, m) for m in ps] == [ 1,-1, 1]
+   @test [character(l, m) for m in ps] == [1,-1, 1]
    l = Partition(T[2,1])
    @test [character(l, m) for m in ps] == [ 2, 0,-1]
    l = Partition(T[3])
@@ -296,15 +296,16 @@ function test_characters()
 end
 
 function test_perm()
+   IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
    test_perm_abstract_types()
-   test_perm_constructors()
-   test_perm_printing()
-   test_perm_basic_manipulation()
-   test_perm_iteration()
-   test_perm_binary_ops()
-   test_perm_mixed_binary_ops()
-   test_perm_inversion()
-   test_misc_functions()
-   test_characters()
+   test_perm_constructors(IntTypes)
+   test_perm_printing(IntTypes)
+   test_perm_basic_manipulation(IntTypes)
+   test_perm_iteration(IntTypes)
+   test_perm_binary_ops(IntTypes)
+   test_perm_mixed_binary_ops(IntTypes)
+   test_perm_inversion(IntTypes)
+   test_misc_functions(IntTypes)
+   test_characters(IntTypes)
    println("")
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -8,253 +8,269 @@ function test_perm_abstract_types()
    println("PASS")
 end
 
+types = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt]
+
 function test_perm_constructors()
-   print("perm.constructors...")
+   print(rpad("perm.constructors...", 30))
 
-   @test elem_type(Generic.PermGroup{Int}) == Generic.perm{Int}
-   @test parent_type(Generic.perm{Int}) == Generic.PermGroup{Int}
+   for T in types
+      print("$T ")
+      @test elem_type(Generic.PermGroup{T}) == Generic.perm{T}
+      @test parent_type(Generic.perm{T}) == Generic.PermGroup{T}
 
-   R = PermutationGroup(10)
-   @test typeof(R) == Generic.PermGroup{Int}
-   @test elem_type(R) == Generic.perm{Int}
+      @test PermutationGroup(T(10)) isa Generic.PermGroup{T}
+      R = PermutationGroup(T(10))
+      @test elem_type(R) == Generic.perm{T}
 
-   a = R()
-   @test typeof(a) == Generic.perm{Int}
-   @test parent_type(typeof(a)) == Generic.PermGroup{Int}
+      @test R() isa GroupElem
+      @test R() isa Generic.perm{T}
+      a = R()
+      @test parent_type(typeof(a)) == Generic.PermGroup{T}
+      @test parent(a) == R
 
-   b = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
-   @test typeof(b) == Generic.perm{Int}
-   @test parent_type(typeof(b)) == Generic.PermGroup{Int}
+      @test R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]) isa GroupElem
+      @test R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]) isa Generic.perm{T}
+      b = R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+      @test typeof(b) == Generic.perm{T}
+      @test parent_type(typeof(b)) == Generic.PermGroup{T}
+      @test parent(b) == R
 
-
-   R = PermutationGroup(Int16(10))
-   @test typeof(R) == Generic.PermGroup{Int16}
-   @test elem_type(R) == Generic.perm{Int16}
-
-   a = R()
-   @test typeof(a) == Generic.perm{Int16}
-   @test parent_type(typeof(a)) == Generic.PermGroup{Int16}
-
-   b = R(Int16[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
-   @test typeof(b) == Generic.perm{Int16}
-   @test parent_type(typeof(b)) == Generic.PermGroup{Int16}
-
-   c = R(a)
-
-   @test isa(a, GroupElem)
-   @test isa(b, GroupElem)
-   @test isa(c, GroupElem)
+   end
 
    println("PASS")
 end
 
 function test_perm_printing()
-   print("perm.printing...")
+   print(rpad("perm.printing...", 30))
 
-   R = PermutationGroup(10)
+   for T in types
+      print("$T ")
+      R = PermutationGroup(T(10))
 
-   b = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+      b = R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   setpermstyle(:array);
-   @test string(b) == "[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]"
+      setpermstyle(:array);
+      @test string(b) == "[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]"
 
-   setpermstyle(:cycles);
-   @test string(b) == "(1,2,3,5,6,7)(8,9,10)"
+      setpermstyle(:cycles);
+      @test string(b) == "(1,2,3,5,6,7)(8,9,10)"
+   end
 
    println("PASS")
 end
 
 function test_perm_basic_manipulation()
-   print("perm.basic_manipulation...")
+   print(rpad("perm.basic_manipulation...", 30))
 
-   R = PermutationGroup(10)
+   for T in types
+      print("$T ")
+      R = PermutationGroup(T(10))
 
-   a = R()
-   b = deepcopy(a)
-   c = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+      a = R()
+      b = deepcopy(a)
+      c = R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   @test a == b
+      @test a == b
 
-   @test parity(a) == 0
-   @test parity(c) == 1
+      @test parity(a) == 0
+      @test parity(c) == 1
 
-   @test length(unique([c,deepcopy(c)])) == 1
+      @test length(unique([c,deepcopy(c)])) == 1
 
-   a[1] = 5
-   @test a[1] == 5
+      a[1] = T(5)
+      @test a[1] == T(5)
+      @test setindex!(a, 5, 1) == T(5)
+
+   end
 
    println("PASS")
 end
 
 function test_perm_iteration()
-   print("perm.iteration...")
+   print(rpad("perm.iteration...", 30))
+   for T in types
+      print("$T ")
+      G = PermutationGroup(T(6))
+      @test length(AllPerms(T(6))) == 720
+      @test length(unique(AllPerms(T(6)))) == 720
+      @test_skip order(G) isa Int
+      @test order(G) == 720
 
-   G = PermutationGroup(5)
-   @test length(AllPerms(5)) == 120
-   @test length(unique(AllPerms(5))) == 120
+      @test collect(elements(G))[1] == G()
 
-   @test collect(elements(G))[1] == G()
+      @test length(collect(elements(G))) == 720
+      @test length(unique(elements(G))) == 720
 
-   @test length(collect(elements(G))) == 120
-   @test length(unique(elements(G))) == 120
-
-   G = PermutationGroup(Int8(5))
-   @test length(AllPerms(Int8(5))) == 120
-   @test length(unique(AllPerms(Int8(5)))) == 120
-
-   @test collect(elements(G))[1] == G()
-
-   @test length(collect(elements(G))) == 120
-   @test length(unique(elements(G))) == 120
-
-   G = PermutationGroup(Int8(6))
-   @test collect(elements(G)) isa Vector{Generic.perm{Int8}}
-   @test length(collect(elements(G))) == 720
-   @test Generic.AllPerms(G.n).all == 720
+   end
 
    println("PASS")
 end
 
 function test_perm_binary_ops()
-   print("perm.binary_ops...")
+   print(rpad("perm.binary_ops...", 30))
 
-   G = PermutationGroup(3)
+   for T in types
+      print("$T ")
+      G = PermutationGroup(T(3))
 
-   a = G([2,1,3])
-   b = G([2,3,1])
+      a = G(T[2,1,3])
+      b = G(T[2,3,1])
 
-   @test a*b == G([1,3,2])
-   @test b*a == G([3,2,1])
-   @test a*a == G()
-   @test b*b*b == G()
+      @test a*b == G(T[1,3,2])
+      @test b*a == G(T[3,2,1])
+      @test a*a == G()
+      @test b*b*b == G()
 
-   @test parity(G()) == 0
-   p = parity(a)
-   @test p == 1
-   cycles(a)
-   @test parity(a) == p
+      @test parity(G()) == 0
+      p = parity(a)
+      @test p == 1
+      cycles(a)
+      @test parity(a) == p
 
-   for a in elements(G), b in elements(G)
-      @test parity(a*b) == (parity(b)+parity(a)) % 2
+      for a in elements(G), b in elements(G)
+            @test parity(a*b) == (parity(b)+parity(a)) % 2
+      end
+
+      G = PermutationGroup(T(10))
+      p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
+      @test p^0 == G()
+      @test p^1 == p
+      @test p^-1 == inv(p)
+      @test p^5 == p*p*p*p*p
+      @test p^-4 == inv(p)*inv(p)*inv(p)*inv(p)
+      @test p^2 * p^-2 == G()
+
    end
+   println("PASS")
+end
 
-   G = PermutationGroup(10)
-   p = G([9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
-   @test p^0 == G()
-   @test p^1 == p
-   @test p^-1 == inv(p)
-   @test p^5 == p*p*p*p*p
-   @test p^-4 == inv(p)*inv(p)*inv(p)*inv(p)
-   @test p^2 * p^-2 == G()
    println("PASS")
 end
 
 function test_perm_inversion()
-   print("perm.inversion...")
+   print(rpad("perm.inversion...", 30))
+   for T in types
+      print("$T ")
+      R = PermutationGroup(T(10))
 
-   R = PermutationGroup(10)
+      a = R()
+      b = R(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   a = R()
-   b = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+      @test a == inv(a)
+      @test a == b*inv(b)
 
-   @test a == inv(a)
-   @test a == b*inv(b)
-
-   G = PermutationGroup(3)
-   for a in elements(G), b in elements(G)
-      @test inv(a*b) == inv(b)*inv(a)
+      G = PermutationGroup(3)
+      for a in elements(G), b in elements(G)
+         @test inv(a*b) == inv(b)*inv(a)
+      end
    end
-
    println("PASS")
 end
 
 function test_misc_functions()
-   print("perm.misc...")
+   print(rpad("perm.misc...", 30))
 
-   G = PermutationGroup(10)
-   a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+   for T in types
+      print("$T ")
+      G = PermutationGroup(T(10))
+      a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   @test cycles(G()) == [[i] for i in 1:10]
-   @test order(G()) == 1
-   @test cycles(a) == [[1,2,3,5,6,7], [4], [8,9,10]]
-   @test order(a) == 6
-   @test a^6 == G()
+      @test cycles(G()) isa Generic.CycleDec{T}
+      @test collect(cycles(G())) == [T[i] for i in 1:10]
+      @test order(G()) isa Int
+      @test order(G()) == 1
+      @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
+      @test cycles(a)[1] isa Vector{T}
+      @test cycles(a)[1] == T[1,2,3,5,6,7]
+      @test cycles(a)[2] == T[4]
+      @test cycles(a)[3] == T[8,9,10]
+      @test cycles(a)[1:3] == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
 
-   p = G([9,5,4,7,3,8,2,10,1,6])
+      @test order(a) isa Int
+      @test order(a) == 6
+      @test a^6 == G()
 
-   @test cycles(p) == [[1,9],[2,5,3,4,7],[6,8,10]]
-   @test order(p) == 30
-   @test cycles(p^2) == [[1], [2,3,7,5,4], [6,10,8], [9]]
-   @test order(p^2) == 15
-   @test cycles(p^3) == [[1,9], [2,4,5,7,3], [6], [8], [10]]
-   @test order(p^3) == 10
-   @test cycles(p^5) == [[1,9], [2], [3], [4], [5], [6,10,8], [7]]
-   @test order(p^5) == 6
+      p = G([9,5,4,7,3,8,2,10,1,6])
 
-   M = matrix_repr(a)
-   for (idx, val) in enumerate(a.d)
-      @test M[idx, val] == 1
+      @test collect(cycles(p)) == [T[1,9],T[2,5,3,4,7],T[6,8,10]]
+      @test order(p) == 30
+      @test collect(cycles(p^2)) == [T[1], T[2,3,7,5,4], T[6,10,8], T[9]]
+      @test order(p^2) == 15
+      @test collect(cycles(p^3)) == [T[1,9], T[2,4,5,7,3], T[6], T[8], T[10]]
+      @test order(p^3) == 10
+      @test collect(cycles(p^5)) == [T[1,9], T[2], T[3], T[4], T[5], T[6,10,8], T[7]]
+      @test order(p^5) == 6
+
+      @test matrix_repr(a) isa Matrix{T}
+      M = matrix_repr(a)
+      for (idx, val) in enumerate(a.d)
+         @test M[idx, val] == 1
+      end
    end
 
    println("PASS")
 end
 
 function test_characters()
-   print("perm.characters...")
+   print(rpad("perm.characters...",30))
 
-   N = 8
+   for T in types
+   print("$T ")
+   N = T(7)
    G = PermutationGroup(N)
-   @test all(character(p)(G()) == dim(YoungTableau(p)) for p=AllParts(N))
+   @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
 
-   @test character(Partition([2,2,2,2]), Partition([8])) == 0
+   @test character(Partition(T[2,2,2,2]), Partition(T[8])) == 0
 
-   N = 3
+   N = T(3)
    G = PermutationGroup(N)
-   ps = Partition.([[1,1,1], [2,1], [3]])
-   l = Partition([1,1,1])
+   ps = Partition.([T[1,1,1], T[2,1], T[3]])
+   l = Partition(T[1,1,1])
    @test [character(l, m) for m in ps] == [ 1,-1, 1]
-   l = Partition([2,1])
+   l = Partition(T[2,1])
    @test [character(l, m) for m in ps] == [ 2, 0,-1]
-   l = Partition([3])
+   l = Partition(T[3])
    @test [character(l, m) for m in ps] == [ 1, 1, 1]
 
-   N = 4
+   N = T(4)
    G = PermutationGroup(N)
 
    ps = Partition.([[1,1,1,1], [2,1,1], [2,2], [3,1], [4]])
    @test Set(AllParts(N)) == Set(ps)
 
    l = Partition([1,1,1,1])
+
    @test [character(l, m) for m in ps] == [ 1,-1, 1, 1,-1]
-   l = Partition([2,1,1])
+   l = Partition(T[2,1,1])
    @test [character(l, m) for m in ps] == [ 3,-1,-1, 0, 1]
-   l = Partition([2,2])
+   l = Partition(T[2,2])
    @test [character(l, m) for m in ps] == [ 2, 0, 2,-1, 0]
-   l = Partition([3,1])
+   l = Partition(T[3,1])
    @test [character(l, m) for m in ps] == [ 3, 1,-1, 0,-1]
-   l = Partition([4])
+   l = Partition(T[4])
    @test [character(l, m) for m in ps] == [ 1, 1, 1, 1, 1]
 
    # values taken from GAP; note that we specify the order of partitions to be
    # compatible with GAP numbering of conjugacy classes. This is NOT the order
    # of partitions given by AllParts.
-   N = 5
+   N = T(5)
    G = PermutationGroup(N)
-   ps = Partition.([[1,1,1,1,1], [2,1,1,1], [2,2,1], [3,1,1], [3,2], [4,1], [5]])
-   l = Partition([1,1,1,1,1])
+   ps = Partition.([T[1,1,1,1,1], T[2,1,1,1], T[2,2,1], T[3,1,1], T[3,2], T[4,1], T[5]])
+   l = Partition(T[1,1,1,1,1])
    @test [character(l, m) for m in ps] == [   1,  -1,   1,   1,  -1,  -1,   1 ]
-   l = Partition([2,1,1,1])
+   l = Partition(T[2,1,1,1])
    @test [character(l, m) for m in ps] == [   4,  -2,   0,   1,   1,   0,  -1 ]
-   l = Partition([2,2,1])
+   l = Partition(T[2,2,1])
    @test [character(l, m) for m in ps] == [   5,  -1,   1,  -1,  -1,   1,   0 ]
-   l = Partition([3,1,1])
+   l = Partition(T[3,1,1])
    @test [character(l, m) for m in ps] == [   6,   0,  -2,   0,   0,   0,   1 ]
-   l = Partition([3,2])
+   l = Partition(T[3,2])
    @test [character(l, m) for m in ps] == [   5,   1,   1,  -1,   1,  -1,   0 ]
-   l = Partition([4,1])
+   l = Partition(T[4,1])
    @test [character(l, m) for m in ps] == [   4,   2,   0,   1,  -1,   0,  -1 ]
-   l = Partition([5])
+   l = Partition(T[5])
    @test [character(l, m) for m in ps] == [   1,   1,   1,   1,   1,   1,   1 ]
+   end
 
    # test for overflow
    p = Partition(collect(10:-1:1))

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -91,7 +91,8 @@ function test_perm_iteration(types)
       G = PermutationGroup(T(6))
       @test length(AllPerms(T(6))) == 720
       @test length(unique(AllPerms(T(6)))) == 720
-      @test order(G) isa (T == BigInt ? BigInt : Int)
+      @test order(G) isa BigInt
+      @test order(T, G) isa promote_type(T, Int)
       @test order(G) == 720
 
       @test collect(elements(G)) isa Vector{perm{T}}
@@ -128,7 +129,7 @@ function test_perm_binary_ops(types)
       @test parity(a) == p
 
       for a in elements(G), b in elements(G)
-            @test parity(a*b) == (parity(b)+parity(a)) % 2
+         @test parity(a*b) == (parity(b)+parity(a)) % 2
       end
 
       G = PermutationGroup(T(10))
@@ -193,8 +194,10 @@ function test_misc_functions(types)
 
       @test cycles(G()) isa Generic.CycleDec{T}
       @test collect(cycles(G())) == [T[i] for i in 1:10]
-      @test order(G()) isa (T == BigInt ? BigInt : Int)
+      @test order(G()) isa BigInt
+      @test order(T, G()) isa promote_type(Int, T)
       @test order(G()) == 1
+
       @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
       @test Generic.permtype(a) isa Vector{Int}
       @test Generic.permtype(a) == [6,3,1]
@@ -204,7 +207,8 @@ function test_misc_functions(types)
       @test cycles(a)[3] == T[8,9,10]
       @test cycles(a)[1:3] == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
 
-      @test order(a) isa (T == BigInt ? BigInt : Int)
+      @test order(a) isa BigInt
+      @test order(T, a) isa promote_type(Int, T)
       @test order(a) == 6
       @test a^6 == G()
 
@@ -240,9 +244,8 @@ function test_characters(types)
       print("$T ")
       N = T(7)
       G = PermutationGroup(N)
-      @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
 
-      @test character(Partition([2,2,2,2]), Partition([8])) == 0
+      @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
 
       N = T(3)
       G = PermutationGroup(N)
@@ -250,13 +253,26 @@ function test_characters(types)
       l = Partition(T[1,1,1])
 
       @test typeof(character(l, ps[1])) == BigInt
+      TT = (T<:Union{Unsigned, Signed} ? Int : BigInt)
+      @test typeof(character(T, l, rand(G))) == TT
+      @test typeof(character(T, l, ps[1])) == TT
 
-      @test [character(l, m) for m in ps] == [1,-1, 1]
+      @test [character(l, m) for m in ps] == [ 1,-1, 1]
       l = Partition([2,1])
       @test [character(l, m) for m in ps] == [ 2, 0,-1]
       l = Partition([3])
       @test [character(l, m) for m in ps] == [ 1, 1, 1]
+
+      k_big = character(Partition([1,1,1]), G([2,3,1]))
+      @test typeof(k_big) == BigInt
+
+      k_int = character(Int, Partition([1,1,1]), G([2,3,1]))
+      @test typeof(k_int) == Int
+
+      @test k_big == k_int
    end
+
+   @test character(Partition([2,2,2,2]), Partition([8])) == 0
 
    N = 4
    G = PermutationGroup(N)

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -91,7 +91,7 @@ function test_perm_iteration(types)
       G = PermutationGroup(T(6))
       @test length(AllPerms(T(6))) == 720
       @test length(unique(AllPerms(T(6)))) == 720
-      @test_skip order(G) isa Int
+      @test order(G) isa (T == BigInt ? BigInt : Int)
       @test order(G) == 720
 
       @test collect(elements(G)) isa Vector{perm{T}}
@@ -154,8 +154,8 @@ function test_perm_mixed_binary_ops(types)
          @test G(H()) == G()
          @test H(G()) == H()
          @test G() == H()
-         @test rand(G)*rand(H) isa (T == UInt ? perm{UInt}: perm{Int})
-         @test rand(H)*rand(G) isa (T == UInt ? perm{UInt}: perm{Int})
+         @test rand(G)*rand(H) isa perm{promote_type(Int, T)}
+         @test rand(H)*rand(G) isa perm{promote_type(Int, T)}
          @test G(rand(H)) isa perm{Int}
          @test H(rand(G)) isa perm{T}
       end
@@ -193,7 +193,7 @@ function test_misc_functions(types)
 
       @test cycles(G()) isa Generic.CycleDec{T}
       @test collect(cycles(G())) == [T[i] for i in 1:10]
-      @test order(G()) isa Int
+      @test order(G()) isa (T == BigInt ? BigInt : Int)
       @test order(G()) == 1
       @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
       @test cycles(a)[1] isa Vector{T}
@@ -202,7 +202,7 @@ function test_misc_functions(types)
       @test cycles(a)[3] == T[8,9,10]
       @test cycles(a)[1:3] == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
 
-      @test order(a) isa Int
+      @test order(a) isa (T == BigInt ? BigInt : Int)
       @test order(a) == 6
       @test a^6 == G()
 
@@ -242,6 +242,9 @@ function test_characters(types)
    G = PermutationGroup(N)
    ps = Partition.([T[1,1,1], T[2,1], T[3]])
    l = Partition(T[1,1,1])
+
+   @test typeof(character(l, ps[1])) == (T == BigInt? BigInt : Int)
+
    @test [character(l, m) for m in ps] == [1,-1, 1]
    l = Partition(T[2,1])
    @test [character(l, m) for m in ps] == [ 2, 0,-1]
@@ -289,7 +292,7 @@ function test_characters(types)
    end
 
    # test for overflow
-   p = Partition(collect(10:-1:1))
+   p = Partition(collect(big(10):-1:1))
    @test character(p, PermutationGroup(55)()) == 44261486084874072183645699204710400
 
    println("PASS")

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -231,27 +231,28 @@ function test_characters(types)
    print(rpad("perm.characters...",30))
 
    for T in types
-   print("$T ")
-   N = T(7)
-   G = PermutationGroup(N)
-   @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
+      print("$T ")
+      N = T(7)
+      G = PermutationGroup(N)
+      @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
 
-   @test character(Partition(T[2,2,2,2]), Partition(T[8])) == 0
+      @test character(Partition([2,2,2,2]), Partition([8])) == 0
 
-   N = T(3)
-   G = PermutationGroup(N)
-   ps = Partition.([T[1,1,1], T[2,1], T[3]])
-   l = Partition(T[1,1,1])
+      N = T(3)
+      G = PermutationGroup(N)
+      ps = Partition.([[1,1,1], [2,1], [3]])
+      l = Partition(T[1,1,1])
 
-   @test typeof(character(l, ps[1])) == (T == BigInt? BigInt : Int)
+      @test typeof(character(l, ps[1])) == BigInt
 
-   @test [character(l, m) for m in ps] == [1,-1, 1]
-   l = Partition(T[2,1])
-   @test [character(l, m) for m in ps] == [ 2, 0,-1]
-   l = Partition(T[3])
-   @test [character(l, m) for m in ps] == [ 1, 1, 1]
+      @test [character(l, m) for m in ps] == [1,-1, 1]
+      l = Partition([2,1])
+      @test [character(l, m) for m in ps] == [ 2, 0,-1]
+      l = Partition([3])
+      @test [character(l, m) for m in ps] == [ 1, 1, 1]
+   end
 
-   N = T(4)
+   N = 4
    G = PermutationGroup(N)
 
    ps = Partition.([[1,1,1,1], [2,1,1], [2,2], [3,1], [4]])
@@ -260,40 +261,43 @@ function test_characters(types)
    l = Partition([1,1,1,1])
 
    @test [character(l, m) for m in ps] == [ 1,-1, 1, 1,-1]
-   l = Partition(T[2,1,1])
+   l = Partition([2,1,1])
    @test [character(l, m) for m in ps] == [ 3,-1,-1, 0, 1]
-   l = Partition(T[2,2])
+   l = Partition([2,2])
    @test [character(l, m) for m in ps] == [ 2, 0, 2,-1, 0]
-   l = Partition(T[3,1])
+   l = Partition([3,1])
    @test [character(l, m) for m in ps] == [ 3, 1,-1, 0,-1]
-   l = Partition(T[4])
+   l = Partition([4])
    @test [character(l, m) for m in ps] == [ 1, 1, 1, 1, 1]
 
    # values taken from GAP; note that we specify the order of partitions to be
    # compatible with GAP numbering of conjugacy classes. This is NOT the order
    # of partitions given by AllParts.
-   N = T(5)
+   N = 5
    G = PermutationGroup(N)
-   ps = Partition.([T[1,1,1,1,1], T[2,1,1,1], T[2,2,1], T[3,1,1], T[3,2], T[4,1], T[5]])
-   l = Partition(T[1,1,1,1,1])
+   ps = Partition.([[1,1,1,1,1], [2,1,1,1], [2,2,1], [3,1,1], [3,2], [4,1], [5]])
+   @test Set(AllParts(N)) == Set(ps)
+
+   l = Partition([1,1,1,1,1])
    @test [character(l, m) for m in ps] == [   1,  -1,   1,   1,  -1,  -1,   1 ]
-   l = Partition(T[2,1,1,1])
+   l = Partition([2,1,1,1])
    @test [character(l, m) for m in ps] == [   4,  -2,   0,   1,   1,   0,  -1 ]
-   l = Partition(T[2,2,1])
+   l = Partition([2,2,1])
    @test [character(l, m) for m in ps] == [   5,  -1,   1,  -1,  -1,   1,   0 ]
-   l = Partition(T[3,1,1])
+   l = Partition([3,1,1])
    @test [character(l, m) for m in ps] == [   6,   0,  -2,   0,   0,   0,   1 ]
-   l = Partition(T[3,2])
+   l = Partition([3,2])
    @test [character(l, m) for m in ps] == [   5,   1,   1,  -1,   1,  -1,   0 ]
-   l = Partition(T[4,1])
+   l = Partition([4,1])
    @test [character(l, m) for m in ps] == [   4,   2,   0,   1,  -1,   0,  -1 ]
-   l = Partition(T[5])
+   l = Partition([5])
    @test [character(l, m) for m in ps] == [   1,   1,   1,   1,   1,   1,   1 ]
-   end
 
    # test for overflow
-   p = Partition(collect(big(10):-1:1))
-   @test character(p, PermutationGroup(55)()) == 44261486084874072183645699204710400
+
+   p = Partition(collect(10:-1:1))
+   @test character(p, PermutationGroup(big(55))()) == 44261486084874072183645699204710400
+   @test dim(YoungTableau(p)) == 44261486084874072183645699204710400
 
    println("PASS")
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -144,6 +144,22 @@ function test_perm_binary_ops()
    println("PASS")
 end
 
+function test_perm_mixed_binary_ops()
+   print(rpad("perm.mixed_binary_ops...", 30))
+      G = PermutationGroup(6)
+      for T in types
+         print("$T ")
+         H = PermutationGroup(T(6))
+
+         @test G(H()) == G()
+         @test H(G()) == H()
+         @test G() == H()
+         @test rand(G)*rand(H) isa (T == UInt ? perm{UInt}: perm{Int})
+         @test rand(H)*rand(G) isa (T == UInt ? perm{UInt}: perm{Int})
+         @test G(rand(H)) isa perm{Int}
+         @test H(rand(G)) isa perm{T}
+      end
+
    println("PASS")
 end
 
@@ -286,6 +302,7 @@ function test_perm()
    test_perm_basic_manipulation()
    test_perm_iteration()
    test_perm_binary_ops()
+   test_perm_mixed_binary_ops()
    test_perm_inversion()
    test_misc_functions()
    test_characters()

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -10,6 +10,7 @@ function test_partition_type()
    @test size(p) == (3,)
    @test p[1] == 4
    @test p[3] == 1
+   @test_throws BoundsError p[4]
 
    @test length(p) == 3
    @test sum(p) == 8
@@ -110,9 +111,6 @@ function test_skewdiags()
    @test has_bottom_neighbor(xi, 6, 1) == true
    @test has_bottom_neighbor(xi, 7, 1) == false
 
-   xi = Partition([4,3,2,1])/Partition([2,2,2,1])
-   @test isrimhook(xi) == true
-
    println("PASS")
 end
 
@@ -142,6 +140,29 @@ function test_rimhooks()
 
    xi = SkewDiagram([4,3,1], [2])
    @test isrimhook(xi) == true
+
+   xi = Partition([4,3,2,1])/Partition([2,2,2,1])
+   @test isrimhook(xi) == true
+
+   xi = Partition([4,3,2,1])/Partition([3,3,2,1])
+   @test isrimhook(xi) == true
+
+   xi = Partition([4,3,2,1])/Partition([2,2,1,1])
+   @test isrimhook(xi) == false
+
+   xi = Partition([4,3,2,1])/Partition([3,2,2,1])
+   @test isrimhook(xi) == false
+
+   xi = Partition([4,3,2,1])/Partition([3,3,1,1])
+   @test isrimhook(xi) == false
+
+   xi = Partition([4,3,2,1])/Partition([4,3,2,1])
+   @test isrimhook(xi) == true
+
+   lambda = Partition([5,3,2,2,1])
+   mu = Partition([2,2,1])
+
+   @test isrimhook(lambda/mu) == false # is disconnected
 
    println("PASS")
 end

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -38,6 +38,8 @@ function test_youngtabs()
    @test [hooklength(Y,i,j) for i in 1:size(Y,1), j in 1:size(Y,2)] ==
       [6 4 3 1; 4 2 1 0; 1 0 0 0]
 
+   @test dim(Y) isa BigInt
+
    @test dim(Y) == 70
    @test dim(YoungTableau([2,2])) == 2
    @test dim(YoungTableau([3,1])) == 3

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -25,7 +25,7 @@ function test_partition_type()
    println("PASS")
 end
 
-function test_youngtabs()
+function test_ytabs()
    print("youngtabs.YoungTableau...")
 
    lambda = [4,3,1]
@@ -165,9 +165,9 @@ function test_partitionseqs()
    println("PASS")
 end
 
-function test_ytabs()
+function test_youngtabs()
    test_partition_type()
-   test_youngtabs()
+   test_ytabs()
    test_skewdiags()
    test_rimhooks()
    test_partitionseqs()


### PR DESCRIPTION
```julia
using AbstractAlgebra
import AbstractAlgebra.Generic: CycleDec, cycledec
using BenchmarkTools
function perm_sample(N::T=1000; samplesize=1000, seed=1234) where T<:Integer
    srand(seed)
    G = PermutationGroup(N)
    return [rand(G) for i in 1:samplesize]
end

ps = perm_sample(N)
function test_pow(ps)
    k = 0
    for p in ps 
        pp = p^6
        k+= (pp)[1]
        cycledec(pp.d)
    end
    k
end
@benchmark test_pow(ps)
```
`N = 1000`,  old:
```
  memory estimate:  25.15 MiB
  allocs estimate:  35408
  --------------
  minimum time:     17.508 ms (7.32% GC)
  median time:      17.784 ms (7.39% GC)
  mean time:        18.480 ms (8.37% GC)
  maximum time:     31.734 ms (17.22% GC)
  --------------
  samples:          271
  evals/sample:     1
```
`N = 1000`, new:
```
  memory estimate:  16.76 MiB
  allocs estimate:  25621
  --------------
  minimum time:     9.265 ms (0.00% GC)
  median time:      11.123 ms (12.76% GC)
  mean time:        10.914 ms (10.17% GC)
  maximum time:     13.668 ms (11.86% GC)
  --------------
  samples:          458
  evals/sample:     1
```
for `N=100` the ratio of medians is `3 (ms) : 2 (ms)`; for `N=10000` it is `177:106`

this pull builds on top of the previous;