### PR TITLE
change % into - in ^(::perm, ::Integer)

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -448,7 +448,7 @@ function ^(g::perm{T}, n::Integer) where T
          k = n % l
          for (idx,j) in enumerate(cycle)
             idx += k
-            idx = (idx > l ? idx%l : idx)
+            idx = (idx > l ? idx-l : idx)
             new_perm[j] = cycle[idx]
          end
       end


### PR DESCRIPTION
this is circular shift

benchmark:
```julia
using AbstractAlgebra
using BenchmarkTools

function perm_sample(N::Integer=255; samplesize=1000, seed=1234)
    srand(seed)
    G = PermutationGroup(N)
    return [rand(G) for i in 1:samplesize]
end

function bench(sample; power = 50, pow_function=^)
    T = eltype(sample[1])
    n = T(0)
    for p in sample
        n += pow_function(p,power)[1]
    end
    return n
end

sample = perm_sample(500, samplesize=10000);
bench(sample, 50) # pre-computes cycle decompositions
@benchmark  bench(sample, 50)
```

old:
```
BenchmarkTools.Trial: 
  memory estimate:  45.31 MiB
  allocs estimate:  165828
  --------------
  minimum time:     43.933 ms (9.23% GC)
  median time:      44.832 ms (9.27% GC)
  mean time:        45.522 ms (9.60% GC)
  maximum time:     52.169 ms (8.36% GC)
  --------------
  samples:          110
  evals/sample:     1
```
new:
```
BenchmarkTools.Trial: 
  memory estimate:  45.31 MiB
  allocs estimate:  165828
  --------------
  minimum time:     31.762 ms (12.65% GC)
  median time:      32.338 ms (12.83% GC)
  mean time:        33.421 ms (13.13% GC)
  maximum time:     43.008 ms (16.66% GC)
  --------------
  samples:          150
  evals/sample:     1
```
