### PR TITLE
Mpoly speedups

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -91,18 +91,38 @@ end
     change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
 > Returns the polynomial obtained by applying g to the coefficients of p.
 """
-function change_base_ring(p::AbstractAlgebra.Generic.MPoly{T}, g) where {T <: RingElement}
+function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingElement}
    new_base_ring = parent(g(zero(base_ring(p.parent))))
    new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(v) for v in symbols(p.parent)], ordering = p.parent.ord)
    new_p = zero(new_polynomial_ring)
 
    for i = 1:length(p)
-      e = exponent_vector(p,i)
+      e = exponent_vector(p, i)
       set_exponent_vector!(new_p, i, e)
-      setcoeff!(new_p, e, new_base_ring(coeff(p,i)))
+      setcoeff!(new_p, e, new_base_ring(coeff(p, i)))
    end
    
    return(new_p)
+end
+
+function change_base_ring(p::MPoly{T}, g) where {T <: RingElement}
+   new_base_ring = parent(g(zero(base_ring(p.parent))))
+   new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(
+v) for v in symbols(p.parent)], ordering = p.parent.ord)
+
+   if typeof(gens_new_polynomial_ring[1]) <: MPoly
+      exps = deepcopy(p.exps)
+      coeffs = [new_base_ring(p.coeffs[i]) for i in 1:length(p)]
+      return new_polynomial_ring(coeffs, exps)
+   else
+      new_p = zero(new_polynomial_ring)
+      for i = 1:length(p)
+         e = exponent_vector(p, i)
+         set_exponent_vector!(new_p, i, e)
+         setcoeff!(new_p, e, new_base_ring(coeff(p, i)))
+      end
+      return(new_p)
+   end
 end
 
 @doc Markdown.doc"""


### PR DESCRIPTION
This PR does the following:

1. Sorting of already sorted polys is made fast (I was sorting starting from reverse order!)
2. Sorting is no longer used for lex in inflate/deflate (it is needed for other orderings)
3. Deflation now short circuits the gcds once they reach 1
4. Inflate/deflate now have special versions for MPolys which don't read and write exponent vectors
5. Change_base_ring is sped up for MPoly type