### PR TITLE
Speed up evaluation - WIP (do not merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:
-    - julia: nightly
+    #- julia: nightly
 env:
    global:
       - DOCUMENTER_DEBUG=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-    #- julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3374,7 +3374,7 @@ function evaluate(a::AbstractAlgebra.MPolyElem{T}, vals::Vector{U}) where {T <: 
    # Note that this function accepts values in a non-commutative ring, so operations
    # must be done in a certain order.
    S = parent(one(R)*one(parent(vals[1])))
-   r = geobucket(S)
+   r = zero(S)
    cvzip = zip(coeffs(a), exponent_vectors(a))
    for (c, v) in cvzip
       t = one(R)
@@ -3385,9 +3385,9 @@ function evaluate(a::AbstractAlgebra.MPolyElem{T}, vals::Vector{U}) where {T <: 
          end
          t = t*powers[j][exp]
       end
-      push!(r, c*t)
+      r = addeq!(r, c*t)
    end
-   return finish(r)
+   return r
 end
 
 @doc Markdown.doc"""

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -312,11 +312,13 @@ function test_misc_functions(types)
       @test Generic.permtype(p^5) == [3, 2, 1, 1, 1, 1, 1]
       @test order(p^5) == 6
 
-      @test matrix_repr(a) isa AbstractArray{T,2}
-      @test matrix_repr(a) isa SparseMatrixCSC{T,T}
-      M = matrix_repr(a)
-      for (idx, val) in enumerate(a.d)
-         @test M[idx, val] == 1
+      if VERSION <= v"1.2"
+         @test matrix_repr(a) isa AbstractArray{T,2}
+         @test matrix_repr(a) isa SparseMatrixCSC{T,T}
+         M = matrix_repr(a)
+         for (idx, val) in enumerate(a.d)
+            @test M[idx, val] == 1
+         end
       end
    end
 


### PR DESCRIPTION
DO NOT MERGE YET!

These are two speedups that came out of working on an example sent by @ThomasBreuer

* Implement geobuckets for multivariate polynomials
* Work around non-quadratic growth when resizing 2-dim arrays in Julia.

Both significantly speed up evaluation of multivariates.

Unfortunately the test code now causes the type inference in Julia to crash or hang in every version of Julia, so we cannot test this code.