### PR TITLE
Mod for polynomials over power series

### DIFF
--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1113,7 +1113,7 @@ end
     mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
 > Return $f \pmod{g}$.
 """
-function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement, SeriesElem}}
    check_parent(f, g)
    if length(g) == 0
       throw(DivideError())


### PR DESCRIPTION
Currently mod for polynomial rings is limited to base rings being fields and residue rings, seeing as series elem's are sort of like residue rings it would be nice to have mod for Poly{SeriesElems} also.
It seems like this works okay with this one line change, hopefully I can add some tests to this branch shortly to make this less of an issue and more of a PR.