### PR TITLE
Add some missing sigils. 

### DIFF
--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -32,10 +32,10 @@ import Base: floor, ceil, hypot, log, log1p, exp, expm1, sin, cos, sinpi,
              cospi, tan, cot, sinh, cosh, tanh, coth, atan, asin, acos, atanh,
              asinh, acosh, sinpi, cospi
 
-import AbstractAlgebra: Integers, Rationals, NCRing, NCRingElem, Ring, RingElem,
+import ..AbstractAlgebra: Integers, Rationals, NCRing, NCRingElem, Ring, RingElem,
        RingElement, Field, FieldElement, Map, promote_rule
 
-using AbstractAlgebra
+using ..AbstractAlgebra
 
 include("generic/GenericTypes.jl")
 


### PR DESCRIPTION
@chethega suggests we have been doing our imports from supermodule incorrectly. The syntax we were using refers to the AbstractAlgebra package on the system, not the supermodule, which is what we want here.

Although this doesn't affect us, it may make it harder for people to reproduce bugs we report.