### PR TITLE
Bug number 4. [DO NOT MERGE]

### DIFF
--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -117,7 +117,23 @@ function test_module_isomorphism()
    for iter = 1:100
       # test image of composition of canonical injection and projection
       M = rand_module(R, -10:10)::AbstractAlgebra.FPModule{elem_type(R)}
-      _test_module_isomorphism(M)
+      # _test_module_isomorphism(M)
+
+      n = ngens(M)
+      R = base_ring(M)
+      S = MatrixSpace(R, n, n)
+      N = randmat_with_rank(S, n, -10:10)
+      f = ModuleIsomorphism(M, M, N)
+
+      @test mat(f) == N
+      @test N*inverse_mat(f) == 1
+
+      m = rand(M, -10:10)
+
+      @test inv(f)(f(m)) == m
+
+      @test isa(image_fn(f), Function)
+      @test isa(inverse_image_fn(f), Function)
    end
    
    println("PASS")

--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -82,14 +82,40 @@ function test_module_homomorphism_image()
    for iter = 1:100
       # test image of composition of canonical injection and projection
       M = rand_module(R, -10:10)::AbstractAlgebra.FPModule{elem_type(R)}
-      _test_module_homomorphism_image(M)
+      # _test_module_homomorphism_image(M)
+
+      ngens1 = rand(1:5)
+      gens1 = [rand(M, -10:10) for j in 1:ngens1]
+      M1, f1 = sub(M, gens1)
+
+      Q, g = quo(M, M1)
+      k1, h1 = kernel(g)
+
+      k = compose(h1, g)
+      I, f = image(k)
+      T, t = sub(Q, elem_type(Q)[])
+
+      @test I == T
    end
 
    S = AbstractAlgebra.JuliaQQ
    for iter = 1:100
       # test image of composition of canonical injection and projection
       N = rand_module(S, -10:10)::AbstractAlgebra.FPModule{elem_type(S)}
-      _test_module_homomorphism_image(N)
+      # _test_module_homomorphism_image(N)
+
+      ngens1 = rand(1:5)
+      gens1 = [rand(N, -10:10) for j in 1:ngens1]
+      M1, f1 = sub(N, gens1)
+
+      Q, g = quo(N, M1)
+      k1, h1 = kernel(g)
+
+      k = compose(h1, g)
+      I, f = image(k)
+      T, t = sub(Q, elem_type(Q)[])
+
+      @test I == T
    end
 
    println("PASS")


### PR DESCRIPTION
This exhibits the inlining/type inference hang that forced us to split our test functions up into two functions.

@thofma I can't find the other incidence of this that you fixed. Do you recall where it was? I looked for noinline with grep, but can't find it any more.

I thought this is what you had done to fix the issue with our evaluation in MPoly. But I just don't see that any more. Was it no longer necessary? 