### PR TITLE
Fix deepcopy to not preserve identity between elements of a matrix.

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -893,7 +893,7 @@ function Base.deepcopy_internal(a::MPoly{T}, dict::IdDict) where {T <: RingEleme
    Re = deepcopy_internal(a.exps, dict)
    Rc = Array{T}(undef, a.length)
    for i = 1:a.length
-      Rc[i] = deepcopy_internal(a.coeffs[i], dict)
+      Rc[i] = deepcopy(a.coeffs[i])
    end
    return parent(a)(Rc, Re)
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -238,7 +238,7 @@ function deepcopy_internal(d::MatrixElem, dict::IdDict)
    c = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
-         c[i, j] = deepcopy_internal(d[i, j], dict)
+         c[i, j] = deepcopy(d[i, j])
       end
    end
    return c


### PR DESCRIPTION
We sometimes deepcopy matrices so that we can apply in-place functions to them (e.g. rref!, fflu!, etc.). These in-place functions require all entries of the copy to be distinct (otherwise modifying an entry will modify more than one entry), but Julia has the unusual behaviour of preserving identity of objects under deepcopy, meaning that if the matrix started with elements that were identical objects, the deepcopy will have the same property.

This patch stops that from happening. But perhaps @thofma can confirm that this won't cause some other problem for us, e.g. with sets or whatever it was that we wrote the code this way for in the first place?