### PR TITLE
Fix ambiguity in setcoeff!(::MPoly, ...)

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4138,13 +4138,19 @@ end
     setcoeff!(a::MPoly{T}, i::Int, c::T) where T <: RingElement
 > Set the coefficient of the i-th term of the polynomial to $c$.
 """
-function setcoeff!(a::MPoly{T}, i::Int, c::T) where T <: RingElement
-   fit!(a, i)
-   a.coeffs[i] = c
-   if i > length(a)
-      a.length = i
-   end
-   return a
+setcoeff!(a::MPoly{<: RingElement}, i::Int, c::RingElement)
+
+for T in [RingElem, Integer, Rational, AbstractFloat]
+  @eval begin
+    function setcoeff!(a::MPoly{S}, i::Int, c::S) where {S <: $T}
+       fit!(a, i)
+       a.coeffs[i] = c
+       if i > length(a)
+          a.length = i
+       end
+       return a
+    end
+  end
 end
 
 @doc Markdown.doc"""


### PR DESCRIPTION
The source of the failure on julia 1.3 is an ambiguity error (it won't error on 1.1 or 1.2):
```julia
julia> using AbstractAlgebra;

julia> S, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"]; ordering=:lex);

julia> f = -8*x^5*y^3*z^5+9*x^5*y^2*z^3-8*x^4*y^5*z^4-10*x^4*y^3*z^2+8*x^3*y^2*z-10*x*y^3*z^4-4*x*y-10*x*z^2+8*y^2*z^5-9*y^2*z^3;

julia> coeff(f, [2, 3], [3, 2])
ERROR: MethodError: setcoeff!(::AbstractAlgebra.Generic.MPoly{BigInt}, ::Int64, ::BigInt) is ambiguous. Candidates:
  setcoeff!(a::AbstractAlgebra.Generic.MPoly{T}, i::Int64, c::T) where T<:Union{RingElem, AbstractFloat, Integer, Rational} in AbstractAlgebra.Generic at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:4142
  setcoeff!(a::AbstractAlgebra.Generic.MPoly{T}, i::Int64, c::U) where {T<:Union{RingElem, AbstractFloat, Integer, Rational}, U<:Integer} in AbstractAlgebra.Generic at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:4155
  setcoeff!(a::AbstractAlgebra.Generic.MPoly{T}, i::Int64, c::T) where T<:Union{RingElem, AbstractFloat, Integer, Rational} in AbstractAlgebra.Generic at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:4142
Possible fix, define
  setcoeff!(::AbstractAlgebra.Generic.MPoly{T<:Union{RingElem, AbstractFloat, Integer, Rational}}, ::Int64, ::T<:Union{RingElem, AbstractFloat, Integer, Rational})
Stacktrace:
 [1] push_term!(::MPolyBuildCtx{AbstractAlgebra.Generic.MPoly{BigInt},DataType}, ::BigInt, ::Array{Int64,1}) at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:4641
 [2] coeff(::AbstractAlgebra.Generic.MPoly{BigInt}, ::Array{Int64,1}, ::Array{Int64,1}) at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:260
 [3] top-level scope at REPL[4]:1
```
This commit fixes this by unrolling the union.