### PR TITLE
widen similar signature to MatrixElem

### DIFF
--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -167,26 +167,6 @@ identity_matrix(R::Ring, n::Int)
 
 Construct the $n\times n$ AbstractAlgebra.jl identity matrix over the ring `R`.
 
-The following functions are available for matrices in both matrix algebras and matrix
-spaces.
-
-```julia
-similar(x::MyMat{T}, R::Ring=base_ring(x)) where T <: AbstractAlgebra.RingElem
-```
-
-Construct the zero matrix with the same dimensions as the given matrix, and the
-same base ring unless explicitly specified.
-
-```julia
-similar(x::MyMat{T}, R::Ring, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
-similar(x::MyMat{T}, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
-```
-
-Construct the $r\times c$ zero matrix with `R` as base ring (which defaults to the
-base ring of the the given matrix).
-If $x$ belongs to a matrix algebra and $r \neq c$, an exception is raised, and it's
-also possible to specify only one `Int` as the order (e.g. `similar(x, n)`).
-
 **Examples**
 
 ```jldoctest
@@ -210,31 +190,12 @@ julia> Q = identity_matrix(ZZ, 4)
 [0 0 1 0]
 [0 0 0 1]
 
-julia> C = similar(P)
-[0 0]
-[0 0]
-[0 0]
-
-julia> D = similar(Q, 4, 5)
-[0 0 0 0 0]
-[0 0 0 0 0]
-[0 0 0 0 0]
-[0 0 0 0 0]
-
 julia> R = MatrixAlgebra(ZZ, 2)
 Matrix Algebra of degree 2 over Integers
 
 julia> M = R()
 [0 0]
 [0 0]
-
-julia> F = similar(M)
-[0 0]
-[0 0]
-
-julia> similar(M, QQ)
-[0//1 0//1]
-[0//1 0//1]
 ```
 
 ### Views
@@ -474,4 +435,52 @@ julia> Q = vcat(M, N)
 [0 1 0]
 [1 0 1]
 
+```
+
+### Optional similar
+
+The following functions are available for matrices in both matrix algebras and matrix
+spaces.
+
+```julia
+similar(x::MyMat{T}, R::Ring=base_ring(x)) where T <: AbstractAlgebra.RingElem
+```
+
+Construct the zero matrix with the same dimensions as the given matrix, and the
+same base ring unless explicitly specified.
+
+```julia
+similar(x::MyMat{T}, R::Ring, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
+similar(x::MyMat{T}, r::Int, c::Int) where T <: AbstractAlgebra.RingElem
+```
+
+Construct the $r\times c$ zero matrix with `R` as base ring (which defaults to the
+base ring of the the given matrix).
+If $x$ belongs to a matrix algebra and $r \neq c$, an exception is raised, and it's
+also possible to specify only one `Int` as the order (e.g. `similar(x, n)`).
+
+Custom matrices may choose which specific matrix type is best-suited to return for the
+given ring and dimensionality. If they do not specialize this method, the default is a
+`Generic.MatSpaceElem` matrix, or `Generic.MatAlgElem` for matrix algebras.
+
+**Examples**
+
+```jldoctest
+julia> M = matrix(ZZ, BigInt[3 1 2; 2 0 1])
+[3 1 2]
+[2 0 1]
+
+julia> A = similar(M)
+[0 0 0]
+[0 0 0]
+
+julia> B = similar(M, 4, 5)
+[0 0 0 0 0]
+[0 0 0 0 0]
+[0 0 0 0 0]
+[0 0 0 0 0]
+
+julia> C = similar(M, QQ, 2, 2)
+[0//1 0//1]
+[0//1 0//1]
 ```

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -28,24 +28,24 @@ export MatrixSpace, fflu!, fflu, solve_triu, isrref, charpoly_danilevsky!,
 #
 ###############################################################################
 
-function _similar(x::Union{Mat{T}, MatAlgElem{T}}, R::Ring, r::Int, c::Int) where T <: RingElement
+function _similar(x::MatrixElem{T}, R::Ring, r::Int, c::Int) where T <: RingElement
    TT = elem_type(R)
-   M = similar(x.entries, TT, r, c)
+   M = Matrix{TT}(undef, (r, c))
    for i in 1:size(M, 1)
       for j in 1:size(M, 2)
          M[i, j] = zero(R)
       end
    end
-   z = x isa Mat ? MatSpaceElem{TT}(M) : MatAlgElem{TT}(M)
+   z = x isa AbstractAlgebra.MatElem ? MatSpaceElem{TT}(M) : MatAlgElem{TT}(M)
    z.base_ring = R
    return z
 end
 
-similar(x::Mat, R::Ring, r::Int, c::Int) = _similar(x, R, r, c)
+similar(x::AbstractAlgebra.MatElem, R::Ring, r::Int, c::Int) = _similar(x, R, r, c)
 
-similar(x::Mat, R::Ring=base_ring(x))= similar(x, R, nrows(x), ncols(x))
+similar(x::AbstractAlgebra.MatElem, R::Ring=base_ring(x)) = similar(x, R, nrows(x), ncols(x))
 
-similar(x::Mat, r::Int, c::Int) = similar(x, base_ring(x), r, c)
+similar(x::AbstractAlgebra.MatElem, r::Int, c::Int) = similar(x, base_ring(x), r, c)
 
 @doc Markdown.doc"""
     eye(x::Generic.MatrixElem)

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -105,18 +105,18 @@ isunit(a::AbstractAlgebra.MatAlgElem{T}) where T <: FieldElement = rank(a) == de
 > Create a matrix over the given ring and dimensions,
 > with defaults based upon the given source matrix `x`.
 """
-similar(x::MatAlgElem, R::Ring, n::Int) = _similar(x, R, n, n)
+similar(x::AbstractAlgebra.MatAlgElem, R::Ring, n::Int) = _similar(x, R, n, n)
 
-similar(x::MatAlgElem, R::Ring=base_ring(x)) = similar(x, R, degree(x))
+similar(x::AbstractAlgebra.MatAlgElem, R::Ring=base_ring(x)) = similar(x, R, degree(x))
 
-similar(x::MatAlgElem, n::Int) = similar(x, base_ring(x), n)
+similar(x::AbstractAlgebra.MatAlgElem, n::Int) = similar(x, base_ring(x), n)
 
-function similar(x::MatAlgElem{T}, R::Ring, m::Int, n::Int) where T <: RingElement
+function similar(x::AbstractAlgebra.MatAlgElem{T}, R::Ring, m::Int, n::Int) where T <: RingElement
    m != n && error("Dimensions don't match in similar")
    return similar(x, R, n)
 end
 
-similar(x::MatAlgElem, m::Int, n::Int) = similar(x, base_ring(x), m, n)
+similar(x::AbstractAlgebra.MatAlgElem, m::Int, n::Int) = similar(x, base_ring(x), m, n)
 
 ################################################################################
 #


### PR DESCRIPTION
This means that Generic.MatSpaceElem is the default fall-back type
when similar(matrix, ...) is not specifically implemented for matrix.
In particular, this implements the similar interface for Nemo
matrices. In other words, similar becomes an optional functionality
for custom matrices.