### PR TITLE
beautify matrix printing with unicode

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -156,6 +156,24 @@ Matrix(::MatrixElem)
 Array(::MatrixElem)
 ```
 
+## Pretty printing
+
+It's possible to have matrices printed using unicode characters by setting
+an `IOContext` attribute:
+```julia # not jldoctest, as the the second command doesn't always work
+julia> println(IOContext(stdout, :ascii=>false), matrix(ZZ, [3 1; 2 2; 0 1]))
+⎛3  1⎞
+⎜2  2⎟
+⎝0  1⎠
+
+julia> Base.active_repl.options.iocontext[:ascii] = false; # requires Julia 1.4
+
+julia> matrix(ZZ, [3 1; 2 2; 0 1])
+⎛3  1⎞
+⎜2  2⎟
+⎝0  1⎠
+```
+
 ## Matrix functionality provided by AbstractAlgebra.jl
 
 Most of the following generic functionality is available for both matrix spaces and

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -474,8 +474,12 @@ function show(io::IO, a::MatrixElem)
                            context = :compact => true) for i=1:r, j=1:c]
    maxs = maximum(length, strings, dims=1)
 
+   ascii = get(io, :ascii, true)
+   lefts  = ascii ? ('[', '[', '[') : ('⎛', '⎜', '⎝')
+   rights = ascii ? (']', ']', ']') : ('⎞', '⎟', '⎠')
+
    for i = 1:r
-      print(io, i == 1 ? '⎛' : i == r ? '⎝' : '⎜')
+      print(io, i == 1 ? lefts[1] : i == r ? lefts[3] : lefts[2])
       for j = 1:c
          s = strings[i, j]
          s = ' '^(maxs[j] - length(s)) * s
@@ -484,7 +488,7 @@ function show(io::IO, a::MatrixElem)
             print(io, "  ")
          end
       end
-      print(io,  i == 1 ? '⎞' : i == r ? '⎠' : '⎟')
+      print(io,  i == 1 ? rights[1] : i == r ? rights[3] : rights[2])
       i != r && println(io)
    end
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -475,7 +475,7 @@ function show(io::IO, a::MatrixElem)
    maxs = maximum(length, strings, dims=1)
 
    for i = 1:r
-      print(io, "[")
+      print(io, i == 1 ? '⎛' : i == r ? '⎝' : '⎜')
       for j = 1:c
          s = strings[i, j]
          s = ' '^(maxs[j] - length(s)) * s
@@ -484,10 +484,8 @@ function show(io::IO, a::MatrixElem)
             print(io, "  ")
          end
       end
-      print(io, "]")
-      if i != r
-         println(io, "")
-      end
+      print(io,  i == 1 ? '⎞' : i == r ? '⎠' : '⎟')
+      i != r && println(io)
    end
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -2715,6 +2715,8 @@ end
    @test string(MatrixAlgebra(QQ, 0)()) == "0 by 0 matrix"
    @test string(similar(matrix(ZZ, [3 1 2; 2 0 1]))) ==
       "[#undef  #undef  #undef]\n[#undef  #undef  #undef]"
+   @test sprint(show, matrix(ZZ, [3 1; 2 2; 0 1]), context = :ascii=>false) ==
+      "⎛3  1⎞\n⎜2  2⎟\n⎝0  1⎠"
 end
 
 @testset "Generic.Mat.array_conversion" begin


### PR DESCRIPTION
Before:
```julia
julia> matrix(ZZ, 4, 3, 1:12)
[ 1   2   3]
[ 4   5   6]
[ 7   8   9]
[10  11  12]
```
After:
```julia
julia> matrix(ZZ, 4, 3, 1:12)
⎛ 1   2   3⎞
⎜ 4   5   6⎟
⎜ 7   8   9⎟
⎝10  11  12⎠
```
In IJulia, it really looks like big parentheses (no gap between the symbols).