### PR TITLE
Fancy macros for multivariates

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -175,7 +175,7 @@ import .Generic: add!, addeq!, addmul!, base_ring, cached, canonical_unit, chang
                  solve, solve_rational, solve_triu, sub, subst, swap_rows,
                  swap_rows!, symbols, total_degree, trail, truncate, typed_hcat, typed_hvcat, upscale,
                  valuation, var, vars, weak_popov, weak_popov_with_trafo, zero,
-                 zero!, zero_matrix, kronecker_product
+                 zero!, zero_matrix, kronecker_product, @PolynomialRing
 
 export add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_ring, character,
                  characteristic, charpoly, charpoly_danilevsky!,
@@ -229,7 +229,7 @@ export add!, addeq!, addmul!, base_ring, cached, canonical_unit, change_base_rin
                  total_degree, trail, truncate, typed_hcat, typed_hvcat,
                  upscale, valuation, var, vars,
                  weak_popov, weak_popov_with_trafo, zero, zero!,
-                 zero_matrix, kronecker_product, tr, lu, lu!
+                 zero_matrix, kronecker_product, tr, lu, lu!, @PolynomialRing
 
 function exp(a::T) where T
    return Base.exp(a)

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -7,7 +7,8 @@
 export max_degrees, total_degree, gens, divides,
        isconstant, isdegree, ismonomial, isreverse, isterm, main_variable,
        main_variable_extract, main_variable_insert, nvars, vars, ordering,
-       rand_ordering, symbols, monomial_set!, monomial_iszero, derivative, change_base_ring
+       rand_ordering, symbols, monomial_set!, monomial_iszero, derivative,
+       change_base_ring, @PolynomialRing
 
 ###############################################################################
 #
@@ -3107,4 +3108,68 @@ function PolynomialRing(R::AbstractAlgebra.Ring, s::Array{String, 1}; cached::Bo
    parent_obj = MPolyRing{T}(R, U, ordering, N, cached)
 
    return tuple(parent_obj, gens(parent_obj, Val{ordering}))
+end
+
+################################################################################
+#
+#  Fancy macro
+#
+################################################################################
+
+function build_names(prefix, indices...)
+  map(i -> "$(prefix)[$(join(i, ","))]", Iterators.product(indices...))
+end
+
+function build_variable(arg::Symbol)
+  t = gensym()
+  return t, :($(esc(t)) = String[$"$arg"])
+end
+
+function build_variable(arg::Expr)
+  isa(arg, Expr) || error("Expected $var to be a variable name")
+  Base.Meta.isexpr(arg, :ref) || error("Expected $var to be of the form varname[idxset]")
+  (2 ≤ length(arg.args)) || error("Expected $var to have at least one index set")
+  varname = arg.args[1]
+  prefix = string(varname)
+  t = gensym()
+  return t, :($(esc(t)) = build_names($prefix, $(esc.(arg.args[2:end])...)))
+end
+
+function build_variables_strings(args)
+  names = Symbol[]
+  exprs = Expr[]
+  for arg in args
+    name_var, define_names = build_variable(arg)
+    push!(exprs, define_names)
+    #push!(exprs, :(print($(esc(name_var)))))
+    push!(names, name_var)
+  end
+  return names, exprs
+end
+
+macro PolynomialRing(R, args...)
+    names, exprs = build_variables_strings(args)
+    all_names = gensym()
+    push!(exprs, :($(esc(all_names)) = String[]))
+    for t in names
+      push!(exprs, :(append!($(esc(all_names)), reshape($(esc(t)), length($(esc(t)))))))
+    end
+    ring1 = gensym()
+    ring2 = gensym()
+    push!(exprs, :($(Expr(:tuple, esc(ring1), esc(ring2))) = PolynomialRing($(esc(R)), $(esc(all_names)))))
+    vars = Symbol[]
+    k = gensym()
+    push!(exprs, :($(esc(k)) = 0))
+    for (i, t) in enumerate(names)
+      var_sym = gensym()
+      if args[i] isa Symbol
+        push!(exprs, :($(esc(var_sym)) = ($(esc(ring2)))[$(esc(k)) + 1]))
+      else
+        push!(exprs, :($(esc(var_sym)) = elem_type($(esc(ring1)))[($(esc(ring2)))[$(esc(k)) + i] for (i,_) in enumerate($(esc(t)))]))
+      end
+      push!(vars, var_sym)
+      push!(exprs, :($(esc(k)) = $(esc(k)) + length($(esc(t)))))
+    end
+    res = :($(foldl((x,y) -> :($x; $y), exprs, init=:())); $(Expr(:tuple, esc(ring1), esc.(vars)...)))
+    return res
 end


### PR DESCRIPTION
@saschatimme was teasing me about our polynomial ring constructors. They are a bit clumsy in the REPL. I threw together a simple macro to make life easier. It will just overwrite whatever there was before with the same name. There are a bit fragile, but they should be good enough for interactive use. I would like to get some feedback from @wbhart, @fieker. In particular I don't know if this should support different monomial orders.
```julia
julia> @PolynomialRing ZZ x y z
Multivariate Polynomial Ring in x, y, z over Integers

julia> x + y * z
x+y*z

julia> @PolynomialRing ZZ x[1:10]
Multivariate Polynomial Ring in 10 variables x1, x2, x3, x4, ..., x10 over Integers

julia> @PolynomialRing ZZ x[1:2:10]
Multivariate Polynomial Ring in x1, x3, x5, x7, x9 over Integers

julia> @PolynomialRing ZZ x[1:2:10] y z w[1:10]
Multivariate Polynomial Ring in 17 variables x1, x3, x5, x7, ..., w10 over Integers

julia> S = @PolynomialRing ZZ x[1:2:10] y z w[1:10]
Multivariate Polynomial Ring in 17 variables x1, x3, x5, x7, ..., w10 over Integers

julia> symbols(S)
17-element Array{Symbol,1}:
 :x1 
 :x3 
 :x5 
 :x7 
 :x9 
 :y  
 :z  
 :w1 
 :w2 
 :w3 
 :w4 
 :w5 
 :w6 
 :w7 
 :w8 
 :w9 
 :w10

julia> gens(S)
17-element Array{AbstractAlgebra.Generic.MPoly{BigInt},1}:
 x1 
 x3 
 x5 
 x7 
 x9 
 y  
 z  
 w1 
 w2 
 w3 
 w4 
 w5 
 w6 
 w7 
 w8 
 w9 
 w10
```