### PR TITLE
add function "change_base_ring" for MPoly

### DIFF
--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -303,6 +303,27 @@ m = evaluate(f, Rational{BigInt}[2, 3])
 n = evaluate(f, [2, 3])
 ```
 
+In order to substitute the variables of a polynomial $f$ over a ring $T$ by elements in a $T$-algebra $S$,
+you first have to change the base ring of $f$ using the following function, where $g$ is a function
+representing the structure homomorphism of the $T$-algebra $S$.
+
+```@docs
+change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
+```
+
+**Examples**
+
+```julia
+R, (x, y) = PolynomialRing(ZZ, ["x", "y"])
+S, (u, v) = PolynomialRing(ZZ, ["u", "v"])
+
+f = 2x^2*y + 2x + y + 1
+
+evaluate(change_base_ring(f, a->S(a)), [S(1), v])
+evaluate(change_base_ring(f, a->R(a)), [y, x])
+```
+
+
 ### GCD
 
 In cases where there is a meaningful Euclidean structure on the coefficient ring, it is

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -114,7 +114,7 @@ include("julia/JuliaTypes.jl")
 
 include("Generic.jl")
 
-import .Generic: add!, addeq!, addmul!, base_ring, cached, canonical_unit,
+import .Generic: add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_ring,
                  character, characteristic, charpoly, charpoly_danilevsky!,
                  charpoly_danilevsky_ff!, charpoly_hessenberg!, chebyshev_t,
                  chebyshev_u, _check_dim, check_parent, codomain, coeff, cols,
@@ -168,7 +168,7 @@ import .Generic: add!, addeq!, addmul!, base_ring, cached, canonical_unit,
                  valuation, var, vars, weak_popov, weak_popov_with_trafo, zero,
                  zero!, zero_matrix, kronecker_product
 
-export add!, addeq!, addmul!, base_ring, cached, canonical_unit, character,
+export add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_ring, character,
                  characteristic, charpoly, charpoly_danilevsky!,
                  charpoly_danilevsky_ff!, charpoly_hessenberg!, chebyshev_t,
                  chebyshev_u, _check_dim, check_parent, codomain, coeff, cols,

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -139,9 +139,8 @@ function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: Ri
    new_base_ring = parent(new_p)
    new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(v) for v in vars_parent])
 
-   coeffs = p.coeffs
    for i=1:length(p)
-      prod = g(coeffs[i])
+      prod = g(p.coeffs[i])
       for j=1:n
          prod = prod * gens_new_polynomial_ring[j]^Int(exps[j,i])
       end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -7,7 +7,7 @@
 export max_degrees, gens, divides,
        isconstant, isdegree, ismonomial, isreverse, isterm, main_variable,
        main_variable_extract, main_variable_insert, nvars, ordering,
-       rand_ordering, vars, monomial_set!, monomial_iszero, derivative
+       rand_ordering, vars, monomial_set!, monomial_iszero, derivative, change_base_ring
 
 ###############################################################################
 #
@@ -113,6 +113,41 @@ function derivative(f::MPoly{T}, x::MPoly{T}) where {T <: RingElement}
    end
 
    return(derivative)
+end
+
+
+
+doc"""
+    change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
+> Returns the polynomial obtained by applying g to the coefficients of p.
+"""
+function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
+   vars_parent = vars(p.parent)
+
+   n = p.parent.num_vars
+   exps = p.exps
+
+   size_exps = size(p.exps)
+   if (p.parent.ord != :lex)
+      exps = exps[2:size_exps[1],:]
+   end
+   if (p.parent.ord == :degrevlex)
+      exps = exps[end:-1:1,:]
+   end
+
+   new_p = g(zero(p.parent.base_ring))
+   new_base_ring = parent(new_p)
+   new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(v) for v in vars_parent])
+
+   coeffs = p.coeffs
+   for i=1:length(p)
+      prod = g(coeffs[i])
+      for j=1:n
+         prod = prod * gens_new_polynomial_ring[j]^Int(exps[j,i])
+      end
+      new_p = new_p + prod
+   end
+   return(new_p)
 end
 
 doc"""

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -83,7 +83,7 @@ function derivative(f::MPoly{T}, x::MPoly{T}) where {T <: RingElement}
       error("Can compute the partial derivative only with respect to generators.")
    end
 
-   n = f.parent.num_vars
+   n = nvars(f.parent)
    exps = copy(f.exps)
 
    size_exps = size(f.exps)
@@ -124,7 +124,7 @@ doc"""
 function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
    vars_parent = vars(p.parent)
 
-   n = p.parent.num_vars
+   n = nvars(p.parent)
    exps = p.exps
 
    size_exps = size(p.exps)
@@ -135,7 +135,7 @@ function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: Ri
       exps = exps[end:-1:1,:]
    end
 
-   new_p = g(zero(p.parent.base_ring))
+   new_p = g(zero(base_ring(p.parent)))
    new_base_ring = parent(new_p)
    new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(v) for v in vars_parent])
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -128,10 +128,10 @@ function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: Ri
    exps = p.exps
 
    size_exps = size(p.exps)
-   if (p.parent.ord != :lex)
+   if p.parent.ord != :lex
       exps = exps[2:size_exps[1],:]
    end
-   if (p.parent.ord == :degrevlex)
+   if p.parent.ord == :degrevlex
       exps = exps[end:-1:1,:]
    end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -531,8 +531,8 @@ function test_gen_mpoly_change_base_ring()
 
       for iter in 1:10
          f = rand(R, 5:10, 1:10, -100:100)
-         @test evaluate( change_base_ring(f, a -> R(a)), [ one(R) for i=1:num_vars] ) == sum( f.coeffs[i] for i=1:f.length )
-         @test evaluate( change_base_ring(f, a -> R(a)), vars ) == f
+         @test evaluate(change_base_ring(f, a -> R(a)), [one(R) for i=1:num_vars]) == sum(f.coeffs[i] for i=1:f.length)
+         @test evaluate(change_base_ring(f, a -> R(a)), vars) == f
       end
    end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -520,6 +520,25 @@ function test_gen_mpoly_derivative()
    println("PASS")
 end
 
+function test_gen_mpoly_change_base_ring()
+   print("Generic.MPoly.change_base_ring...")
+
+   for num_vars=1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      R, vars = PolynomialRing(ZZ, var_names; ordering=ord)
+
+      for iter in 1:10
+         f = rand(R, 5:10, 1:10, -100:100)
+         @test evaluate( change_base_ring(f, a -> R(a)), [ one(R) for i=1:num_vars] ) == sum( f.coeffs[i] for i=1:f.length )
+         @test evaluate( change_base_ring(f, a -> R(a)), vars ) == f
+      end
+   end
+
+   println("PASS")
+end
+
 function test_gen_mpoly()
    test_gen_mpoly_constructors()
    test_gen_mpoly_manipulation()
@@ -535,6 +554,7 @@ function test_gen_mpoly()
    test_gen_mpoly_evaluation()
    test_gen_mpoly_valuation()
    test_gen_mpoly_derivative()
+   test_gen_mpoly_change_base_ring()
 
    println("")
 end


### PR DESCRIPTION
In #106 @thofma proposed a function `change_ring`. Here I implemented such a function, which I rather called `change_base_ring`. I do not consider it to be nice, but it works. If there is a low level constructor using the internal data structures `coeffs` and `exps`, this could probably be implemented more efficiently by simply applying `g` to coeffs. But I did not find such a constructor.