### PR TITLE
Print nested structures with :compact => true

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -157,7 +157,7 @@ function show(io::IO, x::AbstractAlgebra.AbsSeriesElem)
             if i != 0
                if !isone(c)
                   print(io, "(")
-                  print(io, c)
+                  print(IOContext(io, :compact => true), c)
                   print(io, ")")
                   if i != 0
                      print(io, "*")
@@ -169,7 +169,7 @@ function show(io::IO, x::AbstractAlgebra.AbsSeriesElem)
                   print(io, i)
                end
             else
-               print(io, c)
+               print(IOContext(io, :compact => true), c)
             end
             coeff_printed = true
          end

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -176,23 +176,23 @@ function show(io::IO, x::AbstractAlgebra.FracElem)
    # Canonicalise for display
    n = AbstractAlgebra.numerator(x, true)
    d = AbstractAlgebra.denominator(x, true)
-   if d != 1 && needs_parentheses(n)
+   if !isone(d) && needs_parentheses(n)
       print(io, "(")
    end
-   print(io, n)
-   if d != 1
+   print(IOContext(io, :compact => true), n)
+   if !isone(d)
       if needs_parentheses(n)
          print(io, ")")
       end
       print(io, "//")
       print(io, "(") # always print parentheses for denoninators e.g. x//(x*y*z)
-      print(io, d)
+      print(IOContext(io, :compact => true), d)
       print(io, ")")
    end
 end
 
 function show(io::IO, a::AbstractAlgebra.FracField)
-   print(io, "Fraction field of ", base_ring(a))
+   print(IOContext(io, compact => true), "Fraction field of ", base_ring(a))
 end
 
 # Parentheses are only needed for fractions if we didn't print them already

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -67,25 +67,25 @@ function show(io::IO, M::FreeModule{T}) where T <: Union{RingElement, NCRingElem
    print(io, "Free module of rank ")
    print(io, rank(M))
    print(io, " over ")
-   show(io, base_ring(M))
+   show(IOContext(io, :compact => true), base_ring(M))
 end
 
 function show(io::IO, M::FreeModule{T}) where T <: FieldElement
    print(io, "Vector space of dimension ")
    print(io, dim(M))
    print(io, " over ")
-   show(io, base_ring(M))
+   show(IOContext(io, :compact => true), base_ring(M))
 end
 
 function show(io::IO, a::free_module_elem)
    print(io, "(")
    M = parent(a)
    for i = 1:rank(M) - 1
-      print(io, a.v[1, i])
+      print(IOContext(io, :compact => true), a.v[1, i])
       print(io, ", ")
    end
    if rank(M) > 0
-      print(io, a.v[1, rank(M)])
+      print(IOContext(io, :compact => true), a.v[1, rank(M)])
    end
    print(io, ")")
 end

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -409,7 +409,7 @@ end
 function show(io::IO, x::LaurentSeriesElem)
    len = pol_length(x)
    if len == 0
-      print(io, zero(base_ring(x)))
+      print(IOContext(io, :compact => true), zero(base_ring(x)))
    else
       coeff_printed = false
       sc = scale(x)
@@ -425,7 +425,7 @@ function show(io::IO, x::LaurentSeriesElem)
                   if bracket
                      print(io, "(")
                   end
-                  print(io, c)
+                  print(IOContext(io, :compact => true), c)
                   if bracket
                      print(io, ")")
                   end
@@ -442,7 +442,7 @@ function show(io::IO, x::LaurentSeriesElem)
                   print(io, valuation(x) + i*sc)
                end
             else
-               print(io, c)
+               print(IOContext(io, :compact => true), c)
             end
             coeff_printed = true
          end
@@ -453,12 +453,12 @@ end
 
 function show(io::IO, a::LaurentSeriesRing)
    print(io, "Laurent series ring in ", var(a), " over ")
-   show(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 function show(io::IO, a::LaurentSeriesField)
    print(io, "Laurent series field in ", var(a), " over ")
-   show(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 needs_parentheses(x::LaurentSeriesElem) = pol_length(x) > 1

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -1058,7 +1058,7 @@ function show(io::IO, x::MPoly, U::Array{<: AbstractString, 1})
           if bracket
             print(io, "(")
           end
-          show(io, c)
+          print(io, c)
           if bracket
             print(io, ")")
           end
@@ -1099,7 +1099,7 @@ end
 function show(io::IO, x::MPoly)
     len = length(x)
     U = [string(x) for x in symbols(parent(x))]
-    show(io, x, U)
+    print(IOContext(io, :compact => true), x, U)
 end
 
 function show(io::IO, p::MPolyRing)
@@ -1118,7 +1118,7 @@ function show(io::IO, p::MPolyRing)
    end
    print(io, string(p.S[n]))
    print(io, " over ")
-   show(io, base_ring(p))
+   print(IOContext(io, :compact => true), base_ring(p))
 end
 
 show_minus_one(::Type{U}) where U <: AbstractAlgebra.MPolyElem{T} where T <: RingElement = show_minus_one(T)
@@ -4522,7 +4522,8 @@ function MPolyBuildCtx(R::AbstractAlgebra.MPolyRing)
 end
 
 function show(io::IO, M::MPolyBuildCtx)
-   print(io, "Builder for a polynomial in ", parent(M.poly))
+   iocomp = IOContext(io, :compact => true)
+   print(iocomp, "Builder for a polynomial in ", parent(M.poly))
 end
 
 function push_term!(M::MPolyBuildCtx{T}, c::S, expv::Vector{Int}) where T <: AbstractAlgebra.MPolyElem{S} where S <: RingElement

--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -170,7 +170,7 @@ function compose(f::AbstractAlgebra.Map(AbstractAlgebra.FunctionalMap){D, U}, g:
 end
 
 function show_short(io::IO, M::AbstractAlgebra.Map)
-   println(domain(M), " -> ", codomain(M))
+   println(IOContext(io, :compact => true), domain(M), " -> ", codomain(M))
 end
 
 function show_short(io::IO, M::FunctionalCompositeMap)
@@ -186,4 +186,3 @@ function show(io::IO, M::FunctionalCompositeMap)
    println(io, "then")
    show_short(io, M.map2)
 end
-

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -335,7 +335,7 @@ issquare(a::MatElem) = (nrows(a) == ncols(a))
 function show(io::IO, a::AbstractAlgebra.MatSpace)
    print(io, "Matrix Space of ")
    print(io, a.nrows, " rows and ", a.ncols, " columns over ")
-   print(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 function show(io::IO, a::MatrixElem)
@@ -347,7 +347,7 @@ function show(io::IO, a::MatrixElem)
    for i = 1:r
       print(io, "[")
       for j = 1:c
-         print(io, a[i, j])
+         print(IOContext(io, :compact => true), a[i, j])
          if j != c
             print(io, " ")
          end

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -146,7 +146,7 @@ issquare(a::MatAlgElem) = true
 function show(io::IO, a::AbstractAlgebra.MatAlgebra)
    print(io, "Matrix Algebra of degree ")
    print(io, a.n, " over ")
-   print(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 show_minus_one(::Type{AbstractAlgebra.MatAlgElem{T}}) where T <: RingElement = false

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -15,10 +15,10 @@ export ModuleHomomorphism
 function show(io::IO, f::ModuleHomomorphism)
    println(io, "Module homomorphism with")
    print(io, "Domain: ")
-   show(io, domain(f))
+   print(IOContext(io, :compact => true), domain(f))
    println(io, "")
    print(io, "Codomain: ")
-   show(io, codomain(f))
+   print(IOContext(io, :compact => true), codomain(f))
 end
 
 ###############################################################################

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -114,7 +114,7 @@ function show(io::IO, p::AbstractAlgebra.NCPolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(p)))
    print(io, " over ")
-   show(io, base_ring(p))
+   print(IOContext(io, :compact => true), base_ring(p))
 end
 
 show_minus_one(::Type{NCPoly{T}}) where {T <: NCRingElem} = show_minus_one(T)

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -260,7 +260,7 @@ function show(io::IO, x::PolynomialElem)
    len = length(x)
    S = var(parent(x))
    if len == 0
-      print(io, base_ring(x)(0))
+      print(IOContext(io, :compact => true), base_ring(x)(0))
    else
       for i = 1:len - 1
          c = coeff(x, len - i)
@@ -273,7 +273,7 @@ function show(io::IO, x::PolynomialElem)
                if bracket
                   print(io, "(")
                end
-               show(io, c)
+               print(IOContext(io, :compact => true), c)
                if bracket
                   print(io, ")")
                end
@@ -298,7 +298,7 @@ function show(io::IO, x::PolynomialElem)
          if bracket
             print(io, "(")
          end
-         show(io, c)
+         print(IOContext(io, :compact => true), c)
          if bracket
             print(io, ")")
          end
@@ -310,7 +310,7 @@ function show(io::IO, p::AbstractAlgebra.PolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(p)))
    print(io, " over ")
-   show(io, base_ring(p))
+   print(IOContext(io, :compact => true), base_ring(p))
 end
 
 needs_parentheses(x::PolynomialElem) = length(x) > 1

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -284,7 +284,7 @@ end
 function show(io::IO, x::PuiseuxSeriesElem)
    len = pol_length(x.data)
    if len == 0
-      print(io, zero(base_ring(x)))
+      print(IOContext(io, :compact => true), zero(base_ring(x)))
    else
       coeff_printed = false
       sc = scale(x.data)
@@ -301,7 +301,7 @@ function show(io::IO, x::PuiseuxSeriesElem)
                   if bracket
                      print(io, "(")
                   end
-                  print(io, c)
+                  print(IOContext(io, :compact => true), c)
                   if bracket
                      print(io, ")")
                   end
@@ -316,28 +316,28 @@ function show(io::IO, x::PuiseuxSeriesElem)
                if (i*sc + valuation(x.data))//den != 1
                   print(io, "^")
                   q = (valuation(x.data) + i*sc)//den
-                  print(io, denominator(q) == 1 ? numerator(q) : q)
+                  print(IOContext(io, :compact => true), denominator(q) == 1 ? numerator(q) : q)
                end
             else
-               print(io, c)
+               print(IOContext(io, :compact => true), c)
             end
             coeff_printed = true
          end
       end
    end
-   q =  precision(x.data)//x.scale
-   print(io, "+O(", string(var(parent(x.data))), "^", denominator(q) == 1 ? numerator(q) :
+   q = precision(x.data)//x.scale
+   print(IOContext(io, :compact => true), "+O(", string(var(parent(x.data))), "^", denominator(q) == 1 ? numerator(q) :
  q, ")")
 end
 
 function show(io::IO, a::PuiseuxSeriesRing)
    print(io, "Puiseux series ring in ", var(laurent_ring(a)), " over ")
-   show(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 function show(io::IO, a::PuiseuxSeriesField)
    print(io, "Puiseux series field in ", var(laurent_ring(a)), " over ")
-   show(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 needs_parentheses(x::PuiseuxSeriesElem) = pol_length(x.data) > 1

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -51,29 +51,29 @@ end
 
 function show(io::IO, N::QuotientModule{T}) where T <: RingElement
    println(io, "Quotient module of:")
-   show(io, N.m)
+   print(IOContext(io, :compact => true), N.m)
    println(io, "")
    println(io, " with relations:")
-   show(io, N.rels)
+   print(IOContext(io, :compact => true), N.rels)
 end
 
 function show(io::IO, N::QuotientModule{T}) where T <: FieldElement
    println(io, "Quotient space of:")
-   show(io, N.m)
+   print(IOContext(io, :compact => true), N.m)
    println(io, "")
    println(io, " with relations:")
-   show(io, N.rels)
+   print(IOContext(io, :compact => true), N.rels)
 end
 
 function show(io::IO, v::quotient_module_elem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
-      print(io, v.v[1, i])
+      print(IOContext(io, :compact => true), v.v[1, i])
       print(io, ", ")
    end
    if len > 0
-      print(io, v.v[1, len])
+      print(IOContext(io, :compact => true), v.v[1, len])
    end
    print(io, ")")
 end

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -243,7 +243,7 @@ end
 function show(io::IO, x::AbstractAlgebra.RelSeriesElem)
    len = pol_length(x)
    if len == 0
-      print(io, zero(base_ring(x)))
+      print(IOContext(io, :compact => true), zero(base_ring(x)))
    else
       coeff_printed = false
       for i = 0:len - 1
@@ -258,7 +258,7 @@ function show(io::IO, x::AbstractAlgebra.RelSeriesElem)
                   if bracket
                      print(io, "(")
                   end
-                  print(io, c)
+                  print(IOContext(io, :compact => true), c)
                   if bracket
                      print(io, ")")
                   end
@@ -275,7 +275,7 @@ function show(io::IO, x::AbstractAlgebra.RelSeriesElem)
                   print(io, valuation(x) + i)
                end
             else
-               print(io, c)
+               print(IOContext(io, :compact => true), c)
             end
             coeff_printed = true
          end
@@ -286,7 +286,7 @@ end
 
 function show(io::IO, a::SeriesRing)
    print(io, "Univariate power series ring in ", var(a), " over ")
-   show(io, base_ring(a))
+   print(IOContext(io, :compact => true), base_ring(a))
 end
 
 needs_parentheses(x::AbstractAlgebra.SeriesElem) = (!iszero(x))

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -159,11 +159,11 @@ end
 ###############################################################################
 
 function show(io::IO, x::AbstractAlgebra.ResElem)
-   print(io, data(x))
+   print(IOContext(io, :compact => true), data(x))
 end
 
 function show(io::IO, a::AbstractAlgebra.ResRing)
-   print(io, "Residue ring of ", base_ring(a), " modulo ", modulus(a))
+   print(IOContext(io, :compact => true), "Residue ring of ", base_ring(a), " modulo ", modulus(a))
 end
 
 needs_parentheses(x::AbstractAlgebra.ResElem) = needs_parentheses(data(x))

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -170,11 +170,11 @@ end
 ###############################################################################
 
 function show(io::IO, x::AbstractAlgebra.ResFieldElem)
-   print(io, data(x))
+   print(IOContext(io, :compact => true), data(x))
 end
 
 function show(io::IO, a::AbstractAlgebra.ResField)
-   print(io, "Residue field of ", base_ring(a), " modulo ", modulus(a))
+   print(IOContext(io, :compact => true), "Residue field of ", base_ring(a), " modulo ", modulus(a))
 end
 
 needs_parentheses(x::AbstractAlgebra.ResFieldElem) = needs_parentheses(data(x))

--- a/src/generic/Submodule.jl
+++ b/src/generic/Submodule.jl
@@ -49,29 +49,29 @@ end
 
 function show(io::IO, N::Submodule{T}) where T <: RingElement
    println(io, "Submodule of:")
-   show(io, N.m)
+   print(IOContext(io, :compact => true), N.m)
    println(io, "")
    println(io, " with generators:")
-   show(io, N.gens)
+   print(IOContext(io, :compact => true), N.gens)
 end
 
 function show(io::IO, N::Submodule{T}) where T <: FieldElement
    println(io, "Subspace of:")
-   show(io, N.m)
+   print(IOContext(io, :compact => true), N.m)
    println(io, "")
    println(io, " with generators:")
-   show(io, N.gens)
+   print(IOContext(io, :compact => true), N.gens)
 end
 
 function show(io::IO, v::submodule_elem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
-      print(io, v.v[1, i])
+      print(IOContext(io, :compact => true), v.v[1, i])
       print(io, ", ")
    end
    if len > 0
-      print(io, v.v[1, len])
+      print(IOContext(io, :compact => true), v.v[1, len])
    end
    print(io, ")")
 end


### PR DESCRIPTION
Julia usually prints nested structures (like arrays or dictionaries) with `:compact => true`, for example:
```julia
julia> print(1im)
0 + 1im

julia> print(IOContext(stdout, :compact => true), 1im)
0+1im
 
julia> print([1im])
Complex{Int64}[0+1im]
```
This PR enables the same for all "derived" structures in AbstractAlgebra. Here is an example from Hecke:
```julia
julia> Ax, x = A["x"]
(Univariate Polynomial Ring in x over Group algebra of dimension 8 over Rational Field, x)

julia> A(2)
Element of Group algebra of group
GrpAb: Z/2^3
over
Rational Field with coefficients fmpq[2, 0, 0, 0, 0, 0, 0, 0]

julia> coeff(2*x, 1)
Element of Group algebra of group
GrpAb: Z/2^3
over
Rational Field with coefficients fmpq[2, 0, 0, 0, 0, 0, 0, 0]

julia> 2*x
(fmpq[2, 0, 0, 0, 0, 0, 0, 0])*x
```