### PR TITLE
Change base ring

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -218,6 +218,30 @@ x^2*y^2+x+1//1
 
 ```
 
+Incase a specific parent ring is constructed, it can also be passed to the function.
+
+```@docs
+change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+```
+
+**Examples**
+
+```jldoctest
+julia> R, (x, y) = PolynomialRing(ZZ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y])
+
+julia> S,  = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rationals, AbstractAlgebra.Generic.MPoly{Rational{BigInt}}[x, y])
+
+julia> fz = x^5 + y^3
+x^5+y^3+1
+
+julia> fq = change_base_ring(fz, QQ, S)
+x^5+y^3+1//1
+
+
+```
+
 ### Multivariate coefficients
 
 In order to return the "coefficient" (as a multivariate polynomial in the same

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -90,20 +90,33 @@ function gen(a::MPolyRing{T}, i::Int) where {T <: RingElement}
 end
 
 @doc Markdown.doc"""
-    change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingElement}
-> Return the polynomial obtained by applying g to the coefficients of p.
+    change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::MPolyRing)
+       where T <: RingElement
+> Return the polynomial in R obtained by applying g to the coefficients of p.
 """
-function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingElement}
-   new_base_ring = parent(g(zero(base_ring(p.parent))))
-   new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(v) for v in symbols(p.parent)], ordering = ordering(p.parent))
+function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+
+   z = g(zero(base_ring(p.parent)))
+   base_ring(R) != parent(z) && error("Base rings do not match.")
 
    cvzip = zip(coeffs(p), exponent_vectors(p))
-   M = MPolyBuildCtx(new_polynomial_ring)
+   M = MPolyBuildCtx(R)
    for (c, v) in cvzip
       push_term!(M, g(c), v)
    end
 
    return finish(M)
+end
+
+@doc Markdown.doc"""
+    change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingElement}
+> Return the polynomial obtained by applying g to the coefficients of p.
+"""
+function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where T <: RingElement
+   new_base_ring = parent(g(zero(base_ring(p.parent))))
+   new_polynomial_ring, gens_new_polynomial_ring = AbstractAlgebra.PolynomialRing(new_base_ring, [string(v) for v in symbols(p.parent)], ordering = ordering(p.parent))
+   
+   return change_base_ring(p, g, new_polynomial_ring)
 end
 
 function change_base_ring(p::MPoly{T}, g) where {T <: RingElement}


### PR DESCRIPTION
Modified change base ring, such that it keeps the type of the ring if possible.
To be precise, changing the base ring of a Nemo polynomial ring returns a Nemo polynomial ring.