### PR TITLE
add mul!(::perm, ::perm, ::perm)

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -108,7 +108,7 @@ function parity(g::perm{T}) where T
 end
 
 @doc Markdown.doc"""
-    sign(g::perm{T}) where T 
+    sign(g::perm{T}) where T
 > Return the sign of permutation.
 >
 > `sign` returns $1$ if `g` is even and $-1$ if `g` is odd. `sign` represents
@@ -386,6 +386,12 @@ false
 #   Binary operators
 #
 ###############################################################################
+function mul!(out::perm, g::perm, h::perm)
+   @inbounds for i in eachindex(out.d)
+      out[i] = h[g[i]]
+   end
+   return out
+end
 
 @doc Markdown.doc"""
     *(g::perm{T}, h::perm{T}) where T
@@ -404,11 +410,8 @@ julia> perm([2,3,1,4])*perm([1,3,4,2]) # (1,2,3)*(2,3,4)
 ```
 """
 function *(g::perm{T}, h::perm{T}) where T
-   d = similar(g.d)
-   @inbounds for i in 1:length(d)
-      d[i] = h[g[i]]
-   end
-   return perm(d, false)
+   res = perm(similar(g.d), false)
+   return mul!(res, g, h)
 end
 
 *(g::perm{S}, h::perm{T}) where {S,T} = *(promote(g,h)...)

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -210,8 +210,11 @@ function test_perm_binary_ops(types)
       cycles(a)
       @test parity(a) == p
 
+      z = G()
+
       for a in G, b in G
          @test parity(a*b) == (parity(b)+parity(a)) % 2
+         @test AbstractAlgebra.mul!(z, a, b) == a*b
       end
 
       G = PermutationGroup(T(10))


### PR DESCRIPTION
It would be good to discuss the possible group interface during the next week;

I can definitely see the obvious things like
* `parent[_type]`, `elem_type`, `hash`, `deepcopy_internal`, `==`, `isequal`
* `(G::Group)()`, `(G::Group)(g::GroupElem)`
* `one(::Group)`, `isone(g)`
* `show`;  what do we actually need for `needs_parentheses`, etc?
* rand(::Group)
* `*(g::GroupElem, h::GroupElem)`, `inv(g::GroupElem)`

the unsafes reduce to (with fallbacks):
* `one!(g::GroupElem) = parent(g)()`
* `mul!(out::GroupElem, g::GroupElem, h::GroupElem) = g*h`
* inv!(g::GroupElem) = inv(g)`

I'm not quite sure we should be providing `promotion_rules`?