### PR TITLE
vars for MPoly

### DIFF
--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -166,6 +166,13 @@ ismonomial(f::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
 
 Return `true` if $f$ consists of a single term with coefficient $1$.
 
+```@docs
+vars(p::AbstractAlgebra.Generic.MPoly{T}) where {T <: RingElement}
+```
+
+Note that `vars(p::AbstractAlgebra.Generic.MPoly{T})` returns variables, while
+`vars(S::MyMPolyRing{T})` return symbols.
+
 **Examples**
 
 ```julia

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -165,7 +165,7 @@ import .Generic: add!, addeq!, addmul!, base_ring, cached, canonical_unit, chang
                  similarity!, snf, snf_kb, snf_kb_with_trafo, snf_with_trafo,
                  solve, solve_rational, solve_triu, sub, subst, swap_rows,
                  swap_rows!, symbols, total_degree, trail, truncate, typed_hcat, typed_hvcat, upscale,
-                 valuation, var, weak_popov, weak_popov_with_trafo, zero,
+                 valuation, var, vars, weak_popov, weak_popov_with_trafo, zero,
                  zero!, zero_matrix, kronecker_product
 
 export add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_ring, character,
@@ -218,7 +218,7 @@ export add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_rin
                  snf, snf_kb, snf_kb_with_trafo, snf_with_trafo, solve, symbols,
                  solve_rational, solve_triu, sub, subst, swap_rows, swap_rows!,
                  total_degree, trail, truncate, typed_hcat, typed_hvcat,
-                 upscale, valuation, var,
+                 upscale, valuation, var, vars,
                  weak_popov, weak_popov_with_trafo, zero, zero!,
                  zero_matrix, kronecker_product
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -6,7 +6,7 @@
 
 export max_degrees, total_degree, gens, divides,
        isconstant, isdegree, ismonomial, isreverse, isterm, main_variable,
-       main_variable_extract, main_variable_insert, nvars, ordering,
+       main_variable_extract, main_variable_insert, nvars, vars, ordering,
        rand_ordering, symbols, monomial_set!, monomial_iszero, derivative, change_base_ring
 
 ###############################################################################

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -150,6 +150,32 @@ function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: Ri
 end
 
 doc"""
+    vars(p::AbstractAlgebra.Generic.MPoly{T}) where {T <: RingElement}
+> Returns the variables occuring in $p$.
+"""
+function vars(p::AbstractAlgebra.Generic.MPoly{T}) where {T <: RingElement}
+   vars_in_p = Array{AbstractAlgebra.Generic.MPoly{T}}(0)
+   n = nvars(p.parent)
+   exps = p.exps
+   size_exps = size(exps)
+   if p.parent.ord != :lex
+      exps = exps[2:size_exps[1],:]
+   end
+   if p.parent.ord == :degrevlex
+      exps = exps[end:-1:1,:]
+   end
+   for j=1:n
+      for i=1:length(p)
+         if exps[j,i] > 0
+            push!(vars_in_p, gens(p.parent)[j])
+            break
+         end
+      end
+   end
+   return(vars_in_p)
+end
+
+doc"""
     ordering{T <: RingElement}(a::MPolyRing{T})
 > Return the ordering of the given polynomial ring as a symbol. The options are
 > `:lex`, `:deglex` and `:degrevlex`.

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -566,6 +566,25 @@ function test_gen_mpoly_change_base_ring()
    println("PASS")
 end
 
+function test_gen_mpoly_vars()
+   print("Generic.MPoly.vars...")
+
+   for num_vars=1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      R, vars_R = PolynomialRing(ZZ, var_names; ordering=ord)
+
+      for iter in 1:10
+         f = rand(R, 5:10, 1:10, -100:100)
+         @test length(vars(R(evaluate(change_base_ring(f, a -> R(a)), [one(R) for i=1:num_vars])))) == 0
+         # @test issubset(vars(f), Set(gens(parent(f)))) # This fails, probably due to https://github.com/Nemocas/AbstractAlgebra.jl/issues/111
+      end
+   end
+
+   println("PASS")
+end
+
 function test_gen_mpoly()
    test_gen_mpoly_constructors()
    test_gen_mpoly_manipulation()
@@ -583,6 +602,7 @@ function test_gen_mpoly()
    test_gen_mpoly_derivative()
    test_gen_mpoly_change_base_ring()
    test_gen_mpoly_total_degree()
+   test_gen_mpoly_vars()
 
    println("")
 end


### PR DESCRIPTION
Implementation of a function `vars` that returns the variables occurring in a multivariate polynomial of type `MPoly`.

The downside is that for a polynomial p the return type of `vars(p)` is 

Array{AbstractAlgebra.Generic.MPoly{T},1}

while the return type of `vars(parent(p))` is

Array{Symbol,1}

How about changing `vars(a::MPolyRing)` to something like `symbols(a::MPolyRing)`?