### PR TITLE
fix for needs parentheses

### DIFF
--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -292,7 +292,7 @@ needs_parentheses(x::AbstractAlgebra.SeriesElem) = (!iszero(x))
 
 displayed_with_minus_in_front(x::AbstractAlgebra.SeriesElem) = false
 
-show_minus_one(::Type{AbstractAlgebra.SeriesElem{T}}) where {T <: RingElement} = show_minus_one(T)
+show_minus_one(::Type{AbstractAlgebra.SeriesElem{T}}) where {T <: RingElement} = false
 
 ###############################################################################
 #

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -290,7 +290,7 @@ end
 
 needs_parentheses(x::AbstractAlgebra.SeriesElem) = (!iszero(x))
 
-displayed_with_minus_in_front(x::AbstractAlgebra.SeriesElem) = pol_length(x) <= 1 && displayed_with_minus_in_front(polcoeff(x, 0))
+displayed_with_minus_in_front(x::AbstractAlgebra.SeriesElem) = false
 
 show_minus_one(::Type{AbstractAlgebra.SeriesElem{T}}) where {T <: RingElement} = show_minus_one(T)
 

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -288,7 +288,7 @@ function show(io::IO, a::SeriesRing)
    show(io, base_ring(a))
 end
 
-needs_parentheses(x::AbstractAlgebra.SeriesElem) = pol_length(x) > 1
+needs_parentheses(x::AbstractAlgebra.SeriesElem) = (!iszero(x))
 
 displayed_with_minus_in_front(x::AbstractAlgebra.SeriesElem) = pol_length(x) <= 1 && displayed_with_minus_in_front(polcoeff(x, 0))
 


### PR DESCRIPTION
This fixes two problems: one is that despite this file being in RelSeries, the function is for all SeriesElems including AbsSeriesElem's, which have no pol_length, so printing polynomials over abs series breaks.

I also argue that the current definition as pol_length > 1 is ambiguous for anything non-zero right now, consider:

```
julia> R,x= PowerSeriesRing(QQ, 5,"x",model=:capped_relative)
(Univariate power series ring in x over Rational Field, x+O(x^6))

julia> T,t = PolynomialRing(R, "t")
(Univariate Polynomial Ring in t over Univariate power series ring in x over Rational Field, t)

julia> (x+ 1)*t
(1+x+O(x^5))*t

julia> (x)*t
x+O(x^6)*t

julia> (x)*t  + x^4
x+O(x^6)*t+x^4+O(x^5)
```

If you think about it you can work out what it means, but parens would help, and make it easier to copy paste output to and from files unambiguously.