### PR TITLE
Enable windows build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 os:
   - linux
   - osx
+  - windows
 julia:
   - 1.0
-  - 1.1
   - 1.2
   - 1.3
   - nightly


### PR DESCRIPTION
Builds are taking forever on appveyor (only one concurrent job). So enable the Windows build on travis (and drop 1.1 support).

I have disabled the appveyor webhooks for pull requests.

Let's see how this looks like.