### PR TITLE
align entries when printing matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -403,18 +403,23 @@ function show(io::IO, a::AbstractAlgebra.MatSpace)
 end
 
 function show(io::IO, a::MatrixElem)
+   isempty(a) && return print(io, "$r by $c matrix")
+
    r = nrows(a)
    c = ncols(a)
-   if r*c == 0
-      print(io, "$r by $c matrix")
-      return
-   end
+
+   # preprint each element to know the widths so as to align the columns
+   strings = String[sprint(print, a[i,j], context = :compact => true) for i=1:r, j=1:c]
+   maxs = maximum(length, strings, dims=1)
+
    for i = 1:r
       print(io, "[")
       for j = 1:c
-         print(IOContext(io, :compact => true), a[i, j])
+         s = strings[i, j]
+         s = ' '^(maxs[j] - length(s)) * s
+         print(io, s)
          if j != c
-            print(io, " ")
+            print(io, "  ")
          end
       end
       print(io, "]")


### PR DESCRIPTION
Before:
```julia
julia> matrix(ZZ, 4, 4, [10^i for i=0:15])
[1 10 100 1000]
[10000 100000 1000000 10000000]
[100000000 1000000000 10000000000 100000000000]
[1000000000000 10000000000000 100000000000000 1000000000000000]
```
After:
```julia
julia> matrix(ZZ, 4, 4, [10^i for i=0:15])
[            1              10              100              1000]
[        10000          100000          1000000          10000000]
[    100000000      1000000000      10000000000      100000000000]
[1000000000000  10000000000000  100000000000000  1000000000000000]
```
Also, as can be seen on the last line, I added one more space between entries (so there are at least 2 spaces between entries of adjacent columns) as I find it easier on the eyes, but I can revert that bit. 