### PR TITLE
Fix the geobuckets

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -1153,6 +1153,13 @@ end
 function Base.push!(G::geobucket{T}, p::T) where {T <: AbstractAlgebra.MPolyElem}
    R = parent(p)
    i = max(1, ndigits(length(p), base=4))
+   l = length(G.buckets)
+   if length(G.buckets) < i
+     resize!(G.buckets, i)
+     for j in (l + 1):i
+       G.buckets[j] = zero(R)
+     end
+   end
    G.buckets[i] = addeq!(G.buckets[i], p)
    while i <= G.len
       if length(G.buckets[i]) >= 4^i

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -78,6 +78,26 @@ function test_gen_mpoly_constructors()
    println("PASS")
 end
 
+function test_gen_mpoly_geobuckets()
+   print("Generic.MPoly.geobuckets...")
+
+   R, x = ZZ["y"]
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      S, varlist = PolynomialRing(R, var_names, ordering = ord)
+      g = gens(S)
+
+      C = Generic.geobucket(S)
+      for j in 1:num_vars
+        push!(C, sum(g[j]^i for i in 1:64))
+      end
+      @test finish(C) == sum(sum(g[j]^i for i in 1:64) for j in 1:num_vars)
+   end
+   println("PASS")
+end
+
 function test_gen_mpoly_manipulation()
    print("Generic.MPoly.manipulation...")
 
@@ -1400,6 +1420,7 @@ end
 
 function test_gen_mpoly()
    test_gen_mpoly_constructors()
+   test_gen_mpoly_geobuckets()
    test_gen_mpoly_manipulation()
    test_gen_mpoly_multivariate_coeff()
    test_gen_mpoly_unary_ops()


### PR DESCRIPTION
One could not push a polynomial with more then 4^2 = 16 terms. This fixes it.
```julia
julia> AbstractAlgebra
[ Info: Recompiling stale cache file /home/thofmann/.julia/compiled/v1.1/AbstractAlgebra/b8V2b.ji for AbstractAlgebra [c3fe647b-3220-5bb0-a1ea-a7954cac585d]

julia> R = ResidueRing(ZZ, 2)
Residue ring of Integers modulo 2

julia> R, (x1, x2) = PolynomialRing(R, ["x1", "x2"])
(Multivariate Polynomial Ring in x1, x2 over Residue ring of Integers modulo 2, AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}[x1, x2])

julia> C = AbstractAlgebra.Generic.geobucket(R)
AbstractAlgebra.Generic.geobucket{AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}}(1, AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}[0, 0])

julia> push!(C, sum(x1^i for i in 1:60))
ERROR: BoundsError: attempt to access 2-element Array{AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}},1} at index [3]
Stacktrace:
 [1] getindex at ./array.jl:729 [inlined]
 [2] push!(::AbstractAlgebra.Generic.geobucket{AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}}, ::AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}) at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/MPoly.jl:1163
 [3] top-level scope at none:0
```
With the fix:
```julia
julia> C = AbstractAlgebra.Generic.geobucket(R)
AbstractAlgebra.Generic.geobucket{AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}}(1, AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Res{BigInt}}[0, 0])

julia> push!(C, sum(x1^i for i in 1:60))

julia> finish(C)
x1^60+x1^59+x1^58+x1^57+x1^56+x1^55+x1^54+x1^53+x1^52+x1^51+x1^50+x1^49+x1^48+x1^47+x1^46+x1^45+x1^44+x1^43+x1^42+x1^41+x1^40+x1^39+x1^38+x1^37+x1^36+x1^35+x1^34+x1^33+x1^32+x1^31+x1^30+x1^29+x1^28+x1^27+x1^26+x1^25+x1^24+x1^23+x1^22+x1^21+x1^20+x1^19+x1^18+x1^17+x1^16+x1^15+x1^14+x1^13+x1^12+x1^11+x1^10+x1^9+x1^8+x1^7+x1^6+x1^5+x1^4+x1^3+x1^2+x1
```