### PR TITLE
Another error message for DomainError

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -462,7 +462,7 @@ end
 > Return $a^b$. We require $b \geq 0$.
 """
 function ^(a::AbstractAlgebra.AbsSeriesElem{T}, b::Int) where {T <: RingElement}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError("Can't take negative power"))
    # special case powers of x for constructing power series efficiently
    if b == 0
       z = one(parent(a))


### PR DESCRIPTION
Calling DomainError without an error message results in: `ERROR: MethodError: no method matching DomainError()` so add an error message here.