### PR TITLE
More performant version of AllParts

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -98,6 +98,8 @@ doc"""
 """
 struct AllParts
     n::Int
+    part::Vector{Int}
+    AllParts(n::Integer) = new(n, zeros(Int,n))
 end
 
 ###############################################################################


### PR DESCRIPTION
Benchmark:
```julia
function bench(AP)
   k = 0
   for p in AP
     k += p[1]
   end
   return k
end
```
master:
```julia
julia> @time bench(AllParts(80));
  7.281104 seconds (78.98 M allocations: 8.638 GiB, 32.01% gc time)
```
this branch:
```julia
julia> @time bench(AllParts(80));
  3.321162 seconds (47.39 M allocations: 4.554 GiB, 29.93% gc time)
```
There are three allocations per generated `Partition`: the partition `Vector` of `Int`s, the `Partition` object itself (`32 bytes`) and mysterious something worth another 32 bytes (no idea where it comes from).

There might be a slightly (at most 25%) faster method in 
> Mircea Merca, "Fast algorithms for generating ascending compositions", J Math Model Algor (2012)

but its `nextperm` function (see Algorithm 7 therein) would be way more complicated, not sure it is worth.