### PR TITLE
Solve interpolation fix

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1909,9 +1909,10 @@ function solve_interpolation(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.M
    pt1 = base_ring(R)(1 - b2)
    l = 1
    i = 1
+   pt = 1
    while l <= bound
-      y[l] = base_ring(R)(i - b2)
-      (y[l] == pt1 && i != 1) && error("Not enough interpolation points in ring")
+      y[l] = base_ring(R)(pt - b2)
+      (y[l] == pt1 && pt != 1) && error("Not enough interpolation points in ring")
       for j = 1:m
          for k = 1:m
             X[j, k] = evaluate(M[j, k], y[l])
@@ -1927,16 +1928,18 @@ function solve_interpolation(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.M
          if !(e isa ErrorException)
             rethrow(e)
          end
+         i = i + 1
       end
 
-      # We tested i values and for each of them it was not solvable.
-      # Thus for i values the matrix X is singular.
+      # We tested bound evaluation points and either an impossible
+      # inverse was encountered, or the matrix was singular for all
+      # the values.
 
-      if i > bound
-         error("Singular matrix in solve_interpolation")
+      if i > bound && l == 1
+         error("Impossible inverse or too many singular matrices in solve_interpolation")
       end
 
-      i = i + 1
+      pt = pt + 1
    end
    for k = 1:h
       for i = 1:m

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1015,6 +1015,9 @@ function lu(A::MatrixElem{T}, P = PermGroup(rows(A))) where {T <: FieldElement}
 end
 
 function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: RingElement}
+   if !isdomain_type(T)
+      error("Not implemented")
+   end
    m = rows(A)
    n = cols(A)
    rank = 0
@@ -1069,7 +1072,7 @@ function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: RingElement}
    return rank, d2
 end
 
-function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: FieldElement}
+function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: Union{FieldElement, ResElem}}
    m = rows(A)
    n = cols(A)
    rank = 0
@@ -1129,9 +1132,9 @@ end
 > Return a tuple $r, d, p, L, U$ consisting of the rank of $A$, a
 > denominator $d$, a permutation $p$ of $A$ belonging to $P$, a lower
 > triangular matrix $L$ and an upper triangular matrix $U$ such that
-> $p(A) = LD^1U$, where $p(A)$ stands for the matrix whose rows are the given
+> $p(A) = LDU$, where $p(A)$ stands for the matrix whose rows are the given
 > permutation $p$ of the rows of $A$ and such that $D$ is the diagonal matrix
-> diag$(p_1, p_1p_2, \ldots, p_{n-2}p_{n-1}, p_{n-1}$ where the $p_i$ are the
+> diag$(p_1, p_1p_2, \ldots, p_{n-2}p_{n-1}, p_{n-1})$ where the $p_i$ are the
 > inverses of the diagonal entries of $U$. The denominator $d$ is set to
 > $\pm \mbox{det}(S)$ where $S$ is an appropriate submatrix of $A$ ($S = A$ if
 > $A$ is square) and the sign is decided by the parity of the permutation.
@@ -4197,6 +4200,9 @@ function randmat_triu(S::AbstractAlgebra.MatSpace, v...)
 end
 
 function randmat_with_rank(S::Generic.MatSpace{T}, rank::Int, v...) where {T <: AbstractAlgebra.RingElement}
+   if !isdomain_type(T) && !(T <: ResElem)
+      error("Not implemented")
+   end
    M = S()
    R = base_ring(S)
    for i = 1:rank

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -35,7 +35,7 @@ base_ring(r::AbstractAlgebra.ResFieldElem) = base_ring(parent(r))
 """
 parent(a::AbstractAlgebra.ResFieldElem) = a.parent
 
-isdomain_type(a::Type{T}) where T <: AbstractAlgebra.ResFieldElem = false
+isdomain_type(a::Type{T}) where T <: AbstractAlgebra.ResFieldElem = true
 
 function isexact_type(a::Type{T}) where {S <: RingElement, T <: AbstractAlgebra.ResFieldElem{S}}
    return isexact_type(S)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -600,20 +600,26 @@ end
 function test_gen_mat_rank()
    print("Generic.Mat.rank...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
-   R = MatrixSpace(S, 3, 3)
-
-   M = R([S(3) S(2) S(1); S(2021024) S(2021025) S(2021026); 3*x^2+5*x+2021024 2021022*x^2+4*x+5 S(2021025)])
-
-   @test rank(M) == 2
-
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
    for i = 0:5
-      M = randmat_with_rank(R, i, 0:5, -100:100)
+      M = randmat_with_rank(R, i, -100:100)
+      do_test = false
+      r = 0
 
-      @test rank(M) == i
+      try
+         r = rank(M)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+
+      if do_test
+         @test r == i
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -709,19 +715,29 @@ end
 function test_gen_mat_solve_rational()
    print("Generic.Mat.solve_rational...")
 
-   #S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
 
-   #for dim = 0:5
-   #   R = MatrixSpace(S, dim, dim)
-   #   U = MatrixSpace(S, dim, rand(1:5))
+   for dim = 0:5
+      R = MatrixSpace(S, dim, dim)
+      U = MatrixSpace(S, dim, rand(1:5))
 
-   #   M = randmat_with_rank(R, dim, 0:5, -100:100)
-   #   b = rand(U, 0:5, -100:100);
+      M = randmat_with_rank(R, dim, -100:100)
+      b = rand(U, -100:100)
 
-   #   x, d = solve_rational(M, b)
+      do_test = false
+      try
+         x, d = solve_rational(M, b)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+             rethrow(e)
+         end
+      end
 
-   #   @test M*x == d*b
-   #end
+      if do_test
+         @test M*x == d*b
+      end
+   end
 
    S, z = PolynomialRing(ZZ, "z")
 
@@ -807,16 +823,30 @@ end
 function test_gen_mat_rref()
    print("Generic.Mat.rref...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
    for i = 0:5
-      M = randmat_with_rank(R, i, 0:5, -100:100)
+      M = randmat_with_rank(R, i, -100:100)
 
-      r, d, A = rref(M)
+      do_test = false
+      r = 0
+      d = S(0)
+      A = M
 
-      @test r == i
-      @test isrref(A)
+      try
+          r, d, A = rref(M)
+          do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+
+      if do_test
+         @test r == i
+         @test isrref(A)
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -863,17 +893,32 @@ end
 function test_gen_mat_nullspace()
    print("Generic.Mat.nullspace...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
    for i = 0:5
-      M = randmat_with_rank(R, i, 0:5, -100:100)
+      M = randmat_with_rank(R, i, -100:100)
 
-      n, N = nullspace(M)
+      do_test = false
+      n = 0
+      N = M
+      r = 0
+      
+      try
+         n, N = nullspace(M)
+         r = rank(N)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
 
-      @test n == 5 - i
-      @test rank(N) == n
-      @test iszero(M*N)
+      if do_test
+         @test n == 5 - i
+         @test r == n
+         @test iszero(M*N)
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -923,16 +968,29 @@ end
 function test_gen_mat_inversion()
    print("Generic.Mat.inversion...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
 
    for dim = 1:5
       R = MatrixSpace(S, dim, dim)
 
-      M = randmat_with_rank(R, dim, 0:5, -100:100)
+      M = randmat_with_rank(R, dim, -100:100)
 
-      X, d = inv(M)
+      do_test = false
+      X = M
+      d = R(0)
 
-      @test M*X == d*one(R)
+      try
+          X, d = inv(M)
+          do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+
+      if do_test
+         @test M*X == d*one(R)
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -1524,7 +1582,7 @@ function test_gen_mat_weak_popov()
       @test isunit(det(U))
    end
 
-   R = ResidueRing(ZZ, randprime(100))
+   R = ResidueField(ZZ, randprime(100))
 
    M = MatrixSpace(PolynomialRing(R, "x")[1], rand(1:5), rand(1:5))
 

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -525,20 +525,27 @@ end
 function test_gen_matalg_rank()
    print("Generic.MatAlg.rank...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
-   R = MatrixAlgebra(S, 3)
-
-   M = R([S(3) S(2) S(1); S(2021024) S(2021025) S(2021026); 3*x^2+5*x+2021024 2021022*x^2+4*x+5 S(2021025)])
-
-   @test rank(M) == 2
-
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
    for i = 0:5
-      M = randmat_with_rank(R, i, 0:5, -100:100)
+      M = randmat_with_rank(R, i, -100:100)
 
-      @test rank(M) == i
+      do_test = false
+      r = 0
+
+      try
+         r = rank(M)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+
+      if do_test
+         @test r == i
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -635,16 +642,28 @@ end
 function test_gen_matalg_rref()
    print("Generic.MatAlg.rref...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
    for i = 0:5
-      M = randmat_with_rank(R, i, 0:5, -100:100)
+      M = randmat_with_rank(R, i, -100:100)
 
-      r, d, A = rref(M)
+      do_test = false
+      r = 0
+      A = M
+      try
+         r, d, A = rref(M)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
 
-      @test r == i
-      @test isrref(A)
+      if do_test
+         @test r == i
+         @test isrref(A)
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")
@@ -691,16 +710,29 @@ end
 function test_gen_matalg_inversion()
    print("Generic.MatAlg.inversion...")
 
-   S, x = PolynomialRing(ResidueRing(ZZ, 20011*10007), "x")
+   S = ResidueRing(ZZ, 20011*10007)
 
    for dim = 1:5
       R = MatrixAlgebra(S, dim)
 
-      M = randmat_with_rank(R, dim, 0:5, -100:100)
+      M = randmat_with_rank(R, dim, -100:100)
 
-      X, d = inv(M)
+      do_test = false
+      X = M
+      d = 0
 
-      @test M*X == d*one(R)
+      try
+         X, d = inv(M)
+         do_test = true
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+
+      if do_test
+         @test M*X == d*one(R)
+      end
    end
 
    S, z = PolynomialRing(ZZ, "z")


### PR DESCRIPTION
* Fixes fflu! to work for residue rings
* Otherwise require matrices to be over an integral domain type in fflu!
* Make randmat_with_mat require a residue ring or integral domain type
* Fixes a documentation error
* Fixes test code for Matrix/MatrixAlgebra to not use poly's over residue rings that aren't integral domains

Fixes Nemo's ticket 351.

For some reason, the fraction free LU that uses divexact instead of inv doesn't work over non-integral domains. This includes polynomials over a residue ring for example. I have not been able to modify the algorithm to work in this case, so I simply have to demand an integral domain type. Much of this PR is to ensure this.