### PR TITLE
Clarify MPoly interface for gcd and divrem for ideal division and fix bug in vars.

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -359,7 +359,12 @@ The greated common divisor of two polynomials a and b is returned by
 gcd(a::AbstractAlgebra.Generic.MPoly{T}, b::AbstractAlgebra.Generic.MPoly{T}) where {T <: RingElement}
 ```
 
-The least common multiple of two polynomials a and b is returned by
+Note that this functionality is currently only provided for AbstractAlgebra
+generic polynomials. It is not automatically provided for all multivariate
+rings that implement the multivariate interface.
+
+However, if such a gcd is provided, the least common multiple of two
+polynomials a and b is returned by
 
 ```@docs
 lcm(a::AbstractAlgebra.MPolyElem{T}, b::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}

--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -352,21 +352,6 @@ div(f::MyMPoly{T}, g::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
 As per the `divrem` function, but returning the quotient only. Especially when the
 quotient happens to be exact, this function can be exceedingly fast.
 
-```julia
-divrem(f::MyMPoly{T}, G::Array{MyMPoly{T}, 1}) where T <: AbstractAlgebra.RingElem
-```
-
-As per the `divrem` function above, except that each term of $r$ starting with the
-most significant term, is reduced modulo the leading terms of each of the polynomials
-in the array $G$ for which the leading monomial is a divisor.
-
-A tuple $(Q, r)$ is returned from the function, where $Q$ is an array of polynomials
-of the same length as $G$, and such that $f = r + \sum Q[i]G[i]$.
-
-The result is again dependent on the ordering in general, but if the polynomials in $G$
-are over a field and the reduced generators of a Groebner basis, then the result is
-unique.
-
 **Examples**
 
 ```julia
@@ -374,11 +359,9 @@ R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 
 f = 2x^2*y + 2x + y + 1
 g = x + y
-h = y + 1
 
 q = div(f, g)
 q, r = divrem(f, g)
-Q, r = divrem(f, [g, h])
 ```
 
 ### GCD
@@ -582,6 +565,35 @@ function.
 
 The following functions can optionally be implemented for multivariate
 polynomial types.
+
+### Reduction by an ideal
+
+```julia
+divrem(f::MyMPoly{T}, G::Array{MyMPoly{T}, 1}) where T <: AbstractAlgebra.RingElem
+```
+
+As per the `divrem` function above, except that each term of $r$ starting with the
+most significant term, is reduced modulo the leading terms of each of the polynomials
+in the array $G$ for which the leading monomial is a divisor.
+
+A tuple $(Q, r)$ is returned from the function, where $Q$ is an array of polynomials
+of the same length as $G$, and such that $f = r + \sum Q[i]G[i]$.
+
+The result is again dependent on the ordering in general, but if the polynomials in $G$
+are over a field and the reduced generators of a Groebner basis, then the result is
+unique.
+
+**Examples**
+
+```julia
+R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+f = 2x^2*y + 2x + y + 1
+g = x + y
+h = y + 1
+
+Q, r = divrem(f, [g, h])
+```
 
 ### Evaluation
 

--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -252,7 +252,6 @@ n = length(f)
 isgen(y) == true
 B, b = max_degrees(f)
 nvars(f) == 2
-V = vars(f)
 C = collect(coeffs(f))
 M = collect(monomials(f))
 T = collect(terms(f))

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -138,9 +138,16 @@ function vars(p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
    vars_in_p = Array{U}(undef, 0)
    n = nvars(p.parent)
    gen_list = gens(p.parent)
-   v = maximum.(exponent_vectors(p))
+   biggest = [0 for i in 1:n]
+   for v in exponent_vectors(p)
+      for j = 1:n
+         if v[j] > biggest[j]
+            biggest[j] = v[j]
+         end
+      end
+   end
    for i = 1:n
-      if v[i] != 0
+      if biggest[i] != 0
          push!(vars_in_p, gen_list[i])
       end
    end


### PR DESCRIPTION
Just makes ideal divrem optional and clarifies that gcd is not provided automatically for all multivariate types (yet).

Also fixes a bug in vars function.