### PR TITLE
use Documenter.HTML() instead of :html

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.19"
+Documenter = "~0.21"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, AbstractAlgebra
 
 makedocs(
-         format   = :html,
+         format   = Documenter.HTML(),
          sitename = "AbstractAlgebra.jl",
          modules = [AbstractAlgebra],
          clean = true,


### PR DESCRIPTION
This addresses the following warning:

    Warning: `format = :html` is deprecated, use `format = Documenter.HTML()` instead.
