### PR TITLE
replace "full" by "Array" in a docstring

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -702,7 +702,7 @@ julia> matrix_repr(p)
   [1, 2]  =  1
   [2, 3]  =  1
 
-julia> full(ans)
+julia> Array(ans)
 3×3 Array{Int64,2}:
  0  1  0
  0  0  1


### PR DESCRIPTION
Apparently `full` is not defined anymore in this sense in julia 1.1.0 and `Array` is used to convert sparse to dense arrays.