### PR TITLE
Add some types for number fields

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -41,10 +41,10 @@ export SetElem, GroupElem, NCRingElem, RingElem, ModuleElem, FieldElem, RingElem
 export SetMap, FunctionalMap, IdentityMap
 
 export NCPolyElem, PolyElem, SeriesElem, AbsSeriesElem, RelSeriesElem, ResElem, FracElem,
-       MatElem, MatAlgElem, FinFieldElem, MPolyElem
+       MatElem, MatAlgElem, FinFieldElem, MPolyElem, NumFieldElem, SimpleNumFieldElem
 
 export PolyRing, SeriesRing, ResRing, FracField, MatSpace, MatAlgebra,
-       FinField, MPolyRing
+       FinField, MPolyRing, NumField, SimpleNumField
 
 export ZZ, QQ, zz, qq, RealField, RDF
 

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -73,6 +73,14 @@ abstract type MatSpace{T} <: Module{T} end
 
 abstract type MatAlgebra{T} <: NCRing end
 
+# Abstract types for number fields, parmeterised by the element type of
+# the base field.
+abstract type NumField{T} <: Field end
+
+# A type for number fields, which are represented using a primitive element.
+# (simple number fields)
+abstract type SimpleNumField{T} <: NumField{T} end
+
 # mathematical objects parameterised by an element type
 # these are the type classes of mathematical objects
 # that have some kind of base ring, and a generic
@@ -99,6 +107,10 @@ abstract type AbsSeriesElem{T} <: SeriesElem{T} end
 abstract type MatElem{T} <: ModuleElem{T} end
 
 abstract type MatAlgElem{T} <: NCRingElem end
+
+abstract type NumFieldElem{T} <: FieldElem end
+
+abstract type SimpleNumFieldElem{T} <: NumFieldElem{T} end
 
 # additional abstract types for parents, added ad hoc to form
 # collections of types as needed by applications


### PR DESCRIPTION
We need some better supertypes for `AnticNumberField`. This change here will enable us to do `AnticNumberField <: SimpleNumField{fmpq} <: NumField{fmpq}` in Nemo. This will simplify our work in Hecke tremendously.