### PR TITLE
correct return type of functional map

### DIFF
--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -104,7 +104,7 @@ image_fn(f::AbstractAlgebra.Map(AbstractAlgebra.FunctionalMap)) = get_field(f, :
 
 function (f::FunctionalMap{D, C})(a) where {D, C}
    parent(a) != domain(f) && throw(DomainError(f))
-   return image_fn(f)(a)::elem_type(C)
+   return image_fn(f)(a)::elem_type(codomain(f))
 end
 
 function map_from_func(domain, codomain, image_fn::Function)


### PR DESCRIPTION
The fact that tests passed before comes from ``elem_type(::FlintIntegerRing)`` and ``elem_type(::FlintRationalField)`` being defined, which violates the interface descriptions for Nemo types. Possibly you want to remove these to avoid fallacious passing of tests in the future.