### PR TITLE
apply g to coefficients instead of coercing into new base ring

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -100,7 +100,7 @@ function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingEl
    for i = 1:length(p)
       e = exponent_vector(p, i)
       set_exponent_vector!(new_p, i, e)
-      setcoeff!(new_p, e, new_base_ring(coeff(p, i)))
+      setcoeff!(new_p, e, g(coeff(p, i)))
    end
    
    return(new_p)
@@ -113,14 +113,17 @@ v) for v in symbols(p.parent)], ordering = p.parent.ord)
 
    if typeof(gens_new_polynomial_ring[1]) <: MPoly
       exps = deepcopy(p.exps)
-      coeffs = [new_base_ring(p.coeffs[i]) for i in 1:length(p)]
+      coeffs = Array{elem_type(new_base_ring),1}(undef, length(p))
+      for i in 1:length(p)
+         coeffs[i] = g(p.coeffs[i])
+      end
       return new_polynomial_ring(coeffs, exps)
    else
       new_p = zero(new_polynomial_ring)
       for i = 1:length(p)
          e = exponent_vector(p, i)
          set_exponent_vector!(new_p, i, e)
-         setcoeff!(new_p, e, new_base_ring(coeff(p, i)))
+         setcoeff!(new_p, e, g(coeff(p, i)))
       end
       return(new_p)
    end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -913,6 +913,12 @@ end
 
 function test_gen_mpoly_change_base_ring()
    print("Generic.MPoly.change_base_ring...")
+   
+   F2 = ResidueRing(ZZ, 2)
+   R, varsR = PolynomialRing(F2, ["x"])
+   S, varsS = PolynomialRing(R, ["y"])
+   f = x -> x^2
+   change_base_ring(varsR[1] * varsS[1], f) == f(varsR[1]) * varsS[1]
 
    for num_vars=1:10
       var_names = ["x$j" for j in 1:num_vars]


### PR DESCRIPTION
The documentation of the `change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g)` promises that the function `g` is applied to the coefficients. 
Even though not documented, I guess `change_base_ring(p::MPoly{T}, g)` is supposed to behave similarly.

This pull request ensures that this actually happens instead of coercing the coefficients into `new_base_ring`.
