### PR TITLE
non-allocating version of AllPerms

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -55,12 +55,13 @@ doc"""
 > Returns an iterator over arrays representing all permutations of `1:n`.
 > Similar to `Combinatorics.permutations(1:n)`
 """
-struct AllPerms{T}
-   n::T
+struct AllPerms{T<:Integer}
    all::Int
+   c::Vector{Int}
+   elts::perm{T}
 
-   function AllPerms(n::T) where {T<:Integer}
-      return new{T}(n, factorial(n))
+   function AllPerms(n::T) where T
+      new{T}(Int(factorial(n)), ones(Int, n), perm(collect(T, 1:n), false))
    end
 end
 

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -163,7 +163,7 @@ function test_perm_iteration(types)
       print("$T ")
       G = PermutationGroup(T(6))
       @test length(AllPerms(T(6))) == 720
-      @test length(unique(AllPerms(T(6)))) == 720
+      @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
       @test order(G) isa BigInt
       @test order(T, G) isa promote_type(T, Int)
       @test order(G) == 720


### PR DESCRIPTION
benchmark:
```julia
function generate(itr)
    k = 0
    for p in itr
        @assert p isa perm
        k += p[1]
    end
    return k
end
```
## Old:
```julia
julia> @time generate(elements(PermGroup(10));
  3.818291 seconds (36.29 M allocations: 1.352 GiB, 5.59% gc time)

julia> @time generate(UInt(10));
  3.478949 seconds (36.29 M allocations: 1.352 GiB, 6.14% gc time)
```
## New:
```julia
julia> @time K1 = generate(elements(PermGroup(10)));
  0.307158 seconds (7.26 M allocations: 664.454 MiB, 22.96% gc time)

julia> @time K2 = generate(Generic.elements!(PermGroup(10)));
  0.035850 seconds (12 allocations: 640 bytes)

julia> K1 == K2
true
```
In `generate(elements(PermGroup(10)))`:
* `p = randperm(10); perm(copy(p), false)` allocates `192` bytes and `192*factorial(10)/1024/1024 = 664.453125` (MiB of memory). I don't think You can get any better with allocating Heaps;
* there are two allocations per permutation (`perm` and `copy`?)

This puts us in the league of `C` when comparing to https://en.wikipedia.org/wiki/Heap's_algorithm#cite_note-3: For a simple loop crawling over all perms:
```julia
function allperms(N)
    elts = collect(1:N)
    c = ones(Int, N)
#     doit(elts)
    n = 1
    k = 0
    cc = 1
    while n <= length(elts)
      if c[n] < n
         k = ifelse(isodd(n), 1, c[n])
         elts[k], elts[n] = elts[n], elts[k]
         c[n] += 1
         n = 1
            cc += 1
#          doit(elts)
      else
        c[n] = 1
        n += 1
      end
   end
   return cc
end
@assert allperms(5) == factorial(5)
@time allperms(12)
@time generate(N, Generic.elements!(PermGroup(12)))
```
> `  3.373536 seconds (8 allocations: 560 bytes)`
> `  4.107824 seconds (11 allocations: 640 bytes)`

