### PR TITLE
 implement copy(::MatrixElem)

### DIFF
--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -12,13 +12,13 @@ import LinearAlgebra: lu, lu!, tr
 using Markdown, Random, InteractiveUtils
 
 import Base: Array, abs, asin, asinh, atan, atanh, bin, checkbounds,
-             conj, convert, cmp, cos, cosh, dec, deepcopy,
+             cmp, conj, convert, copy, cos, cosh, dec, deepcopy,
              deepcopy_internal, div, divrem,
              exp, exponent, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
              invmod, isapprox, isequal, isfinite, isless, isqrt, isreal, iszero, lcm,
              ldexp, length, log, mod, ndigits,
              oct, one, parent, parse, precision,
-             rand, Rational, rem, reverse, 
+             rand, Rational, rem, reverse,
              setindex!, show, similar, sign, sin, sinh, size, string,
              tan, tanh, trailing_zeros, transpose, truncate,
              typed_hvcat, typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^,

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -272,6 +272,16 @@ function iszero_column(M::MatrixElem{T}, i::Int) where T <: RingElement
   return true
 end
 
+function copy(d::MatrixElem)
+   c = similar(d)
+   for i = 1:nrows(d)
+      for j = 1:ncols(d)
+         c[i, j] = d[i, j]
+      end
+   end
+   return c
+end
+
 function deepcopy_internal(d::MatrixElem, dict::IdDict)
    c = similar(d)
    for i = 1:nrows(d)
@@ -2431,7 +2441,7 @@ function left_kernel(x::AbstractAlgebra.MatElem{T}) where T <: RingElement
    end
 end
 
-function left_kernel(M::AbstractAlgebra.MatElem{T}) where T <: FieldElement 
+function left_kernel(M::AbstractAlgebra.MatElem{T}) where T <: FieldElement
   n, N = nullspace(transpose(M))
   return n, transpose(N)
 end
@@ -4620,7 +4630,7 @@ function randmat_with_rank(S::Generic.MatSpace{T}, rank::Int, v...) where {T <: 
          M[i, j] = R()
       end
       M[i, i] = rand(R, v...)
-      while iszero(M[i, i]) 
+      while iszero(M[i, i])
          M[i, i] = rand(R, v...)
       end
       for j = i + 1:ncols(M)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -209,7 +209,15 @@ function test_gen_mat_manipulation()
    @test nrows(B) == 3
    @test ncols(B) == 3
 
-   @test deepcopy(A) == A
+   let AA = deepcopy(A)
+      @test AA == A
+      @test AA[1,1] !== A[1,1]
+   end
+
+   let AA = copy(A)
+      @test AA == A
+      @test AA[1,1] === A[1,1]
+   end
 
    C = S([t + 1 R(0) R(1); t^2 R(0) t; R(0) R(0) R(0)])
 
@@ -1109,7 +1117,7 @@ function test_gen_mat_kernel()
       @test n == 5 - i
       @test rank(N) == n
       @test iszero(M*N)
- 
+
       n, N = left_kernel(M)
 
       @test n == 5 - i


### PR DESCRIPTION
This is an expected method (much more common than `deepcopy` in Julia in general), and is by definition faster. For example even for the following small 3x3 matrix over `Univariate Polynomial Ring in t over Rationals`, it's about 6 times faster:
```
[t+1//1 t 1//1]
[t^2 t t]
[-2//1 t+2//1 t^2+t+1//1]
```
For a similar 30x30 matrix, it's 18 times faster.