### PR TITLE
Fix change_base_ring

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -233,6 +233,35 @@ function ppio(a::E, b::E) where E <: RingElem
    return c, n
 end
 
+################################################################################
+#
+#  Change base ring
+#
+################################################################################
+
+@doc Markdown.doc"""
+    change_base_ring(::PolyElem{T}, g::Any) where T <: RingElement
+> Return the polynomial obtained by applying `g` to the coefficients. The new
+> base ring is defined by the image of `0`. 
+"""
+function change_base_ring(p::PolyElem{T}, g) where T <: RingElement
+   z = zero(base_ring(parent(p)))
+   new_base_ring = parent(g(z))
+   new_var_name = string(var(parent(p)))
+   P, _ = PolynomialRing(new_base_ring, new_var_name)
+   return change_base_ring(p, g, P)
+end
+
+@doc Markdown.doc"""
+    change_base_ring(::PolyElem{T}, g::Any, Rx::PolyRing) where T <: RingElement
+> Return the polynomial obtained by applying `g` to the coefficients. The result
+> will have parent `Rx`.
+"""
+function change_base_ring(p::PolyElem{T}, g, Rx::PolyRing) where T <: RingElement
+   new_coefficients = [g(coeff(p, i)) for i in 0:degree(p)]
+   return Rx(new_coefficients)
+end
+
 ###############################################################################
 #
 #   Generic and specific rings and fields

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -40,19 +40,6 @@ base_ring(R::AbstractAlgebra.PolyRing{T}) where T <: RingElement = R.base_ring::
 base_ring(a::PolynomialElem) = base_ring(parent(a))
 
 @doc Markdown.doc"""
-    change_base_ring(::PolyElem{T}, g::Any) where T <: RingElement
-> Return the polynomial obtained by applying `g` to the coefficients. The new base ring is defined by the image of `0`.
-"""
-function change_base_ring(p::PolyElem{T}, g) where T <: RingElement
-   z = zero(base_ring(parent(p)))
-   new_base_ring = parent(g(z))
-   new_var_name = string(var(parent(p)))
-   P, _ = PolynomialRing(new_base_ring, new_var_name)
-   new_coefficients = [g(coeff(p,i)) for i in 0:degree(p)]
-   return P(new_coefficients)
-end
-
-@doc Markdown.doc"""
     parent(a::Generic.PolynomialElem)
 > Return the parent of the given polynomial.
 """


### PR DESCRIPTION
It must be defined outside of generic. This fixes the following bug:
```julia
julia> using Nemo;

julia> Zx, x = PolynomialRing(FlintZZ, "x")
(Univariate Polynomial Ring in x over Integer Ring, x)

julia> F = GF(2)
Galois field with characteristic 2

julia> change_base_ring(x, F)
x

julia> typeof(ans)
AbstractAlgebra.Generic.Poly{Nemo.gfp_elem}
```
It should be `gfp_poly`.

I also added a version where one can supply the target parent. For non-trivial examples one ends up with polynomials with different parents otherwise.