### PR TITLE
Fix Laurent series inplace multiplication

### DIFF
--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1405,16 +1405,16 @@ function add!(c::LaurentSeriesElem{T}, a::LaurentSeriesElem{T}, b::LaurentSeries
    elseif lenb == 1
       sb = sa
    end
-   sz = gcd(gcd(sa, sb), abs(vala - valb))
+   sc = gcd(gcd(sa, sb), abs(vala - valb))
    mina = min(vala + lena*sa, prec)
    minb = min(valb + lenb*sb, prec)
    lenr = max(mina, minb) - valr
-   lenr = div(lenr + sz - 1, sz)
+   lenr = div(lenr + sc - 1, sc)
    R = base_ring(c)
    fit!(c, lenr)
    c.prec = prec
    c.val = valr
-   c.scale = sz
+   c.scale = sc
    pa = vala
    pb = valb
    j = 0

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1351,11 +1351,11 @@ function mul!(c::LaurentSeriesElem{T}, a::LaurentSeriesElem{T}, b::LaurentSeries
    lenc = min(lena + lenb - 1, div(prec + sz - 1, sz))
    fit!(c, lenc)
    for i = 1:min(lena, lenc)
-      c.coeffs[i] = mul!(c.coeffs[i], polcoeff(a, i - 1), polcoeff(b, 0))
+      c.coeffs[i] = polcoeff(a, i - 1) * polcoeff(b, 0)
    end
    if lenc > lena
       for i = 2:min(lenb, lenc - lena + 1)
-         c.coeffs[lena + i - 1] = mul!(c.coeffs[lena + i - 1], polcoeff(a, lena - 1), polcoeff(b, i - 1))
+         c.coeffs[lena + i - 1] = polcoeff(a, lena - 1) * polcoeff(b, i - 1)
       end
    end
    for i = 1:lena - 1

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -227,6 +227,52 @@ function test_laurent_series_binary_ops()
    println("PASS")
 end
 
+function test_laurent_series_inplace_binary_ops()
+   print("Generic.LaurentSeries.inplace_binary_ops...")
+
+   #  Exact ring
+   R, x = LaurentSeriesRing(ZZ, 10, "x")
+   for iter = 1:100
+      f = rand(R, -12:12, -10:10)
+      g = rand(R, -12:12, -10:10)
+      h = rand(R, -12:12, -10:10)
+      r = R()
+      add!(r, f, g)
+      @test isequal(r, f + g)
+      mul!(r, f, g)
+      @test isequal(r, f*g)
+   end
+
+   #  Inexact field
+   R, x = LaurentSeriesField(RealField, 10, "x")
+   for iter = 1:100
+      f = rand(R, -12:12, -1:1)
+      g = rand(R, -12:12, -1:1)
+      h = rand(R, -12:12, -1:1)
+      r = R()
+      add!(r, f, g)
+      @test isapprox(r, f + g)
+      mul!(r, f, g)
+      @test isapprox(r, f*g)
+   end
+
+   # Non-integral domain
+   T = ResidueRing(ZZ, 6)
+   R, x = LaurentSeriesRing(T, 10, "x")
+   for iter = 1:100
+      f = rand(R, -12:12, 0:5)
+      g = rand(R, -12:12, 0:5)
+      h = rand(R, -12:12, 0:5)
+      r = R()
+      add!(r, f, g)
+      @test isequal(r, f + g)
+      mul!(r, f, g)
+      @test isequal(r, f*g)
+   end
+
+   println("PASS")
+end
+
 function test_laurent_series_adhoc_binary_ops()
    print("Generic.LaurentSeries.adhoc_binary_ops...")
 
@@ -838,6 +884,7 @@ function test_gen_laurent_series()
    test_laurent_series_manipulation()
    test_laurent_series_unary_ops()
    test_laurent_series_binary_ops()
+   test_laurent_series_inplace_binary_ops
    test_laurent_series_adhoc_binary_ops()
    test_laurent_series_comparison()
    test_laurent_series_adhoc_comparison()


### PR DESCRIPTION
Fix #229.

In the example of @martinra, the first argument of `mul!` had coefficients that were not zero. But the function was assuming that this is the case. Could you please double check the fix @wbhart?

I think additionially we were violating our aliasing/mutation rules. For the same reason `add!` is also wrong, right? It is not allowed to do what iit s currently doing. If you agree, I will also fix `add!`.