### PR TITLE
Fixes for  `coefficients_of_univariate_MPoly` and `to_univariate`

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3165,7 +3165,7 @@ function coefficients_of_univariate_MPoly(p::AbstractAlgebra.Generic.MPoly)
       exps = exps[end:-1:1,:]
    end
    
-   degs_of_terms = sum(exps,1)
+   degs_of_terms = sum(exps,dims=1)
    order = maximum(degs_of_terms)
    coeffs = [ zero(base_ring(p)) for i=0:order ]
    for i=1:p.length

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3117,16 +3117,19 @@ function (a::MPolyRing{T})(b::Array{T, 1}, m::Array{UInt, 2}) where {T <: RingEl
    return z
 end
 
-function to_univariate(p::AbstractAlgebra.Generic.MPoly{T}) where {T <: AbstractAlgebra.RingElem}
+function to_univariate(p::MPoly{T}, R::PolyRing{T}) where {T <: AbstractAlgebra.RingElement}
    if !involves_at_most_one_variable(p)
       error("Can only convert univariate polynomials of type MPoly.")
    end
    
    vars_p = vars(p)
-   R,v = PolynomialRing(base_ring(p), string(vars_p[1]))
    
    if length(vars_p) == 0
-      return R(p.coeffs[1])
+      if iszero(p)
+         return zero(R)
+      else
+         return R(p.coeffs[1])
+      end
    end
    
    return R(coefficients_of_univariate_MPoly(p))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -592,6 +592,61 @@ function test_gen_mpoly_vars()
    println("PASS")
 end
 
+function test_gen_mpoly_to_univariate()
+   print("Generic.MPoly.to_univariate...")
+
+   for num_vars=1:10
+      ord = rand_ordering()
+
+      R, vars_R = PolynomialRing(ZZ, ["x"]; ordering=ord)
+      R_univ, x_univ = PolynomialRing(ZZ, "x")
+
+      @test zero(R_univ) == to_univariate(zero(R), R_univ)
+      @test one(R_univ) == to_univariate(one(R), R_univ)
+
+      x = vars_R[1]
+
+      for iter in 1:10
+         f = zero(R)
+         f_univ = zero(R_univ)
+         coeffs = rand(Int, 100)
+         for i in 1:100
+            f = f + coeffs[i] * x^i
+            f_univ = f_univ + coeffs[i] * x_univ^i
+         end
+         @test to_univariate(f, R_univ) == f_univ
+      end
+   end
+
+   println("PASS")
+end
+
+function test_gen_mpoly_coefficients_of_univariate_MPoly()
+   print("Generic.MPoly.coefficients_of_univariate_MPoly...")
+
+   for num_vars=1:10
+      ord = rand_ordering()
+
+      R, vars_R = PolynomialRing(ZZ, ["x"]; ordering=ord)
+
+      @test length(AbstractAlgebra.Generic.coefficients_of_univariate_MPoly(zero(R))) == 0
+      @test AbstractAlgebra.Generic.coefficients_of_univariate_MPoly(one(R)) == [ one(base_ring(R)) ]
+
+      x = vars_R[1]
+
+      for iter in 1:10
+         f = zero(R)
+         coeffs = rand(Int, 100)
+         for i in 1:100
+            f = f + coeffs[i] * x^(i-1)
+         end
+         @test AbstractAlgebra.Generic.coefficients_of_univariate_MPoly(f) == coeffs
+      end
+   end
+
+   println("PASS")
+end
+
 function test_gen_mpoly()
    test_gen_mpoly_constructors()
    test_gen_mpoly_manipulation()
@@ -610,6 +665,8 @@ function test_gen_mpoly()
    test_gen_mpoly_change_base_ring()
    test_gen_mpoly_total_degree()
    test_gen_mpoly_vars()
+   test_gen_mpoly_to_univariate()
+   test_gen_mpoly_coefficients_of_univariate_MPoly()
 
    println("")
 end


### PR DESCRIPTION
This pull requests contains fixes for the functions `to_univariate` and `coefficients_of_univariate_MPoly` and adds tests for both of them.

The function `to_univariate` was not working properly for constant polynomials. I also changed the signature of it. Now one has to pass the univariate polynomial ring as an argument.