### PR TITLE
Fix push_term!

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4649,9 +4649,13 @@ function show(io::IO, M::MPolyBuildCtx)
 end
 
 function push_term!(M::MPolyBuildCtx{T}, c::S, expv::Vector{Int}) where T <: AbstractAlgebra.MPolyElem{S} where S <: RingElement
+  if iszero(c)
+    return M
+  end
   len = length(M.poly) + 1
   set_exponent_vector!(M.poly, len, expv)
   setcoeff!(M.poly, len, c)
+  return M
 end
 
 function finish(M::MPolyBuildCtx{T}) where T <: AbstractAlgebra.MPolyElem


### PR DESCRIPTION
At the moment `push_term!` does not check for zero coefficients, yielding invalid polynomials (this breaks hashing). For example:
```julia
julia> R = GF(5)
Finite field F_5

julia> Rx, (x1, x2) = PolynomialRing(R, ["x1", "x2"])
(Multivariate Polynomial Ring in x1, x2 over Finite field F_5, AbstractAlgebra.Generic.MPoly{AbstractAlgebra.gfelem{Int64}}[x1, x2])

julia> derivative(x1^5 + x1^10, 1).coeffs
2-element Array{AbstractAlgebra.gfelem{Int64},1}:
 0
 0

julia> derivative(x1^5 + x1^10, 1) == 0 * x1
true

julia> hash(derivative(x1^5 + x1^10, 1))
0x76045bbcf704c72a

julia> hash(0*x1)
0x094d42ed2df5809f
```
This fixes it by ignoring the term if the coefficient is zero.