### PR TITLE
allow to specify a Ring in similar for matrices

### DIFF
--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -7,7 +7,7 @@ end
 
 # Matrix Interface
 
-Generic matrices are supported in AbstractAlgebra.jl. Both the space of $m\times n$ 
+Generic matrices are supported in AbstractAlgebra.jl. Both the space of $m\times n$
 matrices and the algebra (ring) of $m\times m$ matrices are supported.
 
 As the space of $m\times n$ matrices over a commutative ring is not itself a commutative
@@ -44,7 +44,7 @@ type of elements of the matrices.
 
 Matrix spaces and matrix algebras should be made unique on the system by caching parent
 objects (unless an optional `cache` parameter is set to `false`). Matrix spaces and
-algebras should at least be distinguished based on their base (coefficient) ring and the 
+algebras should at least be distinguished based on their base (coefficient) ring and the
 dimensions of the matrices in the space.
 
 See `src/generic/GenericTypes.jl` for an example of how to implement such a cache (which
@@ -171,17 +171,21 @@ The following functions are available for matrices in both matrix algebras and m
 spaces.
 
 ```julia
-similar(x::MyMat{T}) where T <: AbstractAlgebra.RingElem
+similar(x::MyMat{T}, R::Ring=base_ring(x)) where T <: AbstractAlgebra.RingElem
 ```
 
-Construct the zero matrix with the same dimensions and base ring as the given matrix.
+Construct the zero matrix with the same dimensions as the given matrix, and the
+same base ring unless explicitly specified.
 
 ```julia
+similar(x::MyMat{T}, R::Ring, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
 similar(x::MyMat{T}, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
 ```
 
-Construct the $r\times c$ zero matrix with the same base ring as the given matrix. If
-$x$ belongs to a matrix algebra and $r \neq c$, an exception is raised.
+Construct the $r\times c$ zero matrix with `R` as base ring (which defaults to the
+base ring of the the given matrix).
+If $x$ belongs to a matrix algebra and $r \neq c$, an exception is raised, and it's
+also possible to specify only one `Int` as the order (e.g. `similar(x, n)`).
 
 **Examples**
 
@@ -228,6 +232,9 @@ julia> F = similar(M)
 [0 0]
 [0 0]
 
+julia> similar(M, QQ)
+[0//1 0//1]
+[0//1 0//1]
 ```
 
 ### Views

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -28,31 +28,33 @@ export MatrixSpace, fflu!, fflu, solve_triu, isrref, charpoly_danilevsky!,
 #
 ###############################################################################
 
-function similar(x::Mat{T}) where T <: RingElement
-   R = base_ring(x)
-   M = similar(x.entries)
+function similar(x::Mat{T}, R::Ring=base_ring(x)) where T <: RingElement
+   TT = elem_type(R)
+   M = similar(x.entries, TT)
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = MatSpaceElem{T}(M)
+   z = MatSpaceElem{TT}(M)
    z.base_ring = R
    return z
 end
 
-function similar(x::Mat{T}, r::Int, c::Int) where T <: RingElement
-   R = base_ring(x)
-   M = similar(x.entries, r, c)
+function similar(x::Mat{T}, R::Ring, r::Int, c::Int) where T <: RingElement
+   TT = elem_type(R)
+   M = similar(x.entries, TT, r, c)
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = MatSpaceElem{T}(M)
+   z = MatSpaceElem{TT}(M)
    z.base_ring = R
    return z
 end
+
+similar(x::Mat, r::Int, c::Int) = similar(x, base_ring(x), r, c)
 
 @doc Markdown.doc"""
     eye(x::Generic.MatrixElem)
@@ -2431,7 +2433,7 @@ function left_kernel(x::AbstractAlgebra.MatElem{T}) where T <: RingElement
    end
 end
 
-function left_kernel(M::AbstractAlgebra.MatElem{T}) where T <: FieldElement 
+function left_kernel(M::AbstractAlgebra.MatElem{T}) where T <: FieldElement
   n, N = nullspace(transpose(M))
   return n, transpose(N)
 end
@@ -4620,7 +4622,7 @@ function randmat_with_rank(S::Generic.MatSpace{T}, rank::Int, v...) where {T <: 
          M[i, j] = R()
       end
       M[i, i] = rand(R, v...)
-      while iszero(M[i, i]) 
+      while iszero(M[i, i])
          M[i, i] = rand(R, v...)
       end
       for j = i + 1:ncols(M)

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -32,7 +32,7 @@ parent(a::AbstractAlgebra.MatAlgElem{T}, cached::Bool = true) where T <: RingEle
     MatAlgebra{T}(a.base_ring, size(a.entries)[1], cached)
 
 function check_parent(a::AbstractAlgebra.MatAlgElem{T}, b::AbstractAlgebra.MatAlgElem{T}, throw::Bool = true) where T <: RingElement
-  fl = (base_ring(a) != base_ring(b) || degree(a) != degree(b)) 
+  fl = (base_ring(a) != base_ring(b) || degree(a) != degree(b))
   fl && throw && error("Incompatible matrix spaces in matrix operation")
   return !fl
 end
@@ -94,45 +94,60 @@ isunit(a::AbstractAlgebra.MatAlgElem{T}) where T <: FieldElement = rank(a) == de
 #
 ###############################################################################
 
-function similar(x::MatAlgElem{T}) where T <: RingElement
-   R = base_ring(x)
-   M = similar(x.entries)
+
+@doc Markdown.doc"""
+    similar(x::Generic.MatrixElem, R::Ring=base_ring(x))
+    similar(x::Generic.MatrixElem, R::Ring, r::Int, c::Int)
+    similar(x::Generic.MatrixElem, r::Int, c::Int)
+    similar(x::MatAlgElem, R::Ring, n::Int)
+    similar(x::MatAlgElem, n::Int)
+
+> Create a matrix over the given ring and dimensions,
+> with defaults based upon the given source matrix `x`.
+"""
+function similar(x::MatAlgElem{T}, R::Ring=base_ring(x)) where T <: RingElement
+   TT = elem_type(R)
+   M = similar(x.entries, TT)
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = MatAlgElem{T}(M)
+   z = MatAlgElem{TT}(M)
    z.base_ring = R
    return z
 end
 
-function similar(x::MatAlgElem{T}, n::Int) where T <: RingElement
-   R = base_ring(x)
-   M = similar(x.entries, n, n)
+function similar(x::MatAlgElem{T}, R::Ring, n::Int) where T <: RingElement
+   TT = elem_type(R)
+   M = similar(x.entries, TT, n, n)
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = MatAlgElem{T}(M)
+   z = MatAlgElem{TT}(M)
    z.base_ring = R
    return z
 end
 
-function similar(x::MatAlgElem{T}, m::Int, n::Int) where T <: RingElement
+similar(x::MatAlgElem, n::Int) = similar(x, base_ring(x), n)
+
+function similar(x::MatAlgElem{T}, R::Ring, m::Int, n::Int) where T <: RingElement
    m != n && error("Dimensions don't match in similar")
-   R = base_ring(x)
-   M = similar(x.entries, n, n)
+   TT = elem_type(R)
+   M = similar(x.entries, TT, n, n)
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = MatAlgElem{T}(M)
+   z = MatAlgElem{TT}(M)
    z.base_ring = R
    return z
 end
+
+similar(x::MatAlgElem, m::Int, n::Int) = similar(x, base_ring(x), m, n)
 
 ################################################################################
 #

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1109,7 +1109,7 @@ function test_gen_mat_kernel()
       @test n == 5 - i
       @test rank(N) == n
       @test iszero(M*N)
- 
+
       n, N = left_kernel(M)
 
       @test n == 5 - i
@@ -1846,6 +1846,30 @@ function test_gen_mat_change_base_ring()
    println("PASS")
 end
 
+function test_gen_mat_similar()
+   print("Generic.Mat.similar...")
+   for R = (ZZ, GF(11))
+      M = MatrixSpace(R, rand(0:9), rand(0:9))
+      m = R == ZZ ? rand(M, -10:10) : rand(M)
+      n = similar(m)
+      @test parent(n) == M
+      @test size(n) == (nrows(M), ncols(M))
+      r, c = rand(0:9, 2)
+      n = similar(m, r, c)
+      @test parent(n) == MatrixSpace(R, r, c)
+      @test size(n) == (r, c)
+      for S = [QQ, ZZ, GF(2), GF(5)]
+         n = similar(m, S)
+         @test parent(n) == MatrixSpace(S, size(n)...)
+         @test size(n) == (nrows(M), ncols(M))
+         r, c = rand(0:9, 2)
+         n = similar(m, S, r, c)
+         @test parent(n) == MatrixSpace(S, r, c)
+         @test size(n) == (r, c)
+      end
+   end
+end
+
 function test_gen_mat()
    test_gen_mat_constructors()
    test_gen_mat_size()
@@ -1892,6 +1916,7 @@ function test_gen_mat()
    test_gen_mat_minors()
    test_gen_mat_views()
    test_gen_mat_change_base_ring()
+   test_gen_mat_similar()
 
    println("")
 end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1321,6 +1321,41 @@ function test_gen_matalg_snf()
    println("PASS")
 end
 
+function test_gen_matalg_similar()
+   print("Generic.MatAlg.similar...")
+   for R = (ZZ, GF(11))
+      M = MatrixAlgebra(R, rand(0:9))
+      m = R == ZZ ? rand(M, -10:10) : rand(M)
+      n = similar(m)
+      @test parent(n) == M
+      @test size(n) == (nrows(M), ncols(M))
+      r = rand(0:9)
+      n = similar(m, r)
+      @test parent(n) == MatrixAlgebra(R, r)
+      @test size(n) == (r, r)
+      nn = similar(m, r, r)
+      @test nn == n
+      @test parent(nn) == MatrixAlgebra(R, r)
+      @test size(nn) == (r, r)
+      @test_throws ErrorException similar(m, r, r+1)
+      for S = [QQ, ZZ, GF(2), GF(5)]
+         n = similar(m, S)
+         @test parent(n) == MatrixAlgebra(S, size(n)[1])
+         @test size(n) == (nrows(M), ncols(M))
+         r = rand(0:9)
+         n = similar(m, S, r)
+         @test parent(n) == MatrixAlgebra(S, r)
+         @test size(n) == (r, r)
+         n = similar(m, S, r, r)
+         @test parent(n) == MatrixAlgebra(S, r)
+         @test size(n) == (r, r)
+         @test_throws ErrorException similar(m, S, r, r+2)
+      end
+   end
+
+   println("PASS")
+end
+
 function test_gen_matalg()
    test_gen_matalg_constructors()
    test_gen_matalg_size()
@@ -1355,6 +1390,7 @@ function test_gen_matalg()
    test_gen_matalg_hnf()
    test_gen_matalg_snf_kb()
    test_gen_matalg_snf()
+   test_gen_matalg_similar()
 
    println("")
 end


### PR DESCRIPTION
This is similar to how `similar` works for arrays:
`similar(array, [element_type=eltype(array)], [dims=size(array)])`
Here we specify the ring instead of `element_type`:
```
similar(x::Mat, [R::Ring=base_ring(x)]
similar(x::Mat, [R::Ring=base_ring(x)], r::Int, c::Int)
```