### PR TITLE
faster elements(::PermGroup)

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -389,40 +389,45 @@ end
 #
 ###############################################################################
 
-Base.start(A::AllPerms{T}) where T<:Integer = (collect(T, 1:A.n), one(T), one(T), ones(T, A.n))
-Base.next(A::AllPerms, state) = all_perms(state...)
-Base.done(A::AllPerms, state) = state[2] > A.all
-Base.eltype(::Type{AllPerms{T}}) where T<:Integer = Vector{T}
-length(A::AllPerms) = A.all
+Base.start(A::AllPerms{T}) where T<:Integer = (collect(T, 1:A.n), ones(Int, A.n), 0)
+Base.next(A::AllPerms, state) = nextperm(state...)
+Base.done(A::AllPerms, state) = state[end] >= A.all
+Base.eltype(::Type{AllPerms{T}}) where T<:Integer = perm{T}
+Base.length(A::AllPerms) = A.all
 
-function all_perms(elts, counter, i, c)
-   if counter == 1
-      return (copy(elts), (elts, counter+1, i, c))
+function nextperm(elts::Vector{T}, c, counter) where T
+   if counter == 0
+        return perm(elts, false), (elts, c, counter+1)
    end
-   n = length(elts)
-   @inbounds while i <= n
-      if c[i] < i
-         if isodd(i)
-            elts[1], elts[i] = elts[i], elts[1]
+
+   k = 0
+   n = 1
+
+   while true
+      if c[n] < n
+         if isodd(n)
+            k = 1
          else
-            elts[c[i]], elts[i] = elts[i], elts[c[i]]
+            k = c[n]
          end
-         c[i] += 1
-         i = 1
-         return (copy(elts), (elts, counter+1, i, c))
+         elts[k], elts[n] = elts[n], elts[k]
+         c[n] += 1
+         return perm(elts, false), (elts, c, counter+1)
       else
-         c[i] = 1
-         i += 1
+         c[n] = 1
+         n += 1
       end
    end
 end
 
 doc"""
     elements(G::PermGroup)
-> Returns an iterator over all elements in the group $G$. You may use
-> `collect(elements(G))` to get an array of all elements.
+> Return an iterator over all permutations in `G`.
+>
+> This uses the non-recursive [Heaps algorithm](https://en.wikipedia.org/wiki/Heap's_algorithm).
+> You may use `collect(elements(G))` to get a vector of all elements.
 """
-elements(G::PermGroup) = (G(p, false) for p in AllPerms(G.n))
+elements(G::PermGroup) = AllPerms(G.n)
 
 ###############################################################################
 #


### PR DESCRIPTION
Side-effect of the writing-docs project;

```julia
function generate(N::T) where T
    G = PermGroup(N)
    k = zero(T)
    for p in elements(G)
        k += p[1]
    end
    return k
end
```
* old:
  ```julia
  julia> @time generate(10);
    3.818291 seconds (36.29 M allocations: 1.352 GiB, 5.59% gc time)
  
  julia> @time generate(UInt(10));
    3.478949 seconds (36.29 M allocations: 1.352 GiB, 6.14% gc time)
  ```
* new:
  ```julia
  julia> generate(10)
    0.187002 seconds (10.89 M allocations: 332.227 MiB, 24.28% gc time)
  
  julia> generate(UInt(10))
    0.165168 seconds (10.89 M allocations: 332.227 MiB, 24.04% gc time)
  ```

I don't know why, but if nextperm returns just an array (via `return elts, (elts, c, counter+1)`) this cuts the `@time` further to `0.124588 seconds (7.26 M allocations: 221.485 MiB, 26.26% gc time)`. Where are the additional allocations comming from? Why is constructing `perm(elts, false)` so expensive, when for standalone `d = randperm(10)` `perm(d, false)` takes only `15ns`? 