### PR TITLE
expand test_gen_mpoly_derivative()

### DIFF
--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -547,6 +547,7 @@ function test_gen_mpoly_derivative()
          end
          @test derivative(one(R), v) == zero(R)
          @test derivative(zero(R), v) == zero(R)
+         @test derivative(v, v) == one(R)
       end
    end
 


### PR DESCRIPTION
Test whether the derivative of a generator w.r.t. this generator is one. The motivation for this test is #177. Note that this will cause the tests to fail, because of the current bug in `derivative`.