### PR TITLE
use at-testset instead of test_* functions

### DIFF
--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -9,13 +9,3 @@ include("Rings-test.jl")
 include("Fields-test.jl")
 include("Modules-test.jl")
 include("Benchmark-test.jl")
-
-function test_all()
-   test_maps()
-   test_groups()
-   test_ncrings()
-   test_rings()
-   test_fields()
-   test_modules()
-   test_benchmarks()
-end

--- a/test/Benchmark-test.jl
+++ b/test/Benchmark-test.jl
@@ -1,23 +1,17 @@
-function test_benchmark_fateman()
-   print("Benchmark.fateman...")
-
+@testset "Benchmark.fateman..." begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
    T, z = PolynomialRing(S, "z")
    U, t = PolynomialRing(T, "t")
 
    p = (x + y + z + t + 1)^10
-   
+
    q = p*(p + 1)
 
    @test length(q) == 21
-
-   println("PASS")
 end
 
-function test_benchmark_pearce()
-   print("Benchmark.pearce...")
-
+@testset "Benchmark.pearce..." begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
    T, z = PolynomialRing(S, "z")
@@ -26,18 +20,8 @@ function test_benchmark_pearce()
 
    f = (x + y + 2z^2 + 3t^3 + 5u^5 + 1)^7
    g = (u + t + 2z^2 + 3y^3 + 5x^5 + 1)^7
-   
+
    q = f*g
 
    @test length(q) == 43
-
-   println("PASS")
 end
-
-function test_benchmarks()
-   test_benchmark_fateman()
-   test_benchmark_pearce()
-
-   println("")
-end
-

--- a/test/Fields-test.jl
+++ b/test/Fields-test.jl
@@ -3,12 +3,3 @@ include("generic/Fraction-test.jl")
 include("julia/Rationals-test.jl")
 include("julia/Floats-test.jl")
 include("julia/gfelem-test.jl")
-
-function test_fields()
-   test_gfelem()
-
-   test_Rationals()
-   test_Floats()
-
-   test_gen_frac()
-end

--- a/test/Groups-test.jl
+++ b/test/Groups-test.jl
@@ -1,7 +1,2 @@
 include("generic/YoungTabs-test.jl")
 include("generic/Perm-test.jl")
-
-function test_groups()
-   test_youngtabs()
-   test_perm()
-end

--- a/test/Maps-test.jl
+++ b/test/Maps-test.jl
@@ -1,10 +1,3 @@
 include("generic/Map-test.jl")
 include("generic/MapCache-test.jl")
 include("generic/MapWithInverse-test.jl")
-
-function test_maps()
-   test_gen_map()
-   test_gen_map_cache()
-   test_gen_map_with_inverse()
-
-end

--- a/test/Modules-test.jl
+++ b/test/Modules-test.jl
@@ -1,3 +1,23 @@
+function rand_module(R::AbstractAlgebra.Ring, vals...)
+   rk = rand(0:5)
+   M = FreeModule(R, rk)
+   levels = rand(0:3)
+   for i = 1:levels
+      if ngens(M) == 0
+         break
+      end
+      G = [rand(M, vals...) for i in 1:rand(1:ngens(M))]
+      S, f = sub(M, G)
+      if rand(1:2) == 1
+         M, f = quo(M, S)
+      else
+         M = S
+      end
+   end
+   return M
+end
+
+
 include("generic/FreeModule-test.jl")
 include("generic/ModuleHomomorphism-test.jl")
 include("generic/Submodule-test.jl")
@@ -5,13 +25,3 @@ include("generic/QuotientModule-test.jl")
 include("generic/DirectSum-test.jl")
 include("generic/Module-test.jl")
 include("generic/InvariantFactorDecomposition-test.jl")
-
-function test_modules()
-   test_free_module()
-   test_module_homomorphism()
-   test_submodule()
-   test_quotient_module()
-   test_direct_sum()
-   test_module()
-   test_invariant_factor_decomposition()
-end

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -1,9 +1,2 @@
 include("generic/MatrixAlgebra-test.jl")
 include("generic/NCPoly-test.jl")
-
-function test_ncrings()
-   test_gen_matalg()
-   test_gen_ncpoly()
-
-end
-

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -10,27 +10,7 @@ include("generic/PuiseuxSeries-test.jl")
 include("generic/Matrix-test.jl")
 include("generic/MPoly-test.jl")
 
-function test_gen_rings_broadcast()
-   print("Generic.Rings.broadcast...")
-
+@testset "Generic.Rings.broadcast..." begin
    F = GF(3)
    @test F(2) .* [F(1), F(2)] == [F(2), F(1)]
- 
-   println("PASS")
-end
-
-function test_rings()
-   test_Integers()
-
-   test_gen_poly()
-   test_gen_res()
-   test_gen_res_field()
-   test_gen_abs_series()
-   test_gen_rel_series()
-   test_gen_laurent_series()
-   test_gen_puiseux_series()
-   test_gen_mat()
-   test_gen_mpoly()
-
-   test_gen_rings_broadcast()
 end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -16,9 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_abs_series_constructors()
-   print("Generic.AbsSeries.constructors...")
-
+@testset "Generic.AbsSeries.constructors..." begin
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
 
    S, t = PolynomialRing(QQ, "t")
@@ -80,13 +78,9 @@ function test_abs_series_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_abs_series_manipulation()
-   print("Generic.AbsSeries.manipulation...")
-
+@testset "Generic.AbsSeries.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x", model=:capped_absolute)
 
@@ -121,13 +115,9 @@ function test_abs_series_manipulation()
    U, y = PowerSeriesRing(T, 10, "y", model=:capped_absolute)
 
    @test modulus(T) == 7
-
-   println("PASS")
 end
 
-function test_abs_series_unary_ops()
-   print("Generic.AbsSeries.unary_ops...")
-
+@testset "Generic.AbsSeries.unary_ops..." begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -155,13 +145,9 @@ function test_abs_series_unary_ops()
       @test isequal(-(-f), f)
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_abs_series_binary_ops()
-   print("Generic.AbsSeries.binary_ops...")
-
+@testset "Generic.AbsSeries.binary_ops..." begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:100
@@ -208,13 +194,9 @@ function test_abs_series_binary_ops()
       @test isequal(f*(g + h), f*g + f*h)
       @test isequal(f*(g - h), f*g - f*h)
    end
-
-   println("PASS")
 end
 
-function test_abs_series_adhoc_binary_ops()
-   print("Generic.AbsSeries.adhoc_binary_ops...")
-
+@testset "Generic.AbsSeries.adhoc_binary_ops..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -302,13 +284,9 @@ function test_abs_series_adhoc_binary_ops()
       @test isequal(f*d1 - f*d2, f*(d1 - d2))
       @test isequal(f*d1 + f*d2, f*(d1 + d2))
    end
-
-   println("PASS")
 end
 
-function test_abs_series_comparison()
-   print("Generic.AbsSeries.comparison...")
-
+@testset "Generic.AbsSeries.comparison..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -357,13 +335,9 @@ function test_abs_series_comparison()
       @test (precision(h) > min(precision(f), precision(g)) || f != g + h)
       @test (precision(h) > min(precision(f), precision(g)) || !isequal(f, g + h))
    end
-
-   println("PASS")
 end
 
-function test_abs_series_adhoc_comparison()
-   print("Generic.AbsSeries.adhoc_comparison...")
-
+@testset "Generic.AbsSeries.adhoc_comparison..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -458,13 +432,9 @@ function test_abs_series_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_abs_series_powering()
-   print("Generic.AbsSeries.powering...")
-
+@testset "Generic.AbsSeries.powering..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
 
@@ -515,13 +485,9 @@ function test_abs_series_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_abs_series_shift()
-   print("Generic.AbsSeries.shift...")
-
+@testset "Generic.AbsSeries.shift..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -564,13 +530,9 @@ function test_abs_series_shift()
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
-
-   println("PASS")
 end
 
-function test_abs_series_truncation()
-   print("Generic.AbsSeries.truncation...")
-
+@testset "Generic.AbsSeries.truncation..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -604,13 +566,10 @@ function test_abs_series_truncation()
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
-
-   println("PASS")
 end
 
-function test_abs_series_inversion()
-    print("Generic.AbsSeries.inversion...")
- 
+@testset "Generic.AbsSeries.inversion..." begin
+
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
     for iter = 1:300
@@ -618,10 +577,10 @@ function test_abs_series_inversion()
        while !isunit(f)
           f = rand(R, 0:0, -10:10)
        end
- 
+
        @test f*inv(f) == 1
     end
- 
+
     # Inexact field
     R, x = PowerSeriesRing(RealField, 10, "x", model=:capped_absolute)
     for iter = 1:300
@@ -629,10 +588,10 @@ function test_abs_series_inversion()
        while coeff(f, 0) == 0
           f = rand(R, 0:0, -1:1)
        end
- 
+
        @test isapprox(f*inv(f), R(1))
     end
- 
+
     # Non-integral domain
     T = ResidueRing(ZZ, 6)
     R, x = PowerSeriesRing(T, 10, "x", model=:capped_absolute)
@@ -641,16 +600,12 @@ function test_abs_series_inversion()
        while !isunit(f)
           f = rand(R, 0:0, 0:5)
        end
- 
+
        @test f*inv(f) == 1
     end
- 
-    println("PASS")
  end
- 
-function test_abs_series_square_root()
-    print("Generic.AbsSeries.square_root...")
- 
+
+@testset "Generic.AbsSeries.square_root..." begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
     for iter = 1:300
@@ -659,22 +614,18 @@ function test_abs_series_square_root()
 
        @test isequal(sqrt(g)^2, g)
     end
- 
+
     # Inexact field
     R, x = PowerSeriesRing(RealField, 10, "x", model=:capped_absolute)
     for iter = 1:300
        f = rand(R, 0:10, -1:1)
        g = f^2
- 
+
        @test isapprox(sqrt(g)^2, g)
     end
- 
-    println("PASS")
 end
- 
-function test_abs_series_exact_division()
-   print("Generic.AbsSeries.exact_division...")
 
+@testset "Generic.AbsSeries.exact_division..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -723,13 +674,9 @@ function test_abs_series_exact_division()
 
       @test divexact(f, g)*g == f
    end
-
-   println("PASS")
 end
 
-function test_abs_series_adhoc_exact_division()
-   print("Generic.AbsSeries.adhoc_exact_division...")
-
+@testset "Generic.AbsSeries.adhoc_exact_division..." begin
    # Exact field
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -766,13 +713,9 @@ function test_abs_series_adhoc_exact_division()
 
       @test isequal(divexact(f*c, c), f)
    end
-
-   println("PASS")
 end
 
-function test_abs_series_special_functions()
-   print("Generic.AbsSeries.special_functions...")
-
+@testset "Generic.AbsSeries.special_functions..." begin
    # Exact field
    S, x = PowerSeriesRing(QQ, 10, "x", model=:capped_absolute)
 
@@ -833,26 +776,4 @@ function test_abs_series_special_functions()
 
       @test isequal(exp(f)*exp(g), exp(f + g))
    end
-
-   println("PASS")
-end
-
-function test_gen_abs_series()
-   test_abs_series_constructors()
-   test_abs_series_manipulation()
-   test_abs_series_unary_ops()
-   test_abs_series_binary_ops()
-   test_abs_series_adhoc_binary_ops()
-   test_abs_series_comparison()
-   test_abs_series_adhoc_comparison()
-   test_abs_series_powering()
-   test_abs_series_shift()
-   test_abs_series_truncation()
-   test_abs_series_exact_division()
-   test_abs_series_adhoc_exact_division()
-   test_abs_series_inversion()
-   test_abs_series_square_root()
-   test_abs_series_special_functions()
-
-   println("")
 end

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -1,8 +1,6 @@
 using Random
 
-function test_direct_sum_constructors()
-   print("Generic.DirectSum.constructors...")
-
+@testset "Generic.DirectSum.constructors..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)
@@ -22,12 +20,9 @@ function test_direct_sum_constructors()
    m = D([])
 
    @test isa(m, Generic.direct_sum_module_elem)
-
-   println("PASS")
 end
 
-function test_direct_sum_basic_manipulation()
-   print("Generic.DirectSum.basic_manipulation...")
+@testset "Generic.DirectSum.basic_manipulation..." begin
 
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -39,20 +34,16 @@ function test_direct_sum_basic_manipulation()
          @test summands(D) == M
       end
    end
-
-   println("PASS")
 end
 
-function test_direct_sum_maps()
-   print("Generic.DirectSum.maps...")
-
+@testset "Generic.DirectSum.maps..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)
          M = [rand_module(R, -10:10) for i in 1:num]
 
          D, f, g = DirectSum(M)
-         
+
          m = [rand(M[i], -10:10) for i in 1:num]
 
          for i = 1:num
@@ -60,13 +51,9 @@ function test_direct_sum_maps()
          end
       end
    end
-
-   println("PASS")
 end
 
-function test_direct_sum_isomorphism()
-   print("Generic.DirectSum.isomorphism...")
-
+@testset "Generic.DirectSum.isomorphism..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)
@@ -79,15 +66,4 @@ function test_direct_sum_isomorphism()
          @test isisomorphic(D1, D2)
       end
    end
-   
-   println("PASS")
-end
-
-function test_direct_sum()
-   test_direct_sum_constructors()
-   test_direct_sum_basic_manipulation()
-   test_direct_sum_maps()
-   test_direct_sum_isomorphism()
-
-   println("")
 end

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -1,6 +1,4 @@
-function test_gen_frac_constructors()
-   print("Generic.Frac.constructors...")
-
+@testset "Generic.Frac.constructors..." begin
    S, x = PolynomialRing(ZZ, "x")
    T = FractionField(S)
 
@@ -49,26 +47,18 @@ function test_gen_frac_constructors()
    @test !(a in [b])
    @test a in keys(Dict(a => 1))
    @test !(b in keys(Dict(a => 1)))
-
-   println("PASS")
 end
 
-function test_gen_frac_rand()
-   print("Generic.Frac.rand...")
-
+@testset "Generic.Frac.rand..." begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
    f = rand(K, 0:3, -3:3)
    @test f isa Generic.Frac
    f = rand(rng, K, 0:3, -3:3)
    @test f isa Generic.Frac
-
-   println("PASS")
 end
 
-function test_gen_frac_manipulation()
-   print("Generic.Frac.manipulation...")
-
+@testset "Generic.Frac.manipulation..." begin
    R = FractionField(ZZ)
    S, x = PolynomialRing(ZZ, "x")
 
@@ -85,22 +75,15 @@ function test_gen_frac_manipulation()
    @test isunit((x + 1)//(-x^2 + 1))
 
    @test deepcopy((x + 1)//(-x^2 + 1)) == (x + 1)//(-x^2 + 1)
-   println("PASS")
 end
 
-function test_gen_frac_unary_ops()
-   print("Generic.Frac.unary_ops...")
-
+@testset "Generic.Frac.unary_ops..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    @test -((x + 1)//(-x^2 + 1)) == 1//(x - 1)
-
-   println("PASS")
 end
 
-function test_gen_frac_binary_ops()
-   print("Generic.Frac.binary_ops...")
-
+@testset "Generic.Frac.binary_ops..." begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
 
@@ -114,13 +97,9 @@ function test_gen_frac_binary_ops()
       @test c*(a - b) == c*(a - b)
       @test a - b == -(b - a)
    end
-
-   println("PASS")
 end
 
-function test_gen_frac_adhoc_binary()
-   print("Generic.Frac.adhoc_binary...")
-
+@testset "Generic.Frac.adhoc_binary..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (-x + 1)//(2x^2 + 3)
@@ -137,13 +116,9 @@ function test_gen_frac_adhoc_binary()
    @test b*(x + 1) == (-x-1)//(x-1)
 
    @test (x + 1)*b == (-x-1)//(x-1)
-
-   println("PASS")
 end
 
-function test_gen_frac_comparison()
-   print("Generic.Frac.comparison...")
-
+@testset "Generic.Frac.comparison..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = -((x + 1)//(-x^2 + 1))
@@ -151,13 +126,9 @@ function test_gen_frac_comparison()
    @test a == 1//(x - 1)
 
    @test isequal(a, 1//(x - 1))
-
-   println("PASS")
 end
 
-function test_gen_frac_adhoc_comparison()
-   print("Generic.Frac.adhoc_comparison...")
-
+@testset "Generic.Frac.adhoc_comparison..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = 1//(x - 1)
@@ -169,37 +140,25 @@ function test_gen_frac_adhoc_comparison()
    @test one(S) == 1
 
    @test 1 == one(S)
-
-   println("PASS")
 end
 
-function test_gen_frac_powering()
-   print("Generic.Frac.powering...")
-
+@testset "Generic.Frac.powering..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1)
 
    @test a^-12 == x^12-12*x^11+66*x^10-220*x^9+495*x^8-792*x^7+924*x^6-792*x^5+495*x^4-220*x^3+66*x^2-12*x+1
-
-   println("PASS")
 end
 
-function test_gen_frac_inversion()
-   print("Generic.Frac.inversion...")
-
+@testset "Generic.Frac.inversion..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1)
 
    @test inv(a) == -x + 1
-
-   println("PASS")
 end
 
-function test_gen_frac_exact_division()
-   print("Generic.Frac.exact_division...")
-
+@testset "Generic.Frac.exact_division..." begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
 
@@ -219,13 +178,9 @@ function test_gen_frac_exact_division()
       @test divexact(a*b, b) == a
       @test divexact((a + b)*c, c) == divexact(a*c, c) + divexact(b*c, c)
    end
-
-   println("PASS")
 end
 
-function test_gen_frac_adhoc_exact_division()
-   print("Generic.Frac.adhoc_exact_division...")
-
+@testset "Generic.Frac.adhoc_exact_division..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (-x + 1)//(2x^2 + 3)
@@ -238,13 +193,9 @@ function test_gen_frac_adhoc_exact_division()
    @test (x + 1)//b == -x^2+1
 
    @test 5//a == (-10*x^2-15)//(x-1)
-
-   println("PASS")
 end
 
-function test_gen_frac_divides()
-   print("Generic.Frac.divides...")
-
+@testset "Generic.Frac.divides..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    for i in 1:10000
@@ -257,51 +208,24 @@ function test_gen_frac_divides()
        @test b * q == a
      end
    end
-
-   println("PASS")
 end
 
-function test_gen_frac_gcd()
-   print("Generic.Frac.gcd...")
-
+@testset "Generic.Frac.gcd..." begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1) - x//(2x + 1)
 
    @test gcd(a, (x + 1)//(x - 1)) == 1//(2*x^2-x-1)
-
-   println("PASS")
 end
 
-function test_gen_frac_remove_valuation()
-   print("Generic.Frac.remove_valuation...")
+if @isdefined fmpq
+    @testset "Generic.Frac.remove_valuation..." begin
+        a = fmpq(2, 3)
 
-   a = fmpq(2, 3)
+        @test remove(a, BigInt(2)) == (1, fmpq(1, 3))
+        @test valuation(a, BigInt(2)) == 1
 
-   @test remove(a, BigInt(2)) == (1, fmpq(1, 3))
-   @test valuation(a, BigInt(2)) == 1
-
-   @test remove(a, BigInt(3)) == (-1, fmpq(2, 1))
-   @test valuation(a, BigInt(3)) == -1
-
-   println("PASS")
-end
-
-function test_gen_frac()
-   test_gen_frac_constructors()
-   test_gen_frac_rand()
-   test_gen_frac_manipulation()
-   test_gen_frac_unary_ops()
-   test_gen_frac_binary_ops()
-   test_gen_frac_adhoc_binary()
-   test_gen_frac_comparison()
-   test_gen_frac_adhoc_comparison()
-   test_gen_frac_powering()
-   test_gen_frac_inversion()
-   test_gen_frac_exact_division()
-   test_gen_frac_adhoc_exact_division()
-   test_gen_frac_divides()
-   test_gen_frac_gcd()
-
-   println("")
+        @test remove(a, BigInt(3)) == (-1, fmpq(2, 1))
+        @test valuation(a, BigInt(3)) == -1
+    end
 end

--- a/test/generic/FreeModule-test.jl
+++ b/test/generic/FreeModule-test.jl
@@ -1,6 +1,4 @@
-function test_free_module_constructors()
-   print("Generic.FreeModule.constructors...")
-
+@testset "Generic.FreeModule.constructors..." begin
    R, x = PolynomialRing(ZZ, "x")
    M = FreeModule(R, 5)
 
@@ -17,24 +15,16 @@ function test_free_module_constructors()
    F = FreeModule(ZZ, 0)
 
    @test isa(F([]), Generic.free_module_elem)
-
-   println("PASS")
 end
 
-function test_free_module_manipulation()
-   print("Generic.FreeModule.manipulation...")
-
+@testset "Generic.FreeModule.manipulation..." begin
    R, x = PolynomialRing(ZZ, "x")
    M = FreeModule(R, 5)
 
    @test rank(M) == 5
-
-   println("PASS")
 end
 
-function test_free_module_unary_ops()
-   print("Generic.FreeModule.unary_ops...")
-
+@testset "Generic.FreeModule.unary_ops..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10
@@ -42,7 +32,7 @@ function test_free_module_unary_ops()
 
       v = [rand(R, 0:2, -10:10) for i in 1:3]
       w = [-c for c in v]
-   
+
       @test -M(v) == M(w)
    end
 
@@ -56,13 +46,9 @@ function test_free_module_unary_ops()
 
       @test -M(v) == M(w)
    end
-
-   println("PASS")
 end
 
-function test_free_module_binary_ops()
-   print("Generic.FreeModule.binary_ops...")
-
+@testset "Generic.FreeModule.binary_ops..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10
@@ -84,13 +70,9 @@ function test_free_module_binary_ops()
 
       @test m + n - n == m
    end
-   
-   println("PASS")
 end
 
-function test_free_module_adhoc_binary()
-   print("Generic.FreeModule.adhoc_binary...")
-
+@testset "Generic.FreeModule.adhoc_binary..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10
@@ -119,16 +101,4 @@ function test_free_module_adhoc_binary()
       @test 2*m == m + m
       @test m*c == c*m
    end
-
-   println("PASS")
-end
-
-function test_free_module()
-   test_free_module_constructors()
-   test_free_module_manipulation()
-   test_free_module_unary_ops()
-   test_free_module_binary_ops()
-   test_free_module_adhoc_binary()
-
-   println("")
 end

--- a/test/generic/InvariantFactorDecomposition-test.jl
+++ b/test/generic/InvariantFactorDecomposition-test.jl
@@ -1,6 +1,4 @@
-function test_invariant_factors_constructors()
-   print("Generic.InvariantFactorDecomposition.constructors...")
-
+@testset "Generic.InvariantFactorDecomposition.constructors..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -16,13 +14,9 @@ function test_invariant_factors_constructors()
    m = D([])
 
    @test isa(m, Generic.snf_module_elem)
-
-   println("PASS")
 end
 
-function test_invariant_factors()
-   print("Generic.InvariantFactorDecomposition.invariant_factors...")
-
+@testset "Generic.InvariantFactorDecomposition.invariant_factors..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -33,13 +27,9 @@ function test_invariant_factors()
          @test invariant_factors(I) == invs
       end
    end
-
-   println("PASS")
 end
 
-function test_invariant_factors_isomorphism()
-   print("Generic.InvariantFactorDecomposition.isomorphism...")
-
+@testset "Generic.InvariantFactorDecomposition.isomorphism..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -55,14 +45,4 @@ function test_invariant_factors_isomorphism()
          @test m == inv(f)(f(m))
       end
    end
-   
-   println("PASS")
-end
-
-function test_invariant_factor_decomposition()
-   test_invariant_factors_constructors()
-   test_invariant_factors()
-   test_invariant_factors_isomorphism()
-
-   println("")
 end

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -16,9 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_laurent_series_constructors()
-   print("Generic.LaurentSeries.constructors...")
-
+@testset "Generic.LaurentSeries.constructors..." begin
    R, x = LaurentSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -99,13 +97,9 @@ function test_laurent_series_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_laurent_series_rand()
-   print("Generic.LaurentSeries.rand...")
-
+@testset "Generic.LaurentSeries.rand..." begin
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    f = rand(R, -12:12, -10:10)
    @test f isa Generic.LaurentSeriesRingElem
@@ -117,13 +111,9 @@ function test_laurent_series_rand()
    @test f isa Generic.LaurentSeriesFieldElem
    f = rand(rng, R, -12:12, -1:1)
    @test f isa Generic.LaurentSeriesFieldElem
-
-   println("PASS")
 end
 
-function test_laurent_series_manipulation()
-   print("Generic.LaurentSeries.manipulation...")
-
+@testset "Generic.LaurentSeries.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S, x = LaurentSeriesRing(R, 30, "x")
 
@@ -161,13 +151,9 @@ function test_laurent_series_manipulation()
    U, y = LaurentSeriesRing(T, 10, "y")
 
    @test modulus(T) == 7
-
-   println("PASS")
 end
 
-function test_laurent_series_unary_ops()
-   print("Generic.LaurentSeries.unary_ops...")
-
+@testset "Generic.LaurentSeries.unary_ops..." begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -195,13 +181,9 @@ function test_laurent_series_unary_ops()
       @test isequal(-(-f), f)
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_binary_ops()
-   print("Generic.LaurentSeries.binary_ops...")
-
+@testset "Generic.LaurentSeries.binary_ops..." begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -248,13 +230,9 @@ function test_laurent_series_binary_ops()
       @test f*(g + h) == f*g + f*h
       @test f*(g - h) == f*g - f*h
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_inplace_binary_ops()
-   print("Generic.LaurentSeries.inplace_binary_ops...")
-
+@testset "Generic.LaurentSeries.inplace_binary_ops..." begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -294,13 +272,9 @@ function test_laurent_series_inplace_binary_ops()
       mul!(r, f, g)
       @test isequal(r, f*g)
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_adhoc_binary_ops()
-   print("Generic.LaurentSeries.adhoc_binary_ops...")
-
+@testset "Generic.LaurentSeries.adhoc_binary_ops..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -388,13 +362,9 @@ function test_laurent_series_adhoc_binary_ops()
       @test isequal(f*d1 - f*d2, f*(d1 - d2))
       @test isequal(f*d1 + f*d2, f*(d1 + d2))
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_comparison()
-   print("Generic.LaurentSeries.comparison...")
-
+@testset "Generic.LaurentSeries.comparison..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -443,13 +413,9 @@ function test_laurent_series_comparison()
       @test (precision(h) > min(precision(f), precision(g)) || f != g + h)
       @test (precision(h) > min(precision(f), precision(g)) || !isequal(f, g + h))
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_adhoc_comparison()
-   print("Generic.LaurentSeries.adhoc_comparison...")
-
+@testset "Generic.LaurentSeries.adhoc_comparison..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -544,13 +510,9 @@ function test_laurent_series_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_powering()
-   print("Generic.LaurentSeries.powering...")
-
+@testset "Generic.LaurentSeries.powering..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
 
@@ -601,13 +563,9 @@ function test_laurent_series_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_shift()
-   print("Generic.LaurentSeries.shift...")
-
+@testset "Generic.LaurentSeries.shift..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -641,13 +599,9 @@ function test_laurent_series_shift()
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == precision(f) - s
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_truncation()
-   print("Generic.LaurentSeries.truncation...")
-
+@testset "Generic.LaurentSeries.truncation..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -681,13 +635,9 @@ function test_laurent_series_truncation()
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_inversion()
-   print("Generic.LaurentSeries.inversion...")
-
+@testset "Generic.LaurentSeries.inversion..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -721,13 +671,9 @@ function test_laurent_series_inversion()
 
       @test f*inv(f) == 1
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_square_root()
-   print("Generic.LaurentSeries.square_root...")
-
+@testset "Generic.LaurentSeries.square_root..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -745,13 +691,9 @@ function test_laurent_series_square_root()
 
       @test isapprox(sqrt(g)^2, g)
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_exact_division()
-   print("Generic.LaurentSeries.exact_division...")
-
+@testset "Generic.LaurentSeries.exact_division..." begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -789,13 +731,9 @@ function test_laurent_series_exact_division()
 
       @test divexact(f, g)*g == f
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_adhoc_exact_division()
-   print("Generic.LaurentSeries.adhoc_exact_division...")
-
+@testset "Generic.LaurentSeries.adhoc_exact_division..." begin
    # Exact field
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -832,13 +770,9 @@ function test_laurent_series_adhoc_exact_division()
 
       @test isequal(divexact(f*c, c), f)
    end
-
-   println("PASS")
 end
 
-function test_laurent_series_special_functions()
-   print("Generic.LaurentSeries.special_functions...")
-
+@testset "Generic.LaurentSeries.special_functions..." begin
    # Exact field
    S, x = LaurentSeriesRing(QQ, 10, "x")
 
@@ -899,28 +833,4 @@ function test_laurent_series_special_functions()
 
       @test isequal(exp(f)*exp(g), exp(f + g))
    end
-
-   println("PASS")
-end
-
-function test_gen_laurent_series()
-   test_laurent_series_constructors()
-   test_laurent_series_rand()
-   test_laurent_series_manipulation()
-   test_laurent_series_unary_ops()
-   test_laurent_series_binary_ops()
-   test_laurent_series_inplace_binary_ops()
-   test_laurent_series_adhoc_binary_ops()
-   test_laurent_series_comparison()
-   test_laurent_series_adhoc_comparison()
-   test_laurent_series_powering()
-   test_laurent_series_shift()
-   test_laurent_series_truncation()
-   test_laurent_series_exact_division()
-   test_laurent_series_adhoc_exact_division()
-   test_laurent_series_inversion()
-   test_laurent_series_square_root()
-   test_laurent_series_special_functions()
-
-   println("")
 end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1,6 +1,4 @@
-function test_gen_mpoly_constructors()
-   print("Generic.MPoly.constructors...")
-
+@testset "Generic.MPoly.constructors..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -74,13 +72,9 @@ function test_gen_mpoly_constructors()
       @test x in keys(Dict(x => 1))
       @test !(y in keys(Dict(x => 1)))
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_geobuckets()
-   print("Generic.MPoly.geobuckets...")
-
+@testset "Generic.MPoly.geobuckets..." begin
    R, x = ZZ["y"]
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
@@ -95,12 +89,9 @@ function test_gen_mpoly_geobuckets()
       end
       @test finish(C) == sum(sum(g[j]^i for i in 1:64) for j in 1:num_vars)
    end
-   println("PASS")
 end
 
-function test_gen_mpoly_rand()
-   print("Generic.MPoly.rand...")
-
+@testset "Generic.MPoly.rand..." begin
    R, x = ZZ["y"]
    num_vars = 5
    var_names = ["x$j" for j in 1:num_vars]
@@ -115,13 +106,9 @@ function test_gen_mpoly_rand()
    @test f isa Generic.MPoly
    f = rand(rng, S, 0:5, 0:100, 0:0, -100:100)
    @test f isa Generic.MPoly
-
-   println("PASS")
 end
 
-function test_gen_mpoly_manipulation()
-   print("Generic.MPoly.manipulation...")
-
+@testset "Generic.MPoly.manipulation..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -244,13 +231,9 @@ function test_gen_mpoly_manipulation()
       @test isterm(g)
       @test ismonomial(h)
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_multivariate_coeff()
-   print("Generic.MPoly.multivariate_coeff...")
-
+@testset "Generic.MPoly.multivariate_coeff..." begin
    R = ZZ
 
    for iter = 1:5
@@ -269,12 +252,9 @@ z^4-4*x*y-10*x*z^2+8*y^2*z^5-9*y^2*z^3
       @test coeff(f, [y, z], [3, 2]) == -10*x^4
       @test coeff(f, [x, z], [4, 5]) == 0
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_total_degree()
-   print("Generic.MPoly.total_degree...")
+@testset "Generic.MPoly.total_degree..." begin
    max = 50
    for nvars = 1:10
       var_names = ["x$j" for j in 1:nvars]
@@ -293,12 +273,9 @@ function test_gen_mpoly_total_degree()
          @test length(Set(degrees)) == 1
       end
    end
-   println("PASS")
 end
 
-function test_gen_mpoly_unary_ops()
-   print("Generic.MPoly.unary_ops...")
-
+@testset "Generic.MPoly.unary_ops..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -313,13 +290,9 @@ function test_gen_mpoly_unary_ops()
          @test f == -(-f)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_binary_ops()
-   print("Generic.MPoly.binary_ops...")
-
+@testset "Generic.MPoly.binary_ops..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -342,13 +315,9 @@ function test_gen_mpoly_binary_ops()
          @test f*g == AbstractAlgebra.mul_classical(f, g)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_adhoc_binary()
-   print("Generic.MPoly.adhoc_binary...")
-
+@testset "Generic.MPoly.adhoc_binary..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -387,13 +356,9 @@ function test_gen_mpoly_adhoc_binary()
          end
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_adhoc_comparison()
-   print("Generic.MPoly.adhoc_comparison...")
-
+@testset "Generic.MPoly.adhoc_comparison..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -414,13 +379,9 @@ function test_gen_mpoly_adhoc_comparison()
          @test g == S(g)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_powering()
-   print("Generic.MPoly.powering...")
-
+@testset "Generic.MPoly.powering..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -442,13 +403,9 @@ function test_gen_mpoly_powering()
          @test (f == 0 && expn == 0 && f^expn == 0) || f^expn == r
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_divides()
-   print("Generic.MPoly.divides...")
-
+@testset "Generic.MPoly.divides..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -480,13 +437,9 @@ function test_gen_mpoly_divides()
          end
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_euclidean_division()
-   print("Generic.MPoly.euclidean_division...")
-
+@testset "Generic.MPoly.euclidean_division..." begin
    R, x = QQ["y"]
 
    for num_vars = 1:10
@@ -525,13 +478,9 @@ function test_gen_mpoly_euclidean_division()
       v = varlist[1+Int(round(rand() * (num_vars-1)))]
       @test divrem(v, 2*v) == (1//2, 0)
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_ideal_reduction()
-   print("Generic.MPoly.ideal_reduction...")
-
+@testset "Generic.MPoly.ideal_reduction..." begin
    R, x = QQ["y"]
 
    for num_vars = 1:10
@@ -578,13 +527,9 @@ function test_gen_mpoly_ideal_reduction()
          @test p == g
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_deflation()
-   print("Generic.MPoly.deflation...")
-
+@testset "Generic.MPoly.deflation..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -603,13 +548,9 @@ function test_gen_mpoly_deflation()
          @test h == f
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_gcd()
-   print("Generic.MPoly.gcd...")
-
+@testset "Generic.MPoly.gcd..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -626,13 +567,9 @@ function test_gen_mpoly_gcd()
          @test g2 == g1*h || g2 == -g1*h
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_lcm()
-   print("Generic.MPoly.lcm...")
-
+@testset "Generic.MPoly.lcm..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -654,13 +591,9 @@ function test_gen_mpoly_lcm()
          @test divides(l2, h)[1]
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_evaluation()
-   print("Generic.MPoly.evaluation...")
-
+@testset "Generic.MPoly.evaluation..." begin
    R, x = ZZ["x"]
 
    for num_vars = 1:10
@@ -937,13 +870,9 @@ function test_gen_mpoly_evaluation()
    K = RealField
    R, (x, y) = PolynomialRing(K, ["x", "y"])
    @test evaluate(x + y, [K(1), K(1)]) isa BigFloat
-
-   println("PASS")
 end
 
-function test_gen_mpoly_valuation()
-   print("Generic.MPoly.valuation...")
-
+@testset "Generic.MPoly.valuation..." begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -979,13 +908,9 @@ function test_gen_mpoly_valuation()
          @test q4 == q3
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_derivative()
-   print("Generic.MPoly.derivative...")
-
+@testset "Generic.MPoly.derivative..." begin
    for num_vars=1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1008,13 +933,9 @@ function test_gen_mpoly_derivative()
          j += 1
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_change_base_ring()
-   print("Generic.MPoly.change_base_ring...")
-
+@testset "Generic.MPoly.change_base_ring..." begin
    F2 = ResidueRing(ZZ, 2)
    R, varsR = PolynomialRing(F2, ["x"])
    S, varsS = PolynomialRing(R, ["y"])
@@ -1037,13 +958,9 @@ function test_gen_mpoly_change_base_ring()
          @test parent(change_base_ring(f, a -> R(a))).ord == parent(f).ord
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_vars()
-   print("Generic.MPoly.vars...")
-
+@testset "Generic.MPoly.vars..." begin
    for num_vars=1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1056,13 +973,9 @@ function test_gen_mpoly_vars()
          # @test issubset(vars(f), Set(gens(parent(f)))) # This fails, probably due to https://github.com/Nemocas/AbstractAlgebra.jl/issues/111
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_combine_like_terms()
-   print("Generic.MPoly.combine_like_terms...")
-
+@testset "Generic.MPoly.combine_like_terms..." begin
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1094,13 +1007,9 @@ function test_gen_mpoly_combine_like_terms()
          @test length(f) == lenf - 1 - terms_cancel
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_exponents()
-   print("Generic.MPoly.exponents...")
-
+@testset "Generic.MPoly.exponents..." begin
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1169,13 +1078,9 @@ function test_gen_mpoly_exponents()
          @test f == h
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_to_univariate()
-   print("Generic.MPoly.to_univariate...")
-
+@testset "Generic.MPoly.to_univariate..." begin
    for num_vars=1:10
       ord = rand_ordering()
 
@@ -1200,13 +1105,9 @@ function test_gen_mpoly_to_univariate()
          @test to_univariate(R_univ, f) == f_univ
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_coefficients_of_univariate()
-   print("Generic.MPoly.coefficients_of_univariate...")
-
+@testset "Generic.MPoly.coefficients_of_univariate..." begin
    for num_vars=1:10
       ord = rand_ordering()
       var_names = ["x$j" for j in 1:num_vars]
@@ -1233,13 +1134,9 @@ function test_gen_mpoly_coefficients_of_univariate()
          @test AbstractAlgebra.Generic.coefficients_of_univariate(f, false) == coeffs
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_isless()
-   print("Generic.MPoly.isless...")
-
+@testset "Generic.MPoly.isless..." begin
    n_mpolys = 100
    maxval = 10
    maxdeg = 20
@@ -1333,10 +1230,9 @@ function test_gen_mpoly_isless()
          end
       end
    end
-   println("PASS")
 end
 
-function test_gen_mpoly_lt()
+@testset "Generic.MPoly.lt..." begin
    for num_vars=1:10
       ord = rand_ordering()
       var_names = ["x$j" for j in 1:num_vars]
@@ -1358,9 +1254,7 @@ function test_gen_mpoly_lt()
    end
 end
 
-function test_gen_mpoly_lc()
-   print("Generic.MPoly.lc...")
-
+@testset "Generic.MPoly.lc..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1380,13 +1274,9 @@ function test_gen_mpoly_lc()
          @test parent(lc(f)) == base_ring(f)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_lm()
-   print("Generic.MPoly.lm...")
-
+@testset "Generic.MPoly.lm..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1413,13 +1303,9 @@ function test_gen_mpoly_lm()
          @test parent(lm(f)) == parent(f)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mpoly_ishomogeneous()
-   print("Generic.MPoly.ishomogenous...")
-
+@testset "Generic.MPoly.ishomogenous..." begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1434,43 +1320,4 @@ function test_gen_mpoly_ishomogeneous()
          end
       end
    end
-
-   println("PASS")
-end
-
-
-function test_gen_mpoly()
-   test_gen_mpoly_constructors()
-   test_gen_mpoly_geobuckets()
-   test_gen_mpoly_rand()
-   test_gen_mpoly_manipulation()
-   test_gen_mpoly_multivariate_coeff()
-   test_gen_mpoly_unary_ops()
-   test_gen_mpoly_binary_ops()
-   test_gen_mpoly_adhoc_binary()
-   test_gen_mpoly_adhoc_comparison()
-   test_gen_mpoly_powering()
-   test_gen_mpoly_divides()
-   test_gen_mpoly_euclidean_division()
-   test_gen_mpoly_ideal_reduction()
-   test_gen_mpoly_deflation()
-   test_gen_mpoly_gcd()
-   test_gen_mpoly_evaluation()
-   test_gen_mpoly_valuation()
-   test_gen_mpoly_derivative()
-   test_gen_mpoly_change_base_ring()
-   test_gen_mpoly_total_degree()
-   test_gen_mpoly_vars()
-   test_gen_mpoly_combine_like_terms()
-   test_gen_mpoly_exponents()
-   test_gen_mpoly_to_univariate()
-   test_gen_mpoly_coefficients_of_univariate()
-   test_gen_mpoly_isless()
-   test_gen_mpoly_lc()
-   test_gen_mpoly_lm()
-   test_gen_mpoly_lt()
-   test_gen_mpoly_lcm()
-   test_gen_mpoly_ishomogeneous()
-
-   println("")
 end

--- a/test/generic/Map-test.jl
+++ b/test/generic/Map-test.jl
@@ -9,9 +9,7 @@ a(f::Map(MyMap)) = Generic.get_field(f, :a)
 
 (f::MyMap)(x) =  a(f)*(x + 1)
 
-function test_gen_map_functional()
-   print("Generic.Map.FunctionalMap...")
-
+@testset "Generic.Map.FunctionalMap..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
    g = map_from_func(ZZ, QQ, x -> QQ(x))
 
@@ -25,13 +23,9 @@ function test_gen_map_functional()
 
    @test image_fn(f)(ZZ(1)) == 2
    @test image_fn(g)(ZZ(2)) == QQ(2)
-
-   println("PASS")
 end
 
-function test_gen_map_functional_composite()
-   print("Generic.Map.FunctionalCompositeMap...")
-
+@testset "Generic.Map.FunctionalCompositeMap..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
    g = map_from_func(ZZ, QQ, x -> QQ(x))
 
@@ -53,20 +47,16 @@ function test_gen_map_functional_composite()
 
    @test map1(h) === f
    @test map2(h) === g
-
-   println("PASS")
 end
 
-function test_gen_map_composite()
-   print("Generic.Map.CompositeMap...")
-
+@testset "Generic.Map.CompositeMap..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
 
    s = MyMap(2)
 
    t = compose(f, s)
 
-   @test isa(t, Map(Generic.CompositeMap))     
+   @test isa(t, Map(Generic.CompositeMap))
 
    for i in 1:10
       @test t(ZZ(i)) == 2*(i + 2)
@@ -77,13 +67,9 @@ function test_gen_map_composite()
 
    @test map1(t) === f
    @test map2(t) === s
-
-   println("PASS")
 end
 
-function test_gen_map_identity()
-   print("Generic.Map.IdentityMap...")
-
+@testset "Generic.Map.IdentityMap..." begin
    f = map_from_func(ZZ, QQ, x -> QQ(x + 1))
    g = identity_map(ZZ)
    h = identity_map(QQ)
@@ -106,16 +92,4 @@ function test_gen_map_identity()
 
    @test compose(g, g) === g
    @test compose(h, h) === h
-
-   println("PASS")
 end
-
-function test_gen_map()
-   test_gen_map_functional()
-   test_gen_map_functional_composite()
-   test_gen_map_composite()
-   test_gen_map_identity()
-
-   println("")
-end
-

--- a/test/generic/MapCache-test.jl
+++ b/test/generic/MapCache-test.jl
@@ -1,6 +1,4 @@
-function test_gen_map_cache_constructors()
-   print("Generic.MapCache.constructors...")
-
+@testset "Generic.MapCache.constructors..." begin
    f = cached(map_from_func(ZZ, ZZ, x -> x + 1))
    g = cached(map_from_func(ZZ, QQ, x -> QQ(x)), limit=2)
    h = cached(map_from_func(ZZ, ZZ, x -> x + 2), enabled=false)
@@ -10,7 +8,7 @@ function test_gen_map_cache_constructors()
    @test isa(h, Map(Generic.MapCache))
 
    @test f(ZZ(1)) == 2
-   
+
    for i = 1:10
       @test g(ZZ(i)) == QQ(i)
    end
@@ -22,19 +20,15 @@ function test_gen_map_cache_constructors()
    @test domain(h) == AbstractAlgebra.JuliaZZ
 
    @test image_fn(f)(ZZ(1)) == 2
-
-   println("PASS")
 end
 
-function test_gen_map_cache_enable_disable()
-   print("Generic.MapCache.enable_disable...")
-
+@testset "Generic.MapCache.enable_disable..." begin
    f = cached(map_from_func(ZZ, ZZ, x -> x + 1))
 
    @test f(ZZ(1)) == 2
-   
+
    disable_cache!(f)
-   
+
    @test f(ZZ(1)) == 2
    @test f(ZZ(2)) == 3
 
@@ -56,13 +50,9 @@ function test_gen_map_cache_enable_disable()
 
    @test g(ZZ(1)) == 2
    @test g(ZZ(3)) == 4
-   
-   println("PASS")
 end
 
-function test_gen_map_cache_limit()
-   print("Generic.MapCache.limit...")
-
+@testset "Generic.MapCache.limit..." begin
    g = cached(map_from_func(ZZ, QQ, x -> QQ(x)), limit=2)
 
    set_limit!(g, 3)
@@ -70,15 +60,4 @@ function test_gen_map_cache_limit()
    for i = 1:10
       @test g(ZZ(i)) == QQ(i)
    end
-
-   println("PASS")
 end
-
-function test_gen_map_cache()
-   test_gen_map_cache_constructors()
-   test_gen_map_cache_enable_disable()
-   test_gen_map_cache_limit()
-
-   println("")
-end
-

--- a/test/generic/MapWithInverse-test.jl
+++ b/test/generic/MapWithInverse-test.jl
@@ -1,6 +1,4 @@
-function test_gen_map_with_inverse_constructors()
-   print("Generic.MapWithInverse.constructors...")
-
+@testset "Generic.MapWithInverse.constructors..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
    g = map_from_func(ZZ, ZZ, x -> x - 1)
 
@@ -37,13 +35,9 @@ function test_gen_map_with_inverse_constructors()
    v = map_with_retraction_from_func(ZZ, ZZ, x -> x + 1, x -> x - 1)
 
    @test u(ZZ(1)) == 2
-
-   println("PASS")
 end
 
-function test_gen_map_with_inverse_composition()
-   print("Generic.MapWithInverse.composition...")
-
+@testset "Generic.MapWithInverse.composition..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
    g = map_from_func(ZZ, ZZ, x -> x - 1)
    h = map_from_func(ZZ, ZZ, x -> x + 2)
@@ -62,13 +56,9 @@ function test_gen_map_with_inverse_composition()
    u = compose(s, t)
 
    @test u(ZZ(1)) == 4
-
-   println("PASS")
 end
 
-function test_gen_map_with_inverse_inv()
-   print("Generic.MapWithInverse.inv...")
-
+@testset "Generic.MapWithInverse.inv..." begin
    f = map_from_func(ZZ, ZZ, x -> x + 1)
    g = map_from_func(ZZ, ZZ, x -> x - 1)
    h = map_from_func(ZZ, ZZ, x -> x + 2)
@@ -95,15 +85,4 @@ function test_gen_map_with_inverse_inv()
 
    @test v(ZZ(1)) == -2
    @test w(ZZ(1)) == 0
-
-   println("PASS")
 end
-
-function test_gen_map_with_inverse()
-   test_gen_map_with_inverse_constructors()
-   test_gen_map_with_inverse_composition()
-   test_gen_map_with_inverse_inv()
-
-   println("")
-end
-

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -87,9 +87,7 @@ Base.getindex(a::MyTestMatrix{T}, r::Int, c::Int) where T = a.d
 
 Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
 
-function test_gen_mat_constructors()
-   print("Generic.Mat.constructors...")
-
+@testset "Generic.Mat.constructors..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -181,7 +179,7 @@ function test_gen_mat_constructors()
    S = MatrixSpace(ZZ, 2, 2)
 
    @test isa(S(A), Generic.MatSpaceElem{BigInt})
-  
+
    # Test original matrix not modified
    S = MatrixSpace(QQ, 2, 2)
    a = Rational{BigInt}(1)
@@ -195,13 +193,9 @@ function test_gen_mat_constructors()
    M = S(A)
 
    @test A[1, 1] === a
-
-   println("PASS")
 end
 
-function test_gen_mat_size()
-   print("Generic.Mat.size...")
-
+@testset "Generic.Mat.size..." begin
    A = matrix(QQ, [1 2 3; 4 5 6; 7 8 9])
    B = matrix(QQ, [1 2 3 4; 5 6 7 8])
 
@@ -210,13 +204,9 @@ function test_gen_mat_size()
 
    @test size(B) == (2,4)
    @test !issquare(B)
-
-   println("PASS")
 end
 
-function test_gen_mat_manipulation()
-   print("Generic.Mat.manipulation...")
-
+@testset "Generic.Mat.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -300,13 +290,9 @@ function test_gen_mat_manipulation()
       @test m45 isa Generic.MatSpaceElem
       @test parent(m45) == M45
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_unary_ops()
-   print("Generic.Mat.unary_ops...")
-
+@testset "Generic.Mat.unary_ops..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -314,13 +300,9 @@ function test_gen_mat_unary_ops()
    B = S([-t - 1 (-t) -R(1); -t^2 (-t) (-t); -R(-2) (-t - 2) (-t^2 - t - 1)])
 
    @test -A == B
-
-   println("PASS")
 end
 
-function test_gen_mat_sub()
-   print("Generic.Mat.sub...")
-
+@testset "Generic.Mat.sub..." begin
    S = MatrixSpace(ZZ, 3, 3)
 
    A = S([1 2 3; 4 5 6; 7 8 9])
@@ -350,13 +332,9 @@ function test_gen_mat_sub()
    @test B == @inferred B[:, :]
    @test C == @inferred C[:, :]
    @test D == @inferred D[:, :]
-
-   println("PASS")
 end
 
-function test_gen_mat_binary_ops()
-   print("Generic.Mat.binary_ops...")
-
+@testset "Generic.Mat.binary_ops..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -368,13 +346,9 @@ function test_gen_mat_binary_ops()
    @test A - B == S([t-1 t-3 R(0); t^2 - t R(-1) R(-2); R(-1) (-t^2 + t + 2) (-t^3 + t^2 + t + 1)])
 
    @test A*B == S([t^2 + 2*t + 1 2*t^2 + 4*t + 3 t^3 + t^2 + 3*t + 1; 3*t^2 - t (t^3 + 4*t^2 + t) t^4 + 2*t^2 + 2*t; t-5 t^4 + t^3 + 2*t^2 + 3*t - 4 t^5 + 1*t^4 + t^3 + t^2 + 4*t + 2])
-
-   println("PASS")
 end
 
-function test_gen_mat_adhoc_binary()
-   print("Generic.Mat.adhoc_binary...")
-
+@testset "Generic.Mat.adhoc_binary..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -392,13 +366,9 @@ function test_gen_mat_adhoc_binary()
    @test BigInt(3)*A == A*BigInt(3)
    @test Rational{BigInt}(3)*A == A*Rational{BigInt}(3)
    @test (t - 1)*A == A*(t - 1)
-
-   println("PASS")
 end
 
-function test_gen_mat_permutation()
-   print("Generic.Mat.permutation...")
-
+@testset "Generic.Mat.permutation..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -408,13 +378,9 @@ function test_gen_mat_permutation()
    P = T([2, 3, 1])
 
    @test A == inv(P)*(P*A)
-
-   println("PASS")
 end
 
-function test_gen_mat_comparison()
-   print("Generic.Mat.comparison...")
-
+@testset "Generic.Mat.comparison..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -424,13 +390,9 @@ function test_gen_mat_comparison()
    @test A == B
 
    @test A != one(S)
-
-   println("PASS")
 end
 
-function test_gen_mat_adhoc_comparison()
-   print("Generic.Mat.adhoc_comparison...")
-
+@testset "Generic.Mat.adhoc_comparison..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -446,13 +408,9 @@ function test_gen_mat_adhoc_comparison()
    @test t + 1 == S(t + 1)
    @test A != one(S)
    @test one(S) == one(S)
-
-   println("PASS")
 end
 
-function test_gen_mat_powering()
-   print("Generic.Mat.powering...")
-
+@testset "Generic.Mat.powering..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -467,13 +425,9 @@ function test_gen_mat_powering()
    A = S(Rational{BigInt}[2 3; 7 -4])
 
    @test A^-1 == inv(A)
-
-   println("PASS")
 end
 
-function test_gen_mat_adhoc_exact_division()
-   print("Generic.Mat.adhoc_exact_division...")
-
+@testset "Generic.Mat.adhoc_exact_division..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -483,13 +437,9 @@ function test_gen_mat_adhoc_exact_division()
    @test divexact(12*A, BigInt(12)) == A
    @test divexact(12*A, Rational{BigInt}(12)) == A
    @test divexact((1 + t)*A, 1 + t) == A
-
-   println("PASS")
 end
 
-function test_gen_mat_transpose()
-   print("Generic.Mat.transpose...")
-
+@testset "Generic.Mat.transpose..." begin
    R, t = PolynomialRing(QQ, "t")
    arr = [t + 1 t R(1); t^2 t t]
    A = matrix(R, arr)
@@ -500,51 +450,36 @@ function test_gen_mat_transpose()
    A = matrix(R, arr)
    B = matrix(R, permutedims(arr, [2, 1]))
    @test transpose(A) == B
-
-   println("PASS")
 end
 
-function test_gen_mat_gram()
-   print("Generic.Mat.gram...")
-
+@testset "Generic.Mat.gram..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test gram(A) == S([2*t^2 + 2*t + 2 t^3 + 2*t^2 + t 2*t^2 + t - 1; t^3 + 2*t^2 + t t^4 + 2*t^2 t^3 + 3*t; 2*t^2 + t - 1 t^3 + 3*t t^4 + 2*t^3 + 4*t^2 + 6*t + 9])
-
-   println("PASS")
 end
 
-function test_gen_mat_tr()
-   print("Generic.Mat.tr...")
-
+@testset "Generic.Mat.tr..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test tr(A) == t^2 + 3t + 2
-
-   println("PASS")
 end
 
-function test_gen_mat_content()
-   print("Generic.Mat.content...")
-
+@testset "Generic.Mat.content..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test content((1 + t)*A) == 1 + t
-   println("PASS")
 end
 
-function test_gen_mat_lu()
-   print("Generic.Mat.lu...")
-
+@testset "Generic.Mat.lu..." begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixSpace(K, 3, 3)
@@ -579,13 +514,9 @@ function test_gen_mat_lu()
 
    @test r == 3
    @test P*A == L*U
-
-   println("PASS")
 end
 
-function test_gen_mat_fflu()
-   print("Generic.Mat.fflu...")
-
+@testset "Generic.Mat.fflu..." begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixSpace(K, 3, 3)
@@ -636,13 +567,9 @@ function test_gen_mat_fflu()
    D[3, 3] = inv(U[2, 2])
    @test r == 3
    @test P*A == L*D*U
-
-   println("PASS")
 end
 
-function test_gen_mat_det()
-   print("Generic.Mat.det...")
-
+@testset "Generic.Mat.det..." begin
    S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
 
    for dim = 0:5
@@ -683,14 +610,10 @@ function test_gen_mat_det()
 
       @test det(M) == AbstractAlgebra.det_clow(M)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_minors()
-   print("Generic.Mat.minors...")
-
-   S, z=PolynomialRing(ZZ,"z")
+@testset "Generic.Mat.minors..." begin
+   S, z = PolynomialRing(ZZ,"z")
    n = 5
    R = MatrixSpace(S,n,n)
    for r = 0:n
@@ -704,13 +627,9 @@ function test_gen_mat_minors()
       @test [det(M)] == minors(M, n)
       @test [] == minors(M, n + 1)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_rank()
-   print("Generic.Mat.rank...")
-
+@testset "Generic.Mat.rank..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
@@ -781,13 +700,9 @@ function test_gen_mat_rank()
 
       @test rank(M) == i
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_solve_lu()
-   print("Generic.Mat.solve_lu...")
-
+@testset "Generic.Mat.solve_lu..." begin
    S = QQ
 
    for dim = 0:5
@@ -819,13 +734,9 @@ function test_gen_mat_solve_lu()
 
       @test MK*x == bK
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_solve_rational()
-   print("Generic.Mat.solve_rational...")
-
+@testset "Generic.Mat.solve_rational..." begin
    S = ResidueRing(ZZ, 20011*10007)
 
    for dim = 0:5
@@ -906,13 +817,9 @@ function test_gen_mat_solve_rational()
    x, d = solve_rational(M, b)
 
    @test M*x == d*b
-
-   println("PASS")
 end
 
-function test_gen_mat_solve_left()
-   print("Generic.Mat.solve_left...")
-
+@testset "Generic.Mat.solve_left..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          for dim = 0:5
@@ -954,13 +861,9 @@ function test_gen_mat_solve_left()
          @test X*M == B
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_solve_triu()
-   print("Generic.Mat.solve_triu...")
-
+@testset "Generic.Mat.solve_triu..." begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
 
@@ -975,13 +878,9 @@ function test_gen_mat_solve_triu()
 
       @test M*x == b
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_can_solve_left_reduced_triu()
-   print("Generic.Mat.solve_left_reduced_triu...")
-
+@testset "Generic.Mat.solve_left_reduced_triu..." begin
    for iter = 1:40
       n = rand(1:6)
       m = rand(1:n)
@@ -997,13 +896,9 @@ function test_gen_mat_can_solve_left_reduced_triu()
 
       @test flag == false || x*M == r
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_rref()
-   print("Generic.Mat.rref...")
-
+@testset "Generic.Mat.rref..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
@@ -1067,13 +962,9 @@ function test_gen_mat_rref()
       @test r == i
       @test isrref(A)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_nullspace()
-   print("Generic.Mat.nullspace...")
-
+@testset "Generic.Mat.nullspace..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
@@ -1142,13 +1033,9 @@ function test_gen_mat_nullspace()
       @test rank(N) == n
       @test iszero(M*N)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_kernel()
-   print("Generic.Mat.kernel...")
-
+@testset "Generic.Mat.kernel..." begin
    R = MatrixSpace(ZZ, 5, 5)
 
    for i = 0:5
@@ -1205,13 +1092,9 @@ function test_gen_mat_kernel()
       @test rank(N) == n
       @test iszero(N*M)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_inversion()
-   print("Generic.Mat.inversion...")
-
+@testset "Generic.Mat.inversion..." begin
    for dim = 2:5
       R = MatrixSpace(ZZ, dim, dim)
       M = R(1)
@@ -1298,13 +1181,9 @@ function test_gen_mat_inversion()
 
       @test M*X == d*one(T)
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_hessenberg()
-   print("Generic.Mat.hessenberg...")
-
+@testset "Generic.Mat.hessenberg..." begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -1319,13 +1198,9 @@ function test_gen_mat_hessenberg()
          @test ishessenberg(A)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_kronecker_product()
-   print("Generic.Mat.kronecker_product...")
-
+@testset "Generic.Mat.kronecker_product..." begin
    R = ResidueRing(ZZ, 18446744073709551629)
    S = MatrixSpace(R, 2, 3)
    S2 = MatrixSpace(R, 2, 2)
@@ -1337,13 +1212,9 @@ function test_gen_mat_kronecker_product()
 
    @test size(kronecker_product(A, A)) == (4,9)
    @test kronecker_product(B*A,A*C) == kronecker_product(B,A) * kronecker_product(A,C)
-
-   println("PASS")
 end
 
-function test_gen_mat_charpoly()
-   print("Generic.Mat.charpoly...")
-
+@testset "Generic.Mat.charpoly..." begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -1399,13 +1270,9 @@ function test_gen_mat_charpoly()
    p2 = charpoly(U, M)
 
    @test p1 == p2
-
-   println("PASS")
 end
 
-function test_gen_mat_minpoly()
-   print("Generic.Mat.minpoly...")
-
+@testset "Generic.Mat.minpoly..." begin
    R = GF(103)
    T, y = PolynomialRing(R, "y")
 
@@ -1507,13 +1374,9 @@ function test_gen_mat_minpoly()
    p2 = minpoly(U, M)
 
    @test p1 == p2
-
-   println("PASS")
 end
 
-function test_gen_mat_row_col_swapping()
-   print("Generic.Mat.row_col_swapping...")
-
+@testset "Generic.Mat.row_col_swapping..." begin
    R, x = PolynomialRing(ZZ, "x")
    M = MatrixSpace(R, 3, 2)
 
@@ -1551,13 +1414,9 @@ function test_gen_mat_row_col_swapping()
    @test reverse_cols(a) == matrix(R, [3 2 1; 5 4 3; 7 6 5])
    reverse_cols!(a)
    @test a == matrix(R, [3 2 1; 5 4 3; 7 6 5])
-
-   println("PASS")
 end
 
-function test_gen_mat_elem_op()
-   print("Generic.Mat.gen_mat_elem_op...")
-
+@testset "Generic.Mat.gen_mat_elem_op..." begin
    R, x = PolynomialRing(ZZ, "x")
    for i in 1:10
       r = rand(1:50)
@@ -1678,12 +1537,9 @@ function test_gen_mat_elem_op()
 
       @test multiply_row(multiply_row(M, -one(R), r1), -one(R), r1) == M
    end
-   println("PASS")
 end
 
-function test_gen_mat_concat()
-   print("Generic.Mat.concat...")
-
+@testset "Generic.Mat.concat..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for i = 1:10
@@ -1737,12 +1593,9 @@ function test_gen_mat_concat()
                                     3 4 3 4 1;
                                     0 1 0 1 0;
                                     0 1 0 1 2;])
-   println("PASS")
 end
 
-function test_gen_mat_hnf_minors()
-  print("Generic.Mat.hnf_minors...")
-
+@testset "Generic.Mat.hnf_minors..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1775,13 +1628,9 @@ function test_gen_mat_hnf_minors()
    @test ishnf(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_mat_hnf_kb()
-   print("Generic.Mat.hnf_kb...")
-
+@testset "Generic.Mat.hnf_kb..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1814,13 +1663,9 @@ function test_gen_mat_hnf_kb()
    @test ishnf(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_mat_hnf_cohen()
-   print("Generic.Mat.hnf_cohen...")
-
+@testset "Generic.Mat.hnf_cohen..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1853,13 +1698,9 @@ function test_gen_mat_hnf_cohen()
    @test ishnf(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_mat_hnf()
-   print("Generic.Mat.hnf...")
-
+@testset "Generic.Mat.hnf..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1892,13 +1733,9 @@ function test_gen_mat_hnf()
    @test ishnf(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_mat_snf_kb()
-   print("Generic.Mat.snf_kb...")
-
+@testset "Generic.Mat.snf_kb..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1933,13 +1770,9 @@ function test_gen_mat_snf_kb()
    @test isunit(det(U))
    @test isunit(det(K))
    @test U*B*K == T
-
-   println("PASS")
 end
 
-function test_gen_mat_snf()
-   print("Generic.Mat.snf...")
-
+@testset "Generic.Mat.snf..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -1974,13 +1807,9 @@ function test_gen_mat_snf()
    @test isunit(det(U))
    @test isunit(det(K))
    @test U*B*K == T
-
-   println("PASS")
 end
 
-function test_gen_mat_weak_popov()
-   print("Generic.Mat.weak_popov...")
-
+@testset "Generic.Mat.weak_popov..." begin
    R, x = PolynomialRing(QQ, "x")
 
    A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]))
@@ -2055,13 +1884,9 @@ function test_gen_mat_weak_popov()
       @test U*A == P
       @test isunit(det(U))
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_views()
-   print("Generic.Mat.views...")
-
+@testset "Generic.Mat.views..." begin
    M = matrix(ZZ, 3, 3, BigInt[1, 2, 3, 2, 3, 4, 3, 4, 5])
    M2 = deepcopy(M)
 
@@ -2078,13 +1903,9 @@ function test_gen_mat_views()
 
    @test fflu(N3) == fflu(M) # tests that deepcopy is correct
    @test M2 == M
-
-   println("PASS")
 end
 
-function test_gen_mat_change_base_ring()
-   print("Generic.Mat.change_base_ring...")
-
+@testset "Generic.Mat.change_base_ring..." begin
    for (P, Q, T) in ((MatrixSpace(ZZ, 2, 3), MatrixSpace(ZZ, 3, 2), MatElem),
                      (MatrixAlgebra(ZZ, 3), MatrixAlgebra(ZZ, 3), MatAlgElem))
       M = rand(P, -10:10)
@@ -2102,12 +1923,9 @@ function test_gen_mat_change_base_ring()
          @test MQ * NQ == MNQ
       end
    end
-   println("PASS")
 end
 
-function test_gen_mat_map()
-   print("Generic.Mat.map...")
-
+@testset "Generic.Mat.map..." begin
    u, v = rand(0:9, 2)
    for (mat, algebra) = ((rand(1:9, u, v), false),
                          (rand(1:9, u, u), true))
@@ -2139,11 +1957,9 @@ function test_gen_mat_map()
          end
       end
    end
-   println("PASS")
 end
 
-function test_gen_mat_similar_zero()
-   print("Generic.Mat.similar/zero...")
+@testset "Generic.Mat.similar/zero..." begin
    for sim_zero in (similar, zero)
       test_zero = sim_zero === zero
       for R = (ZZ, GF(11))
@@ -2171,12 +1987,9 @@ function test_gen_mat_similar_zero()
          end
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_mat_show()
-   print("Generic.Mat.show...")
+@testset "Generic.Mat.show..." begin
    @test string(matrix(ZZ, [3 1 2; 2 0 1])) == "[3  1  2]\n[2  0  1]"
    @test string(matrix(ZZ, [3 1 2; 2 0 1])) == "[3  1  2]\n[2  0  1]"
    @test string(matrix(ZZ, 2, 0, [])) == "2 by 0 matrix"
@@ -2187,58 +2000,4 @@ function test_gen_mat_show()
    @test string(MatrixAlgebra(QQ, 0)()) == "0 by 0 matrix"
    @test string(similar(matrix(ZZ, [3 1 2; 2 0 1]))) ==
       "[#undef  #undef  #undef]\n[#undef  #undef  #undef]"
-   println("PASS")
-end
-
-function test_gen_mat()
-   test_gen_mat_constructors()
-   test_gen_mat_size()
-   test_gen_mat_manipulation()
-   test_gen_mat_sub()
-   test_gen_mat_unary_ops()
-   test_gen_mat_binary_ops()
-   test_gen_mat_adhoc_binary()
-   test_gen_mat_permutation()
-   test_gen_mat_comparison()
-   test_gen_mat_adhoc_comparison()
-   test_gen_mat_powering()
-   test_gen_mat_adhoc_exact_division()
-   test_gen_mat_transpose()
-   test_gen_mat_gram()
-   test_gen_mat_tr()
-   test_gen_mat_content()
-   test_gen_mat_lu()
-   test_gen_mat_fflu()
-   test_gen_mat_det()
-   test_gen_mat_rank()
-   test_gen_mat_solve_lu()
-   test_gen_mat_solve_rational()
-   test_gen_mat_solve_left()
-   test_gen_mat_solve_triu()
-   test_gen_mat_can_solve_left_reduced_triu()
-   test_gen_mat_rref()
-   test_gen_mat_nullspace()
-   test_gen_mat_kernel()
-   test_gen_mat_inversion()
-   test_gen_mat_hessenberg()
-   test_gen_mat_kronecker_product()
-   test_gen_mat_charpoly()
-   test_gen_mat_minpoly()
-   test_gen_mat_row_col_swapping()
-   test_gen_mat_elem_op()
-   test_gen_mat_concat()
-   test_gen_mat_hnf_minors()
-   test_gen_mat_hnf_kb()
-   test_gen_mat_hnf_cohen()
-   test_gen_mat_hnf()
-   test_gen_mat_snf_kb()
-   test_gen_mat_snf()
-   test_gen_mat_weak_popov()
-   test_gen_mat_minors()
-   test_gen_mat_views()
-   test_gen_mat_change_base_ring()
-   test_gen_mat_map()
-   test_gen_mat_similar_zero()
-
-   println("")
 end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -76,9 +76,7 @@ function is_weak_popov(P::Generic.MatAlgElem, rank::Int)
    return true
 end
 
-function test_gen_matalg_constructors()
-   print("Generic.MatAlg.constructors...")
-
+@testset "Generic.MatAlg.constructors..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -126,13 +124,9 @@ function test_gen_matalg_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_gen_matalg_size()
-   print("Generic.MatAlg.size...")
-
+@testset "Generic.MatAlg.size..." begin
    S = MatrixAlgebra(QQ, 3)
    A = S([1 2 3; 4 5 6; 7 8 9])
 
@@ -143,13 +137,9 @@ function test_gen_matalg_size()
    @test degree(A) == 3
 
    @test issquare(A)
-
-   println("PASS")
 end
 
-function test_gen_matalg_manipulation()
-   print("Generic.MatAlg.manipulation...")
-
+@testset "Generic.MatAlg.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -187,13 +177,9 @@ function test_gen_matalg_manipulation()
    @test !iszero_row(C, 1)
    @test iszero_column(C, 2)
    @test !iszero_column(C, 1)
-
-   println("PASS")
 end
 
-function test_gen_matalg_unary_ops()
-   print("Generic.MatAlg.unary_ops...")
-
+@testset "Generic.MatAlg.unary_ops..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -201,13 +187,9 @@ function test_gen_matalg_unary_ops()
    B = S([-t - 1 (-t) -R(1); -t^2 (-t) (-t); -R(-2) (-t - 2) (-t^2 - t - 1)])
 
    @test -A == B
-
-   println("PASS")
 end
 
-function test_gen_matalg_binary_ops()
-   print("Generic.MatAlg.binary_ops...")
-
+@testset "Generic.MatAlg.binary_ops..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -219,13 +201,9 @@ function test_gen_matalg_binary_ops()
    @test A - B == S([t-1 t-3 R(0); t^2 - t R(-1) R(-2); R(-1) (-t^2 + t + 2) (-t^3 + t^2 + t + 1)])
 
    @test A*B == S([t^2 + 2*t + 1 2*t^2 + 4*t + 3 t^3 + t^2 + 3*t + 1; 3*t^2 - t (t^3 + 4*t^2 + t) t^4 + 2*t^2 + 2*t; t-5 t^4 + t^3 + 2*t^2 + 3*t - 4 t^5 + 1*t^4 + t^3 + t^2 + 4*t + 2])
-
-   println("PASS")
 end
 
-function test_gen_matalg_adhoc_binary()
-   print("Generic.MatAlg.adhoc_binary...")
-
+@testset "Generic.MatAlg.adhoc_binary..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -243,13 +221,9 @@ function test_gen_matalg_adhoc_binary()
    @test BigInt(3)*A == A*BigInt(3)
    @test Rational{BigInt}(3)*A == A*Rational{BigInt}(3)
    @test (t - 1)*A == A*(t - 1)
-
-   println("PASS")
 end
 
-function test_gen_matalg_permutation()
-   print("Generic.MatAlg.permutation...")
-
+@testset "Generic.MatAlg.permutation..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -259,13 +233,9 @@ function test_gen_matalg_permutation()
    P = T([2, 3, 1])
 
    @test A == inv(P)*(P*A)
-
-   println("PASS")
 end
 
-function test_gen_matalg_comparison()
-   print("Generic.MatAlg.comparison...")
-
+@testset "Generic.MatAlg.comparison..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -275,13 +245,9 @@ function test_gen_matalg_comparison()
    @test A == B
 
    @test A != one(S)
-
-   println("PASS")
 end
 
-function test_gen_matalg_adhoc_comparison()
-   print("Generic.MatAlg.adhoc_comparison...")
-
+@testset "Generic.MatAlg.adhoc_comparison..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -297,13 +263,9 @@ function test_gen_matalg_adhoc_comparison()
    @test t + 1 == S(t + 1)
    @test A != one(S)
    @test one(S) == one(S)
-
-   println("PASS")
 end
 
-function test_gen_matalg_powering()
-   print("Generic.MatAlg.powering...")
-
+@testset "Generic.MatAlg.powering..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -312,13 +274,9 @@ function test_gen_matalg_powering()
    @test A^5 == A^2*A^3
 
    @test A^0 == one(S)
-
-   println("PASS")
 end
 
-function test_gen_matalg_exact_division()
-   print("Generic.MatAlg.exact_division...")
-
+@testset "Generic.MatAlg.exact_division..." begin
    S = MatrixAlgebra(QQ, 3)
 
    M = rand(S, -20:20)
@@ -326,13 +284,9 @@ function test_gen_matalg_exact_division()
 
    @test divexact_right(M*N, N) == M
    @test divexact_left(N*M, N) == M
-
-   println("PASS")
 end
 
-function test_gen_matalg_adhoc_exact_division()
-   print("Generic.MatAlg.adhoc_exact_division...")
-
+@testset "Generic.MatAlg.adhoc_exact_division..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -342,64 +296,45 @@ function test_gen_matalg_adhoc_exact_division()
    @test divexact(12*A, BigInt(12)) == A
    @test divexact(12*A, Rational{BigInt}(12)) == A
    @test divexact((1 + t)*A, 1 + t) == A
-
-   println("PASS")
 end
 
-function test_gen_matalg_transpose()
-   print("Generic.MatAlg.transpose...")
-
+@testset "Generic.MatAlg.transpose..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
    arr = [t + 1 t R(1); t^2 t t; t+1 t^2 R(-1)]
    A = S(arr)
    B = S(permutedims(arr, [2, 1]))
    @test transpose(A) == B
-
-   println("PASS")
 end
 
-function test_gen_matalg_gram()
-   print("Generic.MatAlg.gram...")
-
+@testset "Generic.MatAlg.gram..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test gram(A) == S([2*t^2 + 2*t + 2 t^3 + 2*t^2 + t 2*t^2 + t - 1; t^3 + 2*t^2 + t t^4 + 2*t^2 t^3 + 3*t; 2*t^2 + t - 1 t^3 + 3*t t^4 + 2*t^3 + 4*t^2 + 6*t + 9])
-
-   println("PASS")
 end
 
-function test_gen_matalg_tr()
-   print("Generic.MatAlg.tr...")
-
+@testset "Generic.MatAlg.tr..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test tr(A) == t^2 + 3t + 2
-
-   println("PASS")
 end
 
-function test_gen_matalg_content()
-   print("Generic.MatAlg.content...")
-
+@testset "Generic.MatAlg.content..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
    @test content((1 + t)*A) == 1 + t
-   println("PASS")
 end
 
-function test_gen_matalg_lu()
-   print("Generic.MatAlg.lu...")
-
+@testset "Generic.MatAlg.lu..." begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixAlgebra(K, 3)
@@ -435,13 +370,9 @@ function test_gen_matalg_lu()
 
    @test r == 3
    @test P*A == L*U
-
-   println("PASS")
 end
 
-function test_gen_matalg_fflu()
-   print("Generic.MatAlg.fflu...")
-
+@testset "Generic.MatAlg.fflu..." begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixAlgebra(K, 3)
@@ -493,13 +424,9 @@ function test_gen_matalg_fflu()
    D[3, 3] = inv(U[2, 2])
    @test r == 3
    @test P*A == L*D*U
-
-   println("PASS")
 end
 
-function test_gen_matalg_det()
-   print("Generic.MatAlg.det...")
-
+@testset "Generic.MatAlg.det..." begin
    S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
 
    for dim = 0:5
@@ -540,13 +467,9 @@ function test_gen_matalg_det()
 
       @test det(M) == AbstractAlgebra.det_clow(M)
    end
-
-   println("PASS")
 end
 
-function test_gen_matalg_rank()
-   print("Generic.MatAlg.rank...")
-
+@testset "Generic.MatAlg.rank..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
@@ -618,13 +541,9 @@ function test_gen_matalg_rank()
 
       @test rank(M) == i
    end
-
-   println("PASS")
 end
 
-function test_gen_matalg_solve_lu()
-   print("Generic.MatAlg.solve_lu...")
-
+@testset "Generic.MatAlg.solve_lu..." begin
    S = QQ
 
    for dim = 0:5
@@ -657,13 +576,9 @@ function test_gen_matalg_solve_lu()
 
       @test MK*x == bK
    end
-
-   println("PASS")
 end
 
-function test_gen_matalg_rref()
-   print("Generic.MatAlg.rref...")
-
+@testset "Generic.MatAlg.rref..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
@@ -725,13 +640,9 @@ function test_gen_matalg_rref()
       @test r == i
       @test isrref(A)
    end
-
-   println("PASS")
 end
 
-function test_gen_matalg_inversion()
 @testset "Generic.MatAlg.inversion..." begin
-
    indexing(n) = [(i,j) for i in 1:n for j in 1:n if i !=j ]
    E(R,i,j, val=1) = (M=one(R); M[i,j] = val; return M)
    E(R::MatAlgebra; vals=[1,-1]) = [E(R, i,j,val) for (i,j) in indexing(R.n) for val in vals]
@@ -867,11 +778,8 @@ function test_gen_matalg_inversion()
    end
    end
 end # of @testset "Generic.MatAlg.inversion..."
-end
 
-function test_gen_matalg_hessenberg()
-   print("Generic.MatAlg.hessenberg...")
-
+@testset "Generic.MatAlg.hessenberg..." begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -886,13 +794,9 @@ function test_gen_matalg_hessenberg()
          @test ishessenberg(A)
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_matalg_charpoly()
-   print("Generic.MatAlg.charpoly...")
-
+@testset "Generic.MatAlg.charpoly..." begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -948,13 +852,9 @@ function test_gen_matalg_charpoly()
    p2 = charpoly(U, M)
 
    @test p1 == p2
-
-   println("PASS")
 end
 
-function test_gen_matalg_minpoly()
-   print("Generic.MatAlg.minpoly...")
-
+@testset "Generic.MatAlg.minpoly..." begin
    R = GF(103)
    T, y = PolynomialRing(R, "y")
    S = MatrixAlgebra(R, 3)
@@ -1062,13 +962,9 @@ function test_gen_matalg_minpoly()
    p2 = minpoly(U, M)
 
    @test p1 == p2
-
-   println("PASS")
 end
 
-function test_gen_matalg_row_swapping()
-   print("Generic.MatAlg.row_swapping...")
-
+@testset "Generic.MatAlg.row_swapping..." begin
    R, x = PolynomialRing(ZZ, "x")
    M = MatrixAlgebra(R, 3)
 
@@ -1079,52 +975,46 @@ function test_gen_matalg_row_swapping()
    swap_rows!(a, 2, 3)
 
    @test a == M(map(R, [1 2 3; 7 8 9; 4 5 6]))
-
-   println("PASS")
 end
 
-function test_gen_matalg_hnf_minors()
-  print("Generic.MatAlg.hnf_minors...")
+if false # see bug 160
+    @testset "Generic.MatAlg.hnf_minors..." begin
+        R, x = PolynomialRing(QQ, "x")
 
-   R, x = PolynomialRing(QQ, "x")
+        M = MatrixAlgebra(R, 3)
 
-   M = MatrixAlgebra(R, 3)
+        A = M(map(R, Any[0 0 0; x^3+1 x^2 0; 0 x^2 x^5]))
 
-   A = M(map(R, Any[0 0 0; x^3+1 x^2 0; 0 x^2 x^5]))
+        H = hnf_minors(A)
+        @test istriu(H)
 
-   H = hnf_minors(A)
-   @test istriu(H)
+        H, U = hnf_minors_with_transform(A)
+        @test istriu(H)
+        @test isunit(det(U))
+        @test U*A == H
 
-   H, U = hnf_minors_with_transform(A)
-   @test istriu(H)
-   @test isunit(det(U))
-   @test U*A == H
+        # Fake up finite field of char 7, degree 2
+        R, x = PolynomialRing(GF(7), "x")
+        F = ResidueField(R, x^2 + 6x + 3)
+        a = F(x)
 
-   # Fake up finite field of char 7, degree 2
-   R, x = PolynomialRing(GF(7), "x")
-   F = ResidueField(R, x^2 + 6x + 3)
-   a = F(x)
+        S, y = PolynomialRing(F, "y")
 
-   S, y = PolynomialRing(F, "y")
+        N = MatrixAlgebra(S, 4)
 
-   N = MatrixAlgebra(S, 4)
+        B = N(map(S, Any[1 0 a 0; a*y^3 0 3*a^2 0; y^4+a 0 y^2+y 5; y 1 y 2]))
 
-   B = N(map(S, Any[1 0 a 0; a*y^3 0 3*a^2 0; y^4+a 0 y^2+y 5; y 1 y 2]))
+        H = hnf_minors(B)
+        @test istriu(H)
 
-   H = hnf_minors(B)
-   @test istriu(H)
-
-   H, U = hnf_minors_with_transform(B)
-   @test istriu(H)
-   @test isunit(det(U))
-   @test U*B == H
-
-   println("PASS")
+        H, U = hnf_minors_with_transform(B)
+        @test istriu(H)
+        @test isunit(det(U))
+        @test U*B == H
+    end
 end
 
-function test_gen_matalg_hnf_kb()
-   print("Generic.MatAlg.hnf_kb...")
-
+@testset "Generic.MatAlg.hnf_kb..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1157,13 +1047,9 @@ function test_gen_matalg_hnf_kb()
    @test istriu(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_matalg_hnf_cohen()
-   print("Generic.MatAlg.hnf_cohen...")
-
+@testset "Generic.MatAlg.hnf_cohen..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1196,13 +1082,9 @@ function test_gen_matalg_hnf_cohen()
    @test istriu(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_matalg_hnf()
-   print("Generic.MatAlg.hnf...")
-
+@testset "Generic.MatAlg.hnf..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1235,13 +1117,9 @@ function test_gen_matalg_hnf()
    @test istriu(H)
    @test isunit(det(U))
    @test U*B == H
-
-   println("PASS")
 end
 
-function test_gen_matalg_snf_kb()
-   print("Generic.MatAlg.snf_kb...")
-
+@testset "Generic.MatAlg.snf_kb..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1276,13 +1154,9 @@ function test_gen_matalg_snf_kb()
    @test isunit(det(U))
    @test isunit(det(K))
    @test U*B*K == T
-
-   println("PASS")
 end
 
-function test_gen_matalg_snf()
-   print("Generic.MatAlg.snf...")
-
+@testset "Generic.MatAlg.snf..." begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1317,88 +1191,42 @@ function test_gen_matalg_snf()
    @test isunit(det(U))
    @test isunit(det(K))
    @test U*B*K == T
-
-   println("PASS")
 end
 
-function test_gen_matalg_similar_zero()
-   print("Generic.MatAlg.similar/zero...")
-   for sim_zero in (similar, zero)
-      test_zero = sim_zero === zero
-      for R = (ZZ, GF(11))
-         M = MatrixAlgebra(R, rand(0:9))
-         m = R == ZZ ? rand(M, -10:10) : rand(M)
-         n = sim_zero(m)
+@testset "Generic.MatAlg.$sim_zero..." for sim_zero in (similar, zero)
+   test_zero = sim_zero === zero
+   for R = (ZZ, GF(11))
+      M = MatrixAlgebra(R, rand(0:9))
+      m = R == ZZ ? rand(M, -10:10) : rand(M)
+      n = sim_zero(m)
+      @test !test_zero || iszero(n)
+      @test parent(n) == M
+      @test size(n) == (nrows(M), ncols(M))
+      r = rand(0:9)
+      n = sim_zero(m, r)
+      @test !test_zero || iszero(n)
+      @test parent(n) == MatrixAlgebra(R, r)
+      @test size(n) == (r, r)
+      nn = sim_zero(m, r, r)
+      @test !test_zero || iszero(nn)
+      @test parent(nn) == MatrixAlgebra(R, r)
+      @test size(nn) == (r, r)
+      @test_throws ErrorException sim_zero(m, r, r+1)
+      for S = [QQ, ZZ, GF(2), GF(5)]
+         n = sim_zero(m, S)
          @test !test_zero || iszero(n)
-         @test parent(n) == M
+         @test parent(n) == MatrixAlgebra(S, size(n)[1])
          @test size(n) == (nrows(M), ncols(M))
          r = rand(0:9)
-         n = sim_zero(m, r)
+         n = sim_zero(m, S, r)
          @test !test_zero || iszero(n)
-         @test parent(n) == MatrixAlgebra(R, r)
+         @test parent(n) == MatrixAlgebra(S, r)
          @test size(n) == (r, r)
-         nn = sim_zero(m, r, r)
-         @test !test_zero || iszero(nn)
-         @test parent(nn) == MatrixAlgebra(R, r)
-         @test size(nn) == (r, r)
-         @test_throws ErrorException sim_zero(m, r, r+1)
-         for S = [QQ, ZZ, GF(2), GF(5)]
-            n = sim_zero(m, S)
-            @test !test_zero || iszero(n)
-            @test parent(n) == MatrixAlgebra(S, size(n)[1])
-            @test size(n) == (nrows(M), ncols(M))
-            r = rand(0:9)
-            n = sim_zero(m, S, r)
-            @test !test_zero || iszero(n)
-            @test parent(n) == MatrixAlgebra(S, r)
-            @test size(n) == (r, r)
-            n = sim_zero(m, S, r, r)
-            @test !test_zero || iszero(n)
-            @test parent(n) == MatrixAlgebra(S, r)
-            @test size(n) == (r, r)
-            @test_throws ErrorException sim_zero(m, S, r, r+2)
-         end
+         n = sim_zero(m, S, r, r)
+         @test !test_zero || iszero(n)
+         @test parent(n) == MatrixAlgebra(S, r)
+         @test size(n) == (r, r)
+         @test_throws ErrorException sim_zero(m, S, r, r+2)
       end
    end
-
-   println("PASS")
-end
-
-function test_gen_matalg()
-   test_gen_matalg_constructors()
-   test_gen_matalg_size()
-   test_gen_matalg_manipulation()
-   test_gen_matalg_unary_ops()
-   test_gen_matalg_binary_ops()
-   test_gen_matalg_adhoc_binary()
-   test_gen_matalg_permutation()
-   test_gen_matalg_comparison()
-   test_gen_matalg_adhoc_comparison()
-   test_gen_matalg_powering()
-   test_gen_matalg_exact_division()
-   test_gen_matalg_adhoc_exact_division()
-   test_gen_matalg_transpose()
-   test_gen_matalg_gram()
-   test_gen_matalg_tr()
-   test_gen_matalg_content()
-   test_gen_matalg_lu()
-   test_gen_matalg_fflu()
-   test_gen_matalg_det()
-   test_gen_matalg_rank()
-   test_gen_matalg_solve_lu()
-   test_gen_matalg_rref()
-   test_gen_matalg_inversion()
-   test_gen_matalg_hessenberg()
-   test_gen_matalg_charpoly()
-   test_gen_matalg_minpoly()
-   test_gen_matalg_row_swapping()
-#   test_gen_matalg_hnf_minors() # see bug 160
-   test_gen_matalg_hnf_kb()
-   test_gen_matalg_hnf_cohen()
-   test_gen_matalg_hnf()
-   test_gen_matalg_snf_kb()
-   test_gen_matalg_snf()
-   test_gen_matalg_similar_zero()
-
-   println("")
 end

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -1,22 +1,3 @@
-function rand_module(R::AbstractAlgebra.Ring, vals...)
-   rk = rand(0:5)
-   M = FreeModule(R, rk)
-   levels = rand(0:3)
-   for i = 1:levels
-      if ngens(M) == 0
-         break
-      end
-      G = [rand(M, vals...) for i in 1:rand(1:ngens(M))]
-      S, f = sub(M, G)
-      if rand(1:2) == 1
-         M, f = quo(M, S)
-      else
-         M = S
-      end
-   end
-   return M
-end
-
 function rand_homomorphism(M::AbstractAlgebra.FPModule{T}, vals...) where T <: RingElement
    rk = rand(1:5)
    m = ngens(M)
@@ -32,21 +13,15 @@ function rand_homomorphism(M::AbstractAlgebra.FPModule{T}, vals...) where T <: R
    return S, hom1
 end
 
-function test_module_rand()
-   print("Generic.Module.rand...")
-
+@testset "Generic.Module.rand..." begin
    F = FreeModule(ZZ, 3)
    f = rand(F, 1:9)
    @test f isa Generic.free_module_elem
    f = rand(rng, F, 1:9)
    @test f isa Generic.free_module_elem
-
-   println("PASS")
 end
 
-function test_module_manipulation()
-   print("Generic.Module.manipulation...")
-
+@testset "Generic.Module.manipulation..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          F = FreeModule(R, 3)
@@ -124,12 +99,9 @@ function test_module_manipulation()
    T, h = sub(Q, [b, c, d])
 
    U, k = quo(Q, T)
-
-   println("PASS")
 end
 
-function test_module_elem_getindex()
-   print("Generic.Module.elem_getindex...")
+@testset "Generic.Module.elem_getindex..." begin
 
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -147,13 +119,9 @@ function test_module_elem_getindex()
          @test m1 == m2
       end
    end
-
-   println("PASS")
 end
 
-function test_module_intersection()
-   print("Generic.Module.intersection...")
-
+@testset "Generic.Module.intersection..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -193,13 +161,9 @@ function test_module_intersection()
          @test I1 == I6
       end
    end
-
-   println("PASS")
 end
 
-function test_module_isisomorphic()
-   print("Generic.Module.is_isomorphic...")
-
+@testset "Generic.Module.is_isomorphic..." begin
    # Test the first isomorphism theorem
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -229,13 +193,9 @@ function test_module_isisomorphic()
          @test isisomorphic(I, M1)
       end
    end
-
-   println("PASS")
 end
 
-function test_module_coercions()
-   print("Generic.Module.coercions...")
-
+@testset "Generic.Module.coercions..." begin
    # Test the first isomorphism theorem
    for R in [ZZ, QQ]
       for iter = 1:20
@@ -298,17 +258,4 @@ function test_module_coercions()
          @test parent(D(m9)) === D
       end
    end
-
-   println("PASS")
-end
-
-function test_module()
-   test_module_rand()
-   test_module_manipulation()
-   test_module_elem_getindex()
-   test_module_intersection()
-   test_module_isisomorphic()
-   test_module_coercions()
-
-   println("")
 end

--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -1,8 +1,6 @@
-function test_module_homomorphism_constructors()
-   print("Generic.ModuleHomomorphism.constructors...")
-
+@testset "Generic.ModuleHomomorphism.constructors..." begin
    M = FreeModule(ZZ, 2)
- 
+
    f = ModuleHomomorphism(M, M, matrix(ZZ, 2, 2, [1, 2, 3, 4]))
 
    @test isa(f, Generic.Map(FunctionalMap))
@@ -18,13 +16,9 @@ function test_module_homomorphism_constructors()
    m2 = N([ZZ(4)])
 
    @test g(m2) == N([ZZ(12)])
-
-   println("PASS")
 end
 
-function test_module_homomorphism_kernel()
-   print("Generic.ModuleHomomorphism.kernel...")
-
+@testset "Generic.ModuleHomomorphism.kernel..." begin
    for R in [ZZ, QQ]
       for iter = 1:100
          # test kernels of canonical injection and projection
@@ -35,7 +29,7 @@ function test_module_homomorphism_kernel()
 
          Q, g = quo(M, M1)
          k1, h1 = kernel(f1)
-         
+
          @test ngens(k1) == 0
 
          k2, h2 = kernel(g)
@@ -56,10 +50,10 @@ function test_module_homomorphism_kernel()
 
          m = rand(1:5)
          F = FreeModule(R, m)
- 
+
          S = MatrixSpace(R, m, ngens(M))
          f = ModuleHomomorphism(F, M, rand(S, -10:10))
- 
+
          k, h = kernel(f)
 
          for i = 1:3
@@ -69,13 +63,9 @@ function test_module_homomorphism_kernel()
          end
       end
    end
-
-   println("PASS")
 end
 
-function test_module_homomorphism_image()
-   print("Generic.ModuleHomomorphism.image...")
-
+@testset "Generic.ModuleHomomorphism.image..." begin
    # To make it work on julia nightlies
 
    R = AbstractAlgebra.JuliaZZ
@@ -115,13 +105,9 @@ function test_module_homomorphism_image()
 
       @test I == T
    end
-
-   println("PASS")
 end
 
-function test_module_isomorphism()
-   print("Generic.ModuleIsomorphism...")
-
+@testset "Generic.ModuleIsomorphism..." begin
    R = AbstractAlgebra.JuliaQQ
    for iter = 1:100
       # test image of composition of canonical injection and projection
@@ -143,15 +129,4 @@ function test_module_isomorphism()
       @test isa(image_fn(f), Function)
       @test isa(inverse_image_fn(f), Function)
    end
-   
-   println("PASS")
-end
-
-function test_module_homomorphism()
-   test_module_homomorphism_constructors()
-   test_module_homomorphism_kernel()
-   test_module_homomorphism_image()
-   test_module_isomorphism()
-
-   println("")
 end

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -1,6 +1,4 @@
-function test_gen_ncpoly_constructors()
-   print("Generic.NCPoly.constructors...")
-
+@testset "Generic.NCPoly.constructors..." begin
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
@@ -49,13 +47,9 @@ function test_gen_ncpoly_constructors()
    n = S([ZZ(1), ZZ(2), ZZ(3)])
 
    @test isa(n, NCPolyElem)
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_manipulation()
-   print("Generic.NCPoly.manipulation...")
-
+@testset "Generic.NCPoly.manipulation..." begin
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
@@ -92,13 +86,9 @@ function test_gen_ncpoly_manipulation()
    @test ismonomial(y^2)
 
    @test !ismonomial(y^2 + y + 1)
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_rand()
-   print("Generic.NCPoly.rand...")
-
+@testset "Generic.NCPoly.rand..." begin
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
@@ -106,13 +96,9 @@ function test_gen_ncpoly_rand()
    @test f isa Generic.NCPoly
    f = rand(rng, S, 0:10, -10:10)
    @test f isa Generic.NCPoly
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_binary_ops()
-   print("Generic.NCPoly.binary_ops...")
-
+@testset "Generic.NCPoly.binary_ops..." begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -128,13 +114,9 @@ function test_gen_ncpoly_binary_ops()
       @test (f + g)*(f - g) == f*f + g*f - f*g - g*g
       @test f - g == -(g - f)
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_adhoc_binary()
-   print("Generic.NCPoly.adhoc_binary...")
-
+@testset "Generic.NCPoly.adhoc_binary..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -171,13 +153,9 @@ function test_gen_ncpoly_adhoc_binary()
       @test f*d1 - f*d2 == f*(d1 - d2)
       @test f*d1 + f*d2 == f*(d1 + d2)
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_comparison()
-   print("Generic.NCPoly.comparison...")
-
+@testset "Generic.NCPoly.comparison..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -193,13 +171,9 @@ function test_gen_ncpoly_comparison()
       @test isequal(f, g)
       @test f != g + h
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_adhoc_comparison()
-   print("Generic.NCPoly.adhoc_comparison...")
-
+@testset "Generic.NCPoly.adhoc_comparison..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -244,13 +218,9 @@ function test_gen_ncpoly_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_unary_ops()
-   print("Generic.NCPoly.unary_ops...")
-
+@testset "Generic.NCPoly.unary_ops..." begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -260,13 +230,9 @@ function test_gen_ncpoly_unary_ops()
       @test -(-f) == f
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_truncation()
-   print("Generic.NCPoly.truncation...")
-
+@testset "Generic.NCPoly.truncation..." begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -277,13 +243,9 @@ function test_gen_ncpoly_truncation()
 
       @test truncate(f*g, n) == mullow(f, g, n)
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_reverse()
-   print("Generic.NCPoly.reverse...")
-
+@testset "Generic.NCPoly.reverse..." begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -303,13 +265,9 @@ function test_gen_ncpoly_reverse()
       @test length(frev) == len - shift
       @test f == reverse(frev, len)
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_shift()
-   print("Generic.NCPoly.shift...")
-
+@testset "Generic.NCPoly.shift..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -322,13 +280,9 @@ function test_gen_ncpoly_shift()
       @test shift_left(f, s) == y^s*f
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_powering()
-   print("Generic.NCPoly.powering...")
-
+@testset "Generic.NCPoly.powering..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -345,13 +299,9 @@ function test_gen_ncpoly_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_exact_division()
-   print("Generic.NCPoly.exact_division...")
-
+@testset "Generic.NCPoly.exact_division..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -366,13 +316,9 @@ function test_gen_ncpoly_exact_division()
       @test divexact_right(f*g, g) == f
       @test divexact_left(g*f, g) == f
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_adhoc_exact_division()
-   print("Generic.NCPoly.adhoc_exact_division...")
-
+@testset "Generic.NCPoly.adhoc_exact_division..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -419,13 +365,9 @@ function test_gen_ncpoly_adhoc_exact_division()
       @test divexact_right(f*h, h) == f
       @test divexact_left(h*f, h) == f
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_evaluation()
-   print("Generic.NCPoly.evaluation...")
-
+@testset "Generic.NCPoly.evaluation..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -446,13 +388,9 @@ function test_gen_ncpoly_evaluation()
 
       @test evaluate(f^2, d) == evaluate(f, d)^2
    end
-
-   println("PASS")
 end
 
-function test_gen_ncpoly_derivative()
-   print("Generic.NCPoly.derivative...")
-
+@testset "Generic.NCPoly.derivative..." begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -465,27 +403,4 @@ function test_gen_ncpoly_derivative()
 
       @test derivative(g*f) == derivative(g)*f + g*derivative(f)
    end
-
-   println("PASS")
-end
-
-function test_gen_ncpoly()
-   test_gen_ncpoly_constructors()
-   test_gen_ncpoly_rand()
-   test_gen_ncpoly_manipulation()
-   test_gen_ncpoly_binary_ops()
-   test_gen_ncpoly_adhoc_binary()
-   test_gen_ncpoly_comparison()
-   test_gen_ncpoly_adhoc_comparison()
-   test_gen_ncpoly_unary_ops()
-   test_gen_ncpoly_truncation()
-   test_gen_ncpoly_reverse()
-   test_gen_ncpoly_shift()
-   test_gen_ncpoly_powering()
-   test_gen_ncpoly_exact_division()
-   test_gen_ncpoly_adhoc_exact_division()
-   test_gen_ncpoly_evaluation()
-   test_gen_ncpoly_derivative()
-
-   println("")
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -1,65 +1,53 @@
-function test_perm_abstract_types()
-   print("perm.abstract_types...")
+IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
 
+@testset "perm.abstract_types..." begin
    @test Generic.perm <: GroupElem
 
    @test Generic.PermGroup <: AbstractAlgebra.Group
-
-   println("PASS")
 end
 
-function test_perm_constructors(types)
-   print(rpad("perm.constructors...", 30))
+@testset "perm.constructors ($T)..." for T in IntTypes
+   @test elem_type(Generic.PermGroup{T}) == Generic.perm{T}
+   @test parent_type(Generic.perm{T}) == Generic.PermGroup{T}
 
-   for T in types
-      print("$T ")
-      @test elem_type(Generic.PermGroup{T}) == Generic.perm{T}
-      @test parent_type(Generic.perm{T}) == Generic.PermGroup{T}
+   @test PermutationGroup(T(10)) isa Generic.PermGroup{T}
+   G = PermutationGroup(T(10))
+   @test elem_type(G) == Generic.perm{T}
 
-      @test PermutationGroup(T(10)) isa Generic.PermGroup{T}
-      G = PermutationGroup(T(10))
-      @test elem_type(G) == Generic.perm{T}
+   @test G() isa GroupElem
+   @test G() isa Generic.perm{T}
+   a = G()
+   @test parent_type(typeof(a)) == Generic.PermGroup{T}
+   @test parent(a) == G
 
-      @test G() isa GroupElem
-      @test G() isa Generic.perm{T}
-      a = G()
-      @test parent_type(typeof(a)) == Generic.PermGroup{T}
-      @test parent(a) == G
+   z = T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]
 
-      z = T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]
+   @test G(z) isa GroupElem
+   @test G(z) isa Generic.perm{T}
+   b = G(z)
+   @test typeof(b) == Generic.perm{T}
+   @test parent_type(typeof(b)) == Generic.PermGroup{T}
+   @test parent(b) == G
 
-      @test G(z) isa GroupElem
-      @test G(z) isa Generic.perm{T}
-      b = G(z)
-      @test typeof(b) == Generic.perm{T}
-      @test parent_type(typeof(b)) == Generic.PermGroup{T}
-      @test parent(b) == G
+   @test rand(G) isa Generic.perm{T}
+   @test rand(G, 3) isa Vector{Generic.perm{T}}
+   @test rand(rng, G) isa Generic.perm{T}
+   @test rand(rng, G, 2, 3) isa Matrix{Generic.perm{T}}
+   g = rand(G)
+   @test parent(g) == G
+   @test parent(g) == PermutationGroup(T(10))
 
-      @test rand(G) isa Generic.perm{T}
-      @test rand(G, 3) isa Vector{Generic.perm{T}}
-      @test rand(rng, G) isa Generic.perm{T}
-      @test rand(rng, G, 2,3) isa Matrix{Generic.perm{T}}
-      g = rand(G)
-      @test parent(g) == G
-      @test parent(g) == PermutationGroup(T(10))
+   @test convert(Vector{T}, G(z)) == z
 
-      @test convert(Vector{T}, G(z)) == z
-
-      if T != Int
-         @test parent(g) != PermutationGroup(10)
-      end
-
-      @test similar(g) isa perm{T}
-      @test similar(g, Int) isa perm{Int}
-
+   if T != Int
+      @test parent(g) != PermutationGroup(10)
    end
 
-   println("PASS")
+   @test similar(g) isa perm{T}
+   @test similar(g, Int) isa perm{Int}
 end
 
-function test_perm_parsingGAP(types)
-   print(rpad("perm.parsingGAP...", 30))
-
+@testset "perm.parsingGAP..." begin
    @test Generic.parse_cycles("()") == (Int[], [1])
    @test Generic.parse_cycles("(1)(2)(3)") == ([1,2,3], [1,2,3,4])
    @test Generic.parse_cycles("Cycle decomposition: (1)(2,3)") == ([1,2,3], [1,2,4])
@@ -74,7 +62,7 @@ function test_perm_parsingGAP(types)
 11)(8,80,71,75,35,14,85,25,20,70,65,16,48,47,37,74,33,13,31,69)
 """
 
-s2 ="""
+   s2 ="""
 (1,22,73,64,78,81,24,89,90,54,51,82,91,53,18,38,19,52,44,77,62,95,94,50,43,42,\n10,67,87,60,36,12)(2,57,34,88)(3,92,76,17,99,96,30,55,45,41,98)(4,56,59,97,49,\n21,15,9,26,86,83,29,27,66,6,58,28,5,68,40,72,7,84,93,39,79,23,46,63,32,61,100,\n11)(8,80,71,75,35,14,85,25,20,70,65,16,48,47,37,74,33,13,31,69)
 """
    @test Generic.parse_cycles(s) == Generic.parse_cycles(s2)
@@ -87,15 +75,14 @@ s2 ="""
    @test perm"(1,2,3,4,5)" == perm([2,3,4,5,1])
    @test perm"(3,2,1)(4,5)" == perm([3,1,2,5,4])
 
-@test perm"""
+   @test perm"""
 ( 1, 22,73,64,78,81,  24 ,89,90,54,51,82,91,53,18,38,19,52,44,77,62,95,94,50,43,42,
 10,67,87,60,36,12)(2,57,34,88)(3,92,76,17,99,96,30,55,45,41,98)(4,56,59,97,49,
 21,15,9,26,86,83,29,27,66,6,58,28,5,68,40,72,7,84,93,39,79,23,46,63,32,61,100,
 11)(8,80,71,75,35,14,85,25,20,70,65,16,48,47,37,74,33,13,31,69)
 """ == PermGroup(100)(s2)
 
-   for T in types
-      print("$T ")
+   for T in IntTypes
       G = PermutationGroup(T(5))
       @test G("()") == G()
       @test G("()()") == G()
@@ -114,232 +101,185 @@ s2 ="""
 
       @test all(elt == G(string(cycles(elt))) for elt in G)
    end
-   println("PASS")
 end
 
-function test_perm_printing(types)
-   print(rpad("perm.printing...", 30))
+@testset "perm.printing ($T)..." for T in IntTypes
+   G = PermutationGroup(T(10))
 
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(10))
+   b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-      b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+   Generic.setpermstyle(:array);
+   @test string(b) == "[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]"
 
-      Generic.setpermstyle(:array);
-      @test string(b) == "[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]"
+   Generic.setpermstyle(:cycles);
+   @test string(b) == "(1,2,3,5,6,7)(8,9,10)"
 
-      Generic.setpermstyle(:cycles);
-      @test string(b) == "(1,2,3,5,6,7)(8,9,10)"
+   @test string(perm(T[1,2,3])) == "()"
+   @test string(perm(T[3,2,1])) == "(1,3)"
+end
 
-      @test string(perm(T[1,2,3])) == "()"
-      @test string(perm(T[3,2,1])) == "(1,3)"
+@testset "perm.basic_manipulation ($T)..." for T in IntTypes
+   G = PermutationGroup(T(10))
+
+   a = G()
+   b = deepcopy(a)
+   c = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+
+   @test a == b
+
+   @test parity(a) == 0
+   @test parity(c) == 1
+
+   @test length(unique([c,deepcopy(c)])) == 1
+
+   @test setindex!(a, 5, 2) isa perm
+   @test a[2] == T(5)
+
+   a[1] = T(5)
+   @test a[1] == T(5)
+end
+
+@testset "perm.iteration ($T)..." for T in IntTypes
+   G = PermutationGroup(T(6))
+   @test length(AllPerms(T(6))) == 720
+   @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
+   @test order(G) isa BigInt
+   @test order(T, G) isa promote_type(T, Int)
+   @test order(G) == 720
+
+   @test collect(G) isa Vector{perm{T}}
+
+   elts = collect(G)
+
+   @test elts[1] == G()
+   @test length(elts) == 720
+   @test length(unique(elts)) == 720
+   @test length(G) == 720
+   @test length(unique(collect(G))) == 720
+end
+
+@testset "perm.binary_ops ($T)..." for T in IntTypes
+   G = PermutationGroup(T(3))
+
+   a = perm(T[2,1,3]) # (1,2)
+   b = perm(T[2,3,1]) # (1,2,3)
+
+   @test a*b == G(T[3,2,1]) # (1,2)*(1,2,3) == (1,3)
+   @test b*a == G(T[1,3,2]) # (1,2,3)*(1,2) == (2,3)
+   @test a*a == G()
+   @test b*b*b == G()
+
+   # (1,2,3)*(2,3,4) == (1,3)(2,4)
+   @test perm(T[2,3,1,4])*perm(T[1,3,4,2]) == perm(T[3,4,1,2])
+
+   @test parity(G()) == 0
+   p = parity(a)
+   @test p == 1
+   cycles(a)
+   @test parity(a) == p
+
+   z = G()
+
+   for a in G, b in G
+      @test parity(a*b) == (parity(b)+parity(a)) % 2
+      @test AbstractAlgebra.mul!(z, a, b) == a*b
    end
 
-   println("PASS")
+   a_copy = deepcopy(a)
+   @test a_copy^2 == AbstractAlgebra.mul!(a,a,a)
+   @test a_copy == a
+
+   G = PermutationGroup(T(10))
+   p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
+   @test p^0 == G()
+   @test p^1 == p
+   @test p^-1 == inv(p)
+   @test p^5 == p*p*p*p*p
+   @test p^-4 == inv(p)*inv(p)*inv(p)*inv(p)
+   @test p^2 * p^-2 == G()
 end
 
-function test_perm_basic_manipulation(types)
-   print(rpad("perm.basic_manipulation...", 30))
+@testset "perm.mixed_binary_ops..." begin
+   G = PermutationGroup(6)
+   for T in IntTypes
+      H = PermutationGroup(T(6))
 
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(10))
-
-      a = G()
-      b = deepcopy(a)
-      c = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
-
-      @test a == b
-
-      @test parity(a) == 0
-      @test parity(c) == 1
-
-      @test length(unique([c,deepcopy(c)])) == 1
-
-      @test setindex!(a, 5, 2) isa perm
-      @test a[2] == T(5)
-
-      a[1] = T(5)
-      @test a[1] == T(5)
+      @test G(H()) == G()
+      @test H(G()) == H()
+      @test G() == H()
+      @test rand(G)*rand(H) isa perm{promote_type(Int, T)}
+      @test rand(H)*rand(G) isa perm{promote_type(Int, T)}
+      @test G(rand(H)) isa perm{Int}
+      @test H(rand(G)) isa perm{T}
    end
-
-   println("PASS")
 end
 
-function test_perm_iteration(types)
-   print(rpad("perm.iteration...", 30))
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(6))
-      @test length(AllPerms(T(6))) == 720
-      @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
-      @test order(G) isa BigInt
-      @test order(T, G) isa promote_type(T, Int)
-      @test order(G) == 720
+@testset "perm.inversion ($T)..." for T in IntTypes
+   G = PermutationGroup(T(10))
 
-      @test collect(G) isa Vector{perm{T}}
+   a = G()
+   b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-      elts = collect(G)
+   @test a == inv(a)
+   @test a == b*inv(b)
 
-      @test elts[1] == G()
-      @test length(elts) == 720
-      @test length(unique(elts)) == 720
-      @test length(G) == 720
-      @test length(unique(collect(G))) == 720
+   G = PermutationGroup(3)
+   for a in G, b in G
+      @test inv(a*b) == inv(b)*inv(a)
    end
-
-   println("PASS")
 end
 
-function test_perm_binary_ops(types)
-   print(rpad("perm.binary_ops...", 30))
+@testset "perm.misc ($T)..." for T in IntTypes
+   G = PermutationGroup(T(10))
+   a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(3))
+   @test cycles(G()) isa Generic.CycleDec{T}
+   @test collect(cycles(G())) == [T[i] for i in 1:10]
+   @test order(G()) isa BigInt
+   @test order(T, G()) isa promote_type(Int, T)
+   @test order(G()) == 1
 
-      a = perm(T[2,1,3]) # (1,2)
-      b = perm(T[2,3,1]) # (1,2,3)
+   @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
+   @test Generic.permtype(a) isa Vector{Int}
+   @test Generic.permtype(a) == [6,3,1]
+   @test cycles(a)[1] isa Vector{T}
+   @test cycles(a)[1] == T[1,2,3,5,6,7]
+   @test cycles(a)[2] == T[4]
+   @test cycles(a)[3] == T[8,9,10]
+   @test cycles(a)[1:3] == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
 
-      @test a*b == G(T[3,2,1]) # (1,2)*(1,2,3) == (1,3)
-      @test b*a == G(T[1,3,2]) # (1,2,3)*(1,2) == (2,3)
-      @test a*a == G()
-      @test b*b*b == G()
+   @test order(a) isa BigInt
+   @test order(T, a) isa promote_type(Int, T)
+   @test order(a) == 6
+   @test a^6 == G()
 
-      # (1,2,3)*(2,3,4) == (1,3)(2,4)
-      @test perm(T[2,3,1,4])*perm(T[1,3,4,2]) == perm(T[3,4,1,2])
+   p = G([9,5,4,7,3,8,2,10,1,6])
 
-      @test parity(G()) == 0
-      p = parity(a)
-      @test p == 1
-      cycles(a)
-      @test parity(a) == p
+   @test collect(cycles(p)) == [T[1,9],T[2,5,3,4,7],T[6,8,10]]
+   @test Generic.permtype(p) == [5, 3, 2]
+   @test order(p) == 30
+   @test collect(cycles(p^2)) == [T[1], T[2,3,7,5,4], T[6,10,8], T[9]]
+   @test Generic.permtype(p^2) == [5, 3, 1, 1]
+   @test order(p^2) == 15
+   @test collect(cycles(p^3)) == [T[1,9], T[2,4,5,7,3], T[6], T[8], T[10]]
+   @test Generic.permtype(p^3) == [5, 2, 1, 1, 1]
+   @test order(p^3) == 10
+   @test collect(cycles(p^5)) == [T[1,9], T[2], T[3], T[4], T[5], T[6,10,8], T[7]]
+   @test Generic.permtype(p^5) == [3, 2, 1, 1, 1, 1, 1]
+   @test order(p^5) == 6
 
-      z = G()
-
-      for a in G, b in G
-         @test parity(a*b) == (parity(b)+parity(a)) % 2
-         @test AbstractAlgebra.mul!(z, a, b) == a*b
-      end
-
-      a_copy = deepcopy(a)
-      @test a_copy^2 == AbstractAlgebra.mul!(a,a,a)
-      @test a_copy == a
-
-      G = PermutationGroup(T(10))
-      p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
-      @test p^0 == G()
-      @test p^1 == p
-      @test p^-1 == inv(p)
-      @test p^5 == p*p*p*p*p
-      @test p^-4 == inv(p)*inv(p)*inv(p)*inv(p)
-      @test p^2 * p^-2 == G()
-
-   end
-   println("PASS")
-end
-
-function test_perm_mixed_binary_ops(types)
-   print(rpad("perm.mixed_binary_ops...", 30))
-      G = PermutationGroup(6)
-      for T in types
-         print("$T ")
-         H = PermutationGroup(T(6))
-
-         @test G(H()) == G()
-         @test H(G()) == H()
-         @test G() == H()
-         @test rand(G)*rand(H) isa perm{promote_type(Int, T)}
-         @test rand(H)*rand(G) isa perm{promote_type(Int, T)}
-         @test G(rand(H)) isa perm{Int}
-         @test H(rand(G)) isa perm{T}
-      end
-
-   println("PASS")
-end
-
-function test_perm_inversion(types)
-   print(rpad("perm.inversion...", 30))
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(10))
-
-      a = G()
-      b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
-
-      @test a == inv(a)
-      @test a == b*inv(b)
-
-      G = PermutationGroup(3)
-      for a in G, b in G
-         @test inv(a*b) == inv(b)*inv(a)
-      end
-   end
-   println("PASS")
-end
-
-function test_misc_functions(types)
-   print(rpad("perm.misc...", 30))
-
-   for T in types
-      print("$T ")
-      G = PermutationGroup(T(10))
-      a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
-
-      @test cycles(G()) isa Generic.CycleDec{T}
-      @test collect(cycles(G())) == [T[i] for i in 1:10]
-      @test order(G()) isa BigInt
-      @test order(T, G()) isa promote_type(Int, T)
-      @test order(G()) == 1
-
-      @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
-      @test Generic.permtype(a) isa Vector{Int}
-      @test Generic.permtype(a) == [6,3,1]
-      @test cycles(a)[1] isa Vector{T}
-      @test cycles(a)[1] == T[1,2,3,5,6,7]
-      @test cycles(a)[2] == T[4]
-      @test cycles(a)[3] == T[8,9,10]
-      @test cycles(a)[1:3] == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
-
-      @test order(a) isa BigInt
-      @test order(T, a) isa promote_type(Int, T)
-      @test order(a) == 6
-      @test a^6 == G()
-
-      p = G([9,5,4,7,3,8,2,10,1,6])
-
-      @test collect(cycles(p)) == [T[1,9],T[2,5,3,4,7],T[6,8,10]]
-      @test Generic.permtype(p) == [5, 3, 2]
-      @test order(p) == 30
-      @test collect(cycles(p^2)) == [T[1], T[2,3,7,5,4], T[6,10,8], T[9]]
-      @test Generic.permtype(p^2) == [5, 3, 1, 1]
-      @test order(p^2) == 15
-      @test collect(cycles(p^3)) == [T[1,9], T[2,4,5,7,3], T[6], T[8], T[10]]
-      @test Generic.permtype(p^3) == [5, 2, 1, 1, 1]
-      @test order(p^3) == 10
-      @test collect(cycles(p^5)) == [T[1,9], T[2], T[3], T[4], T[5], T[6,10,8], T[7]]
-      @test Generic.permtype(p^5) == [3, 2, 1, 1, 1, 1, 1]
-      @test order(p^5) == 6
-
-      if VERSION <= v"1.2"
-         @test matrix_repr(a) isa AbstractArray{T,2}
-         @test matrix_repr(a) isa SparseMatrixCSC{T,T}
-         M = matrix_repr(a)
-         for (idx, val) in enumerate(a.d)
-            @test M[idx, val] == 1
-         end
+   if VERSION <= v"1.2"
+      @test matrix_repr(a) isa AbstractArray{T,2}
+      @test matrix_repr(a) isa SparseMatrixCSC{T,T}
+      M = matrix_repr(a)
+      for (idx, val) in enumerate(a.d)
+         @test M[idx, val] == 1
       end
    end
-
-   println("PASS")
 end
 
-function test_characters(types)
-   print(rpad("perm.characters...",30))
-
-   for T in types
-      print("$T ")
+@testset "perm.characters..." begin
+   for T in IntTypes
       N = T(7)
       G = PermutationGroup(N)
 
@@ -418,22 +358,4 @@ function test_characters(types)
    p = Partition(collect(10:-1:1))
    @test character(p, PermutationGroup(big(55))()) == 44261486084874072183645699204710400
    @test dim(YoungTableau(p)) == 44261486084874072183645699204710400
-
-   println("PASS")
-end
-
-function test_perm()
-   IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
-   test_perm_abstract_types()
-   test_perm_constructors(IntTypes)
-   test_perm_parsingGAP(IntTypes)
-   test_perm_printing(IntTypes)
-   test_perm_basic_manipulation(IntTypes)
-   test_perm_iteration(IntTypes)
-   test_perm_binary_ops(IntTypes)
-   test_perm_mixed_binary_ops(IntTypes)
-   test_perm_inversion(IntTypes)
-   test_misc_functions(IntTypes)
-   test_characters(IntTypes)
-   println("")
 end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -16,9 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_gen_poly_constructors()
-   print("Generic.Poly.constructors...")
-
+@testset "Generic.Poly.constructors..." begin
    R, x = ZZ["x"]
    S, y = R["y"]
 
@@ -82,25 +80,17 @@ function test_gen_poly_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_gen_poly_rand()
-   print("Generic.Poly.rand...")
-
+@testset "Generic.Poly.rand..." begin
    R, x = PolynomialRing(ZZ, "x")
    f = rand(R, 0:10, -10:10)
    @test f isa Generic.Poly
    f = rand(rng, R, 0:10, -10:10)
    @test f isa Generic.Poly
-
-   println("PASS")
 end
 
-function test_gen_poly_manipulation()
-   print("Generic.Poly.manipulation...")
-
+@testset "Generic.Poly.manipulation..." begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
 
@@ -137,13 +127,9 @@ function test_gen_poly_manipulation()
    @test ismonomial(x*y^2)
 
    @test !ismonomial(2*x*y^2 + y + 1)
-
-   println("PASS")
 end
 
-function test_gen_poly_binary_ops()
-   print("Generic.Poly.binary_ops...")
-
+@testset "Generic.Poly.binary_ops..." begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:100
@@ -205,13 +191,9 @@ function test_gen_poly_binary_ops()
       @test (f + g)*(f - g) == f*f - g*g
       @test f - g == -(g - f)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_adhoc_binary()
-   print("Generic.Poly.adhoc_binary...")
-
+@testset "Generic.Poly.adhoc_binary..." begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -322,13 +304,9 @@ function test_gen_poly_adhoc_binary()
       @test f*d1 - f*d2 == f*(d1 - d2)
       @test f*d1 + f*d2 == f*(d1 + d2)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_comparison()
-   print("Generic.Poly.comparison...")
-
+@testset "Generic.Poly.comparison..." begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -392,13 +370,9 @@ function test_gen_poly_comparison()
       @test isequal(f, g)
       @test f != g + h
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_adhoc_comparison()
-   print("Generic.Poly.adhoc_comparison...")
-
+@testset "Generic.Poly.adhoc_comparison..." begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -513,13 +487,9 @@ function test_gen_poly_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_unary_ops()
-   print("Generic.Poly.unary_ops...")
-
+@testset "Generic.Poly.unary_ops..." begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:300
@@ -559,13 +529,9 @@ function test_gen_poly_unary_ops()
       @test -(-f) == f
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_truncation()
-   print("Generic.Poly.truncation...")
-
+@testset "Generic.Poly.truncation..." begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:300
@@ -612,13 +578,9 @@ function test_gen_poly_truncation()
       @test truncate(f*g, n) == r
       @test r == 0 || !iszero(lead(r))
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_reverse()
-   print("Generic.Poly.reverse...")
-
+@testset "Generic.Poly.reverse..." begin
    #  Exact ring
    R, x = ZZ["x"]
    for iter = 1:300
@@ -698,13 +660,9 @@ function test_gen_poly_reverse()
       @test length(frev) == len - shift
       @test f == reverse(frev, len)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_shift()
-   print("Generic.Poly.shift...")
-
+@testset "Generic.Poly.shift..." begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:300
@@ -756,13 +714,9 @@ function test_gen_poly_shift()
       @test shift_left(f, s) == x^s*f
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_powering()
-   print("Generic.Poly.powering...")
-
+@testset "Generic.Poly.powering..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -832,195 +786,189 @@ function test_gen_poly_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_modular_arithmetic()
-   print("Generic.Poly.modular_arithmetic...")
+if false
+   @testset "Generic.Poly.modular_arithmetic..." begin
+      # Exact ring
+      R = ResidueRing(ZZ, 23)
+      S, x = PolynomialRing(R, "x")
 
-   # Exact ring
-   R = ResidueRing(ZZ, 23)
-   S, x = PolynomialRing(R, "x")
-
-   for iter = 1:100
-      f = rand(S, 0:5, 0:22)
-      g = rand(S, 0:5, 0:22)
-      h = rand(S, 0:5, 0:22)
-      k = S()
-      while k == 0
-         k = rand(S, 0:5, 0:22)
-      end
-
-      @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
-   end
-
-   for iter = 1:100
-      f = S()
-      g = S()
-      while f == 0 || g == 0 || gcd(f, g) != 1
+      for iter = 1:100
          f = rand(S, 0:5, 0:22)
          g = rand(S, 0:5, 0:22)
+         h = rand(S, 0:5, 0:22)
+         k = S()
+         while k == 0
+            k = rand(S, 0:5, 0:22)
+         end
+
+         @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
       end
 
-      @test mulmod(invmod(f, g), f, g) == mod(S(1), g)
-   end
+      for iter = 1:100
+         f = S()
+         g = S()
+         while f == 0 || g == 0 || gcd(f, g) != 1
+            f = rand(S, 0:5, 0:22)
+            g = rand(S, 0:5, 0:22)
+         end
 
-   for iter = 1:100
-      f = rand(S, 0:5, 0:22)
-      g = S()
-      while g == 0
-         g = rand(S, 0:5, 0:22)
-      end
-      p = mod(S(1), g)
-
-      for expn = 0:5
-         r = powmod(f, expn, g)
-
-         @test (f == 0 && expn == 0 && r == 0) || r == p
-
-         p = mulmod(p, f, g)
-      end
-   end
-
-   # Fake finite field of char 7, degree 2
-   R, y = PolynomialRing(GF(7), "y")
-   F = ResidueField(R, y^2 + 6y + 3)
-   a = F(y)
-   S, x = PolynomialRing(F, "x")
-
-   for iter = 1:100
-      f = rand(S, 0:5, 0:1)
-      g = rand(S, 0:5, 0:1)
-      h = rand(S, 0:5, 0:1)
-      k = S()
-      while k == 0
-         k = rand(S, 0:5, 0:1)
+         @test mulmod(invmod(f, g), f, g) == mod(S(1), g)
       end
 
-      @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
-   end
+      for iter = 1:100
+         f = rand(S, 0:5, 0:22)
+         g = S()
+         while g == 0
+            g = rand(S, 0:5, 0:22)
+         end
+         p = mod(S(1), g)
 
-   for iter = 1:100
-      f = S()
-      g = S()
-      while f == 0 || g == 0 || gcd(f, g) != 1
+         for expn = 0:5
+            r = powmod(f, expn, g)
+
+            @test (f == 0 && expn == 0 && r == 0) || r == p
+
+            p = mulmod(p, f, g)
+         end
+      end
+
+      # Fake finite field of char 7, degree 2
+      R, y = PolynomialRing(GF(7), "y")
+      F = ResidueField(R, y^2 + 6y + 3)
+      a = F(y)
+      S, x = PolynomialRing(F, "x")
+
+      for iter = 1:100
          f = rand(S, 0:5, 0:1)
          g = rand(S, 0:5, 0:1)
+         h = rand(S, 0:5, 0:1)
+         k = S()
+         while k == 0
+            k = rand(S, 0:5, 0:1)
+         end
+
+         @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
       end
 
-      @test mulmod(invmod(f, g), f, g) == mod(S(1), g)
-   end
+      for iter = 1:100
+         f = S()
+         g = S()
+         while f == 0 || g == 0 || gcd(f, g) != 1
+            f = rand(S, 0:5, 0:1)
+            g = rand(S, 0:5, 0:1)
+         end
 
-   for iter = 1:100
-      f = rand(S, 0:5, 0:1)
-      g = S()
-      while g == 0
-         g = rand(S, 0:5, 0:1)
-      end
-      p = mod(S(1), g)
-
-      for expn = 0:5
-         r = powmod(f, expn, g)
-
-         @test (f == 0 && expn == 0 && r == 0) || r == p
-
-         p = mulmod(p, f, g)
-      end
-   end
-
-   # Inexact field
-   S, x = PolynomialRing(RealField, "x")
-
-   for iter = 1:100
-      f = rand(S, 0:5, -1:1)
-      g = rand(S, 0:5, -1:1)
-      h = rand(S, 0:5, -1:1)
-      k = R()
-      while k == 0
-         k = rand(S, 0:5, -1:1)
+         @test mulmod(invmod(f, g), f, g) == mod(S(1), g)
       end
 
-      @test isapprox(mulmod(mulmod(f, g, k), h, k), mulmod(f, mulmod(g, h, k), k))
-   end
+      for iter = 1:100
+         f = rand(S, 0:5, 0:1)
+         g = S()
+         while g == 0
+            g = rand(S, 0:5, 0:1)
+         end
+         p = mod(S(1), g)
 
-   for iter = 1:100
-      f = S()
-      g = S()
-      while f == 0 || g == 0 || gcd(f, g) != 1
+         for expn = 0:5
+            r = powmod(f, expn, g)
+
+            @test (f == 0 && expn == 0 && r == 0) || r == p
+
+            p = mulmod(p, f, g)
+         end
+      end
+
+      # Inexact field
+      S, x = PolynomialRing(RealField, "x")
+
+      for iter = 1:100
          f = rand(S, 0:5, -1:1)
          g = rand(S, 0:5, -1:1)
+         h = rand(S, 0:5, -1:1)
+         k = R()
+         while k == 0
+            k = rand(S, 0:5, -1:1)
+         end
+
+         @test isapprox(mulmod(mulmod(f, g, k), h, k), mulmod(f, mulmod(g, h, k), k))
       end
 
-      @test isapprox(mulmod(invmod(f, g), f, g), mod(S(1), g))
-   end
+      for iter = 1:100
+         f = S()
+         g = S()
+         while f == 0 || g == 0 || gcd(f, g) != 1
+            f = rand(S, 0:5, -1:1)
+            g = rand(S, 0:5, -1:1)
+         end
 
-   for iter = 1:100
-      f = rand(S, 0:5, -1:1)
-      g = S()
-      while g == 0
-         g = rand(S, 0:5, -1:1)
-      end
-      p = mod(S(1), g)
-
-      for expn = 0:5
-         r = powmod(f, expn, g)
-
-         @test (f == 0 && expn == 0 && r == 0) || isapprox(r, p)
-
-         p = mulmod(p, f, g)
-      end
-   end
-
-   # Exact field
-   R, x = PolynomialRing(QQ, "y")
-
-   for iter = 1:10
-      f = rand(R, 0:5, -10:10)
-      g = rand(R, 0:5, -10:10)
-      h = rand(R, 0:5, -10:10)
-      k = R()
-      while k == 0
-         k = rand(R, 0:5, -10:10)
+         @test isapprox(mulmod(invmod(f, g), f, g), mod(S(1), g))
       end
 
-      @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
-   end
+      for iter = 1:100
+         f = rand(S, 0:5, -1:1)
+         g = S()
+         while g == 0
+            g = rand(S, 0:5, -1:1)
+         end
+         p = mod(S(1), g)
 
-   for iter = 1:10
-      f = R()
-      g = R()
-      while f == 0 || g == 0 || gcd(f, g) != 1
+         for expn = 0:5
+            r = powmod(f, expn, g)
+
+            @test (f == 0 && expn == 0 && r == 0) || isapprox(r, p)
+
+            p = mulmod(p, f, g)
+         end
+      end
+
+      # Exact field
+      R, x = PolynomialRing(QQ, "y")
+
+      for iter = 1:10
          f = rand(R, 0:5, -10:10)
          g = rand(R, 0:5, -10:10)
+         h = rand(R, 0:5, -10:10)
+         k = R()
+         while k == 0
+            k = rand(R, 0:5, -10:10)
+         end
+
+         @test mulmod(mulmod(f, g, k), h, k) == mulmod(f, mulmod(g, h, k), k)
       end
 
-      @test mulmod(invmod(f, g), f, g) == mod(R(1), g)
+      for iter = 1:10
+         f = R()
+         g = R()
+         while f == 0 || g == 0 || gcd(f, g) != 1
+            f = rand(R, 0:5, -10:10)
+            g = rand(R, 0:5, -10:10)
+         end
+
+         @test mulmod(invmod(f, g), f, g) == mod(R(1), g)
+      end
+
+      for iter = 1:10
+         f = rand(R, 0:5, -10:10)
+         g = R()
+         while g == 0
+            g = rand(R, 0:5, -10:10)
+         end
+         p = mod(R(1), g)
+
+         for expn = 0:5
+            r = powmod(f, expn, g)
+
+            @test (f == 0 && expn == 0 && r == 0) || r == p
+
+            p = mulmod(p, f, g)
+         end
+      end
    end
-
-   for iter = 1:10
-      f = rand(R, 0:5, -10:10)
-      g = R()
-      while g == 0
-         g = rand(R, 0:5, -10:10)
-      end
-      p = mod(R(1), g)
-
-      for expn = 0:5
-         r = powmod(f, expn, g)
-
-         @test (f == 0 && expn == 0 && r == 0) || r == p
-
-         p = mulmod(p, f, g)
-      end
-   end
-
-   println("PASS")
 end
 
-function test_gen_poly_exact_division()
-   print("Generic.Poly.exact_division...")
-
+@testset "Generic.Poly.exact_division..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1077,13 +1025,9 @@ function test_gen_poly_exact_division()
 
       @test divexact(f*g, g) == f
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_adhoc_exact_division()
-   print("Generic.Poly.adhoc_exact_division...")
-
+@testset "Generic.Poly.adhoc_exact_division..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1186,13 +1130,9 @@ function test_gen_poly_adhoc_exact_division()
 
       @test divexact(f*h, h) == f
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_euclidean_division()
-   print("Generic.Poly.euclidean_division...")
-
+@testset "Generic.Poly.euclidean_division..." begin
    # Exact ring
    R = ResidueRing(ZZ, 23)
    S, x = PolynomialRing(R, "x")
@@ -1304,13 +1244,9 @@ function test_gen_poly_euclidean_division()
 
       @test mod(f, g) == r
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_pseudodivision()
-   print("Generic.Poly.pseudodivision...")
-
+@testset "Generic.Poly.pseudodivision..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1353,13 +1289,9 @@ function test_gen_poly_pseudodivision()
 
       @test pseudorem(f, g) == r
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_content_primpart_gcd()
-   print("Generic.Poly.content_primpart_gcd...")
-
+@testset "Generic.Poly.content_primpart_gcd..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1489,13 +1421,9 @@ function test_gen_poly_content_primpart_gcd()
 
       @test mod(f*inv, g) == mod(S(1), g)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_evaluation()
-   print("Generic.Poly.evaluation...")
-
+@testset "Generic.Poly.evaluation..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1559,13 +1487,9 @@ function test_gen_poly_evaluation()
 
       @test evaluate(g, evaluate(f, d)) == evaluate(subst(g, f), d)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_composition()
-   print("Generic.Poly.composition...")
-
+@testset "Generic.Poly.composition..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1599,13 +1523,9 @@ function test_gen_poly_composition()
 
       @test compose(f, compose(g, h)) == compose(compose(f, g), h)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_derivative()
-   print("Generic.Poly.derivative...")
-
+@testset "Generic.Poly.derivative..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1642,13 +1562,9 @@ function test_gen_poly_derivative()
 
       @test derivative(g*f) == derivative(g)*f + derivative(f)*g
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_integral()
-   print("Generic.Poly.integral...")
-
+@testset "Generic.Poly.integral..." begin
    # Exact field
    R, x = PolynomialRing(QQ, "x")
 
@@ -1691,13 +1607,9 @@ function test_gen_poly_integral()
       @test isapprox(integral(f + g), integral(g) + integral(f))
       @test isapprox(integral(f)*integral(g), integral(integral(f)*g + integral(g)*f))
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_sylvester_matrix()
-   print("Generic.Poly.sylvester_matrix...")
-
+@testset "Generic.Poly.sylvester_matrix..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter in 1:10
@@ -1723,13 +1635,9 @@ function test_gen_poly_sylvester_matrix()
       M = sylvester_matrix(f, g)
       @test v == w * M
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_resultant()
-   print("Generic.Poly.resultant...")
-
+@testset "Generic.Poly.resultant..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1818,13 +1726,9 @@ function test_gen_poly_resultant()
       @test lead(f)*lead(g) == 0 || resultant(f*g, h) == resultant(f, h)*resultant(g, h)
       @test lead(g)*lead(h) == 0 || resultant(f, g*h) == resultant(f, g)*resultant(f, h)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_discriminant()
-   print("Generic.Poly.discriminant...")
-
+@testset "Generic.Poly.discriminant..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1874,13 +1778,9 @@ function test_gen_poly_discriminant()
 #      # The identity on Wikipedia is incorrect as of 07.10.2017
 #      @test discriminant(f*g) == discriminant(f)*discriminant(g)*resultant(g, f)^2
 #   end
-
-   println("PASS")
 end
 
-function test_gen_poly_resx()
-   print("Generic.Poly.resx...")
-
+@testset "Generic.Poly.resx..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2012,13 +1912,9 @@ function test_gen_poly_resx()
 #
 #      @test (u*f + v*g)*h == r
 #   end
-
-   println("PASS")
 end
 
-function test_gen_poly_gcdx()
-   print("Generic.Poly.gcdx...")
-
+@testset "Generic.Poly.gcdx..." begin
    # Exact field
    R, x = PolynomialRing(QQ, "x")
 
@@ -2107,13 +2003,9 @@ function test_gen_poly_gcdx()
 
       @test (u*f + v*g)*h == r
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_newton_representation()
-   print("Generic.Poly.newton_representation...")
-
+@testset "Generic.Poly.newton_representation..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2200,13 +2092,9 @@ function test_gen_poly_newton_representation()
 
       @test f == g
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_interpolation()
-   print("Generic.Poly.interpolation...")
-
+@testset "Generic.Poly.interpolation..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2312,13 +2200,9 @@ function test_gen_poly_interpolation()
 #
 #      @test f == p
 #   end
-
-   println("PASS")
 end
 
-function test_gen_poly_special()
-   print("Generic.Poly.special...")
-
+@testset "Generic.Poly.special..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2434,13 +2318,9 @@ function test_gen_poly_special()
 
       @test T^2 == 1 + (x^2 - 1)*U^2
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_mul_karatsuba()
-   print("Generic.Poly.mul_karatsuba...")
-
+@testset "Generic.Poly.mul_karatsuba..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
@@ -2450,13 +2330,9 @@ function test_gen_poly_mul_karatsuba()
 
    @test mul_karatsuba(f^10, f^10) == mul_classical(f^10, f^10)
    @test mul_karatsuba(f^10, f^30) == mul_classical(f^10, f^30)
-
-   println("PASS")
 end
 
-function test_gen_poly_mul_ks()
-   print("Generic.Poly.mul_ks...")
-
+@testset "Generic.Poly.mul_ks..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
@@ -2466,13 +2342,9 @@ function test_gen_poly_mul_ks()
 
    @test mul_ks(f^10, f^10) == mul_classical(f^10, f^10)
    @test mul_ks(f^10, f^30) == mul_classical(f^10, f^30)
-
-   println("PASS")
 end
 
-function test_gen_poly_remove_valuation()
-   print("Generic.Poly.remove_valuation...")
-
+@testset "Generic.Poly.remove_valuation..." begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2630,13 +2502,9 @@ function test_gen_poly_remove_valuation()
          @test !v
       end
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_generic_eval()
-   print("Generic.Poly.generic_eval...")
-
+@testset "Generic.Poly.generic_eval..." begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter in 1:10
@@ -2658,12 +2526,9 @@ function test_gen_poly_generic_eval()
 
       @test b == f(a)
    end
-
-   println("PASS")
 end
 
-function test_gen_poly_change_base_ring()
-   print("Generic.Poly.change_base_ring...")
+@testset "Generic.Poly.change_base_ring..." begin
    Zx, x = PolynomialRing(ZZ,'x')
    @test 1 == change_base_ring(x^0, sqrt)
    p = Zx([i for i in 1:10])
@@ -2675,45 +2540,4 @@ function test_gen_poly_change_base_ring()
       pqR = change_base_ring(pq, R)
       @test pR * qR == pqR
    end
-
-   println("PASS")
-end
-
-function test_gen_poly()
-   test_gen_poly_constructors()
-   test_gen_poly_rand()
-   test_gen_poly_manipulation()
-   test_gen_poly_binary_ops()
-   test_gen_poly_adhoc_binary()
-   test_gen_poly_comparison()
-   test_gen_poly_adhoc_comparison()
-   test_gen_poly_unary_ops()
-   test_gen_poly_truncation()
-   test_gen_poly_reverse()
-   test_gen_poly_shift()
-   test_gen_poly_powering()
-   #test_gen_poly_modular_arithmetic()
-   test_gen_poly_exact_division()
-   test_gen_poly_adhoc_exact_division()
-   test_gen_poly_euclidean_division()
-   test_gen_poly_pseudodivision()
-   test_gen_poly_content_primpart_gcd()
-   test_gen_poly_evaluation()
-   test_gen_poly_composition()
-   test_gen_poly_derivative()
-   test_gen_poly_integral()
-   test_gen_poly_sylvester_matrix()
-   test_gen_poly_resultant()
-   test_gen_poly_discriminant()
-   test_gen_poly_resx()
-   test_gen_poly_gcdx()
-   test_gen_poly_newton_representation()
-   test_gen_poly_interpolation()
-   test_gen_poly_special()
-   test_gen_poly_mul_karatsuba()
-   test_gen_poly_mul_ks()
-   test_gen_poly_generic_eval()
-   test_gen_poly_remove_valuation()
-   test_gen_poly_change_base_ring()
-   println("")
 end

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -16,9 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_puiseux_series_constructors()
-   print("Generic.PuiseuxSeries.constructors...")
-
+@testset "Generic.PuiseuxSeries.constructors..." begin
    R, x = PuiseuxSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -91,13 +89,9 @@ function test_puiseux_series_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_puiseux_series_rand()
-   print("Generic.PuiseuxSeries.rand...")
-
+@testset "Generic.PuiseuxSeries.rand..." begin
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    f = rand(R, -12:12, 1:6, -10:10)
    @test f isa Generic.PuiseuxSeriesRingElem
@@ -109,13 +103,9 @@ function test_puiseux_series_rand()
    @test f isa Generic.PuiseuxSeriesFieldElem
    f = rand(rng, R, -12:12, 1:6, -1:1)
    @test f isa Generic.PuiseuxSeriesFieldElem
-
-   println("PASS")
 end
 
-function test_puiseux_series_manipulation()
-   print("Generic.PuiseuxSeries.manipulation...")
-
+@testset "Generic.PuiseuxSeries.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PuiseuxSeriesRing(R, 30, "x")
 
@@ -150,13 +140,9 @@ function test_puiseux_series_manipulation()
    U, y = PuiseuxSeriesRing(T, 10, "y")
 
    @test modulus(T) == 7
-
-   println("PASS")
 end
 
-function test_puiseux_series_unary_ops()
-   print("Generic.PuiseuxSeries.unary_ops...")
-
+@testset "Generic.PuiseuxSeries.unary_ops..." begin
    #  Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -184,13 +170,9 @@ function test_puiseux_series_unary_ops()
       @test isequal(-(-f), f)
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_binary_ops()
-   print("Generic.PuiseuxSeries.binary_ops...")
-
+@testset "Generic.PuiseuxSeries.binary_ops..." begin
    #  Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -237,13 +219,9 @@ function test_puiseux_series_binary_ops()
       @test f*(g + h) == f*g + f*h
       @test f*(g - h) == f*g - f*h
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_adhoc_binary_ops()
-   print("Generic.PuiseuxSeries.adhoc_binary_ops...")
-
+@testset "Generic.PuiseuxSeries.adhoc_binary_ops..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -331,13 +309,9 @@ function test_puiseux_series_adhoc_binary_ops()
       @test isequal(f*d1 - f*d2, f*(d1 - d2))
       @test isequal(f*d1 + f*d2, f*(d1 + d2))
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_comparison()
-   print("Generic.PuiseuxSeries.comparison...")
-
+@testset "Generic.PuiseuxSeries.comparison..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -386,13 +360,9 @@ function test_puiseux_series_comparison()
       @test (precision(h) > min(precision(f), precision(g)) || f != g + h)
       @test (precision(h) > min(precision(f), precision(g)) || !isequal(f, g + h))
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_adhoc_comparison()
-   print("Generic.PuiseuxSeries.adhoc_comparison...")
-
+@testset "Generic.PuiseuxSeries.adhoc_comparison..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -487,13 +457,9 @@ function test_puiseux_series_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_powering()
-   print("Generic.PuiseuxSeries.powering...")
-
+@testset "Generic.PuiseuxSeries.powering..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
 
@@ -544,13 +510,9 @@ function test_puiseux_series_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_inversion()
-   print("Generic.PuiseuxSeries.inversion...")
-
+@testset "Generic.PuiseuxSeries.inversion..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -584,13 +546,9 @@ function test_puiseux_series_inversion()
 
       @test f*inv(f) == 1
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_square_root()
-   print("Generic.PuiseuxSeries.square_root...")
-
+@testset "Generic.PuiseuxSeries.square_root..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -608,13 +566,9 @@ function test_puiseux_series_square_root()
 
       @test isapprox(sqrt(g)^2, g)
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_exact_division()
-   print("Generic.PuiseuxSeries.exact_division...")
-
+@testset "Generic.PuiseuxSeries.exact_division..." begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -653,13 +607,9 @@ function test_puiseux_series_exact_division()
 
       @test divexact(f, g)*g == f
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_adhoc_exact_division()
-   print("Generic.PuiseuxSeries.adhoc_exact_division...")
-
+@testset "Generic.PuiseuxSeries.adhoc_exact_division..." begin
    # Exact field
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -696,13 +646,9 @@ function test_puiseux_series_adhoc_exact_division()
 
       @test isequal(divexact(f*c, c), f)
    end
-
-   println("PASS")
 end
 
-function test_puiseux_series_special_functions()
-   print("Generic.PuiseuxSeries.special_functions...")
-
+@testset "Generic.PuiseuxSeries.special_functions..." begin
    # Exact field
    S, x = PuiseuxSeriesRing(QQ, 10, "x")
 
@@ -763,25 +709,4 @@ function test_puiseux_series_special_functions()
 
       @test isequal(exp(f)*exp(g), exp(f + g))
    end
-
-   println("PASS")
-end
-
-function test_gen_puiseux_series()
-   test_puiseux_series_constructors()
-   test_puiseux_series_rand()
-   test_puiseux_series_manipulation()
-   test_puiseux_series_unary_ops()
-   test_puiseux_series_binary_ops()
-   test_puiseux_series_adhoc_binary_ops()
-   test_puiseux_series_comparison()
-   test_puiseux_series_adhoc_comparison()
-   test_puiseux_series_powering()
-   test_puiseux_series_exact_division()
-   test_puiseux_series_adhoc_exact_division()
-   test_puiseux_series_inversion()
-   test_puiseux_series_square_root()
-   test_puiseux_series_special_functions()
-
-   println("")
 end

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -1,6 +1,4 @@
-function test_quotient_module_constructors()
-   print("Generic.QuotientModule.constructors...")
-
+@testset "Generic.QuotientModule.constructors..." begin
    R = ZZ
    M = FreeModule(R, 2)
 
@@ -45,7 +43,7 @@ function test_quotient_module_constructors()
          T = [rand(N, -10:10) for i in 1:ngens2]
          P, g = sub(N, T)
          Q1, h1 = quo(M, P)
-         
+
          U = [f(v) for v in T]
          V, k = sub(M, U)
 
@@ -63,13 +61,9 @@ function test_quotient_module_constructors()
    m = Q([])
 
    @test isa(m, Generic.quotient_module_elem)
-
-   println("PASS")
 end
 
-function test_quotient_module_manipulation()
-   print("Generic.QuotientModule.manipulation...")
-
+@testset "Generic.QuotientModule.manipulation..." begin
    R = ZZ
    M = FreeModule(R, 2)
 
@@ -85,13 +79,9 @@ function test_quotient_module_manipulation()
    end
 
    @test supermodule(Q) == M
-
-   println("PASS")
 end
 
-function test_quotient_module_unary_ops()
-   print("Generic.QuotientModule.unary_ops...")
-
+@testset "Generic.QuotientModule.unary_ops..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -101,17 +91,13 @@ function test_quotient_module_unary_ops()
          Q, g = quo(M, N)
 
          m = rand(Q, -10:10)
-   
+
          @test -(-m) == m
       end
    end
-
-   println("PASS")
 end
 
-function test_quotient_module_binary_ops()
-   print("Generic.QuotientModule.binary_ops...")
-
+@testset "Generic.QuotientModule.binary_ops..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -127,13 +113,9 @@ function test_quotient_module_binary_ops()
          @test m - n == m + (-n)
       end
    end
-
-   println("PASS")
 end
 
-function test_quotient_module_adhoc_binary()
-   print("Generic.QuotientModule.adhoc_binary...")
-
+@testset "Generic.QuotientModule.adhoc_binary..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -152,13 +134,9 @@ function test_quotient_module_adhoc_binary()
          @test c*(m - n) == c*m - c*n
       end
    end
-
-   println("PASS")
 end
 
-function test_quotient_module_canonical_projection()
-   print("Generic.QuotientModule.canonical_projection...")
-
+@testset "Generic.QuotientModule.canonical_projection..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -177,17 +155,4 @@ function test_quotient_module_canonical_projection()
          @test h(preimage(h, n)) == n
       end
    end
-
-   println("PASS")
-end
-
-function test_quotient_module()
-   test_quotient_module_constructors()
-   test_quotient_module_manipulation()
-   test_quotient_module_unary_ops()
-   test_quotient_module_binary_ops()
-   test_quotient_module_adhoc_binary()
-   test_quotient_module_canonical_projection()
-
-   println("")
 end

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -16,9 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_rel_series_constructors()
-   print("Generic.RelSeries.constructors...")
-
+@testset "Generic.RelSeries.constructors..." begin
    R, x = PowerSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -80,25 +78,17 @@ function test_rel_series_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_rel_series_rand()
-   print("Generic.RelSeries.rand...")
-
+@testset "Generic.RelSeries.rand..." begin
    R, x = PowerSeriesRing(ZZ, 10, "x")
    f = rand(R, 0:12, -10:10)
    @test f isa Generic.RelSeries
    f = rand(rng, R, 0:12, -10:10)
    @test f isa Generic.RelSeries
-
-   println("PASS")
 end
 
-function test_rel_series_manipulation()
-   print("Generic.RelSeries.manipulation...")
-
+@testset "Generic.RelSeries.manipulation..." begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x")
 
@@ -136,13 +126,9 @@ function test_rel_series_manipulation()
    U, y = PowerSeriesRing(T, 10, "y")
 
    @test modulus(T) == 7
-
-   println("PASS")
 end
 
-function test_rel_series_unary_ops()
-   print("Generic.RelSeries.unary_ops...")
-
+@testset "Generic.RelSeries.unary_ops..." begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -170,13 +156,9 @@ function test_rel_series_unary_ops()
       @test isequal(-(-f), f)
       @test iszero(f + (-f))
    end
-
-   println("PASS")
 end
 
-function test_rel_series_binary_ops()
-   print("Generic.RelSeries.binary_ops...")
-
+@testset "Generic.RelSeries.binary_ops..." begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -223,13 +205,9 @@ function test_rel_series_binary_ops()
       @test f*(g + h) == f*g + f*h
       @test f*(g - h) == f*g - f*h
    end
-
-   println("PASS")
 end
 
-function test_rel_series_adhoc_binary_ops()
-   print("Generic.RelSeries.adhoc_binary_ops...")
-
+@testset "Generic.RelSeries.adhoc_binary_ops..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -317,13 +295,9 @@ function test_rel_series_adhoc_binary_ops()
       @test isequal(f*d1 - f*d2, f*(d1 - d2))
       @test isequal(f*d1 + f*d2, f*(d1 + d2))
    end
-
-   println("PASS")
 end
 
-function test_rel_series_comparison()
-   print("Generic.RelSeries.comparison...")
-
+@testset "Generic.RelSeries.comparison..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -372,13 +346,9 @@ function test_rel_series_comparison()
       @test (precision(h) > min(precision(f), precision(g)) || f != g + h)
       @test (precision(h) > min(precision(f), precision(g)) || !isequal(f, g + h))
    end
-
-   println("PASS")
 end
 
-function test_rel_series_adhoc_comparison()
-   print("Generic.RelSeries.adhoc_comparison...")
-
+@testset "Generic.RelSeries.adhoc_comparison..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -473,13 +443,9 @@ function test_rel_series_adhoc_comparison()
       @test S(d1) != d1 + f
       @test d1 != S(d1) + f
    end
-
-   println("PASS")
 end
 
-function test_rel_series_powering()
-   print("Generic.RelSeries.powering...")
-
+@testset "Generic.RelSeries.powering..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
 
@@ -530,13 +496,9 @@ function test_rel_series_powering()
          r2 *= f
       end
    end
-
-   println("PASS")
 end
 
-function test_rel_series_shift()
-   print("Generic.RelSeries.shift...")
-
+@testset "Generic.RelSeries.shift..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -579,13 +541,9 @@ function test_rel_series_shift()
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
-
-   println("PASS")
 end
 
-function test_rel_series_truncation()
-   print("Generic.RelSeries.truncation...")
-
+@testset "Generic.RelSeries.truncation..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -619,13 +577,9 @@ function test_rel_series_truncation()
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
-
-   println("PASS")
 end
 
-function test_rel_series_inversion()
-    print("Generic.RelSeries.inversion...")
-
+@testset "Generic.RelSeries.inversion..." begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x")
     for iter = 1:300
@@ -659,13 +613,9 @@ function test_rel_series_inversion()
 
        @test f*inv(f) == 1
     end
+end
 
-    println("PASS")
- end
-
-function test_rel_series_square_root()
-    print("Generic.RelSeries.square_root...")
-
+@testset "Generic.RelSeries.square_root..." begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x")
     for iter = 1:300
@@ -683,13 +633,9 @@ function test_rel_series_square_root()
 
        @test isapprox(sqrt(g)^2, g)
     end
-
-    println("PASS")
 end
 
-function test_rel_series_exact_division()
-   print("Generic.RelSeries.exact_division...")
-
+@testset "Generic.RelSeries.exact_division..." begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -738,13 +684,9 @@ function test_rel_series_exact_division()
 
       @test divexact(f, g)*g == f
    end
-
-   println("PASS")
 end
 
-function test_rel_series_adhoc_exact_division()
-   print("Generic.RelSeries.adhoc_exact_division...")
-
+@testset "Generic.RelSeries.adhoc_exact_division..." begin
    # Exact field
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -781,13 +723,9 @@ function test_rel_series_adhoc_exact_division()
 
       @test isequal(divexact(f*c, c), f)
    end
-
-   println("PASS")
 end
 
-function test_rel_series_special_functions()
-   print("Generic.RelSeries.special_functions...")
-
+@testset "Generic.RelSeries.special_functions..." begin
    # Exact field
    S, x = PowerSeriesRing(QQ, 10, "x")
 
@@ -848,27 +786,4 @@ function test_rel_series_special_functions()
 
       @test isequal(exp(f)*exp(g), exp(f + g))
    end
-
-   println("PASS")
-end
-
-function test_gen_rel_series()
-   test_rel_series_constructors()
-   test_rel_series_rand()
-   test_rel_series_manipulation()
-   test_rel_series_unary_ops()
-   test_rel_series_binary_ops()
-   test_rel_series_adhoc_binary_ops()
-   test_rel_series_comparison()
-   test_rel_series_adhoc_comparison()
-   test_rel_series_powering()
-   test_rel_series_shift()
-   test_rel_series_truncation()
-   test_rel_series_exact_division()
-   test_rel_series_adhoc_exact_division()
-   test_rel_series_inversion()
-   test_rel_series_square_root()
-   test_rel_series_special_functions()
-
-   println("")
 end

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,6 +1,4 @@
-function test_gen_res_constructors()
-   print("Generic.Res.constructors...")
-
+@testset "Generic.Res.constructors..." begin
    B = ZZ
 
    R = Generic.ResidueRing(B, 16453889)
@@ -49,25 +47,17 @@ function test_gen_res_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   println("PASS")
 end
 
-function test_gen_res_rand()
-   print("Generic.Res.rand...")
-
+@testset "Generic.Res.rand..." begin
    R = Generic.ResidueRing(ZZ, 49)
    f = rand(R, 1:9)
    @test f isa Generic.Res
    f = rand(rng, R, 1:9)
    @test f isa Generic.Res
-
-   println("PASS")
 end
 
-function test_gen_res_manipulation()
-   print("Generic.Res.manipulation...")
-
+@testset "Generic.Res.manipulation..." begin
    R = Generic.ResidueRing(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -94,13 +84,9 @@ function test_gen_res_manipulation()
    @test canonical_unit(T(x + 1)) == T(x + 1)
 
    @test deepcopy(h) == h
-
-   println("PASS")
 end
 
-function test_gen_res_unary_ops()
-   print("Generic.Res.unary_ops...")
-
+@testset "Generic.Res.unary_ops..." begin
    R = Generic.ResidueRing(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -109,13 +95,9 @@ function test_gen_res_unary_ops()
    T = ResidueRing(S, x^3 + 3x + 1)
 
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
-
-   println("PASS")
 end
 
-function test_gen_res_binary_ops()
-   print("Generic.Res.binary_ops...")
-
+@testset "Generic.Res.binary_ops..." begin
    R = Generic.ResidueRing(ZZ, 12)
 
    f = R(4)
@@ -139,13 +121,9 @@ function test_gen_res_binary_ops()
    @test n - p == T(5x^2 + 3)
 
    @test n*p == T(3x^2 + 4x + 4)
-
-   println("PASS")
 end
 
-function test_gen_res_gcd()
-   print("Generic.Res.gcd...")
-
+@testset "Generic.Res.gcd..." begin
    R = Generic.ResidueRing(ZZ, 12)
 
    f = R(4)
@@ -161,13 +139,9 @@ function test_gen_res_gcd()
    p = T(x^2 + 2x + 1)
 
    @test gcd(n, p) == 1
-
-   println("PASS")
 end
 
-function test_gen_res_adhoc_binary()
-   print("Generic.Res.adhoc_binary...")
-
+@testset "Generic.Res.adhoc_binary..." begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -188,13 +162,9 @@ function test_gen_res_adhoc_binary()
    @test 4 - f == T(x^2+5*x)
 
    @test f*5 == T(2*x^2+3*x+6)
-
-   println("PASS")
 end
 
-function test_gen_res_comparison()
-   print("Generic.Res.comparison...")
-
+@testset "Generic.Res.comparison..." begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -218,13 +188,9 @@ function test_gen_res_comparison()
    @test h != g
 
    @test isequal(f, g)
-
-   println("PASS")
 end
 
-function test_gen_res_adhoc_comparison()
-   print("Generic.Res.adhoc_comparison...")
-
+@testset "Generic.Res.adhoc_comparison..." begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -238,13 +204,9 @@ function test_gen_res_adhoc_comparison()
    f = T(x^5 + 1)
 
    @test f != 5
-
-   println("PASS")
 end
 
-function test_gen_res_powering()
-   print("Generic.Res.powering...")
-
+@testset "Generic.Res.powering..." begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -257,13 +219,9 @@ function test_gen_res_powering()
    f = T(x^5 + 1)
 
    @test f^100 == T(x^2 + 2x + 1)
-
-   println("PASS")
 end
 
-function test_gen_res_inversion()
-   print("Generic.Res.inversion...")
-
+@testset "Generic.Res.inversion..." begin
    R = Generic.ResidueRing(ZZ, 49)
 
    a = R(5)
@@ -277,13 +235,9 @@ function test_gen_res_inversion()
    f = T(x^5 + 1)
 
    @test inv(f) == T(26*x^2+31*x+10)
-
-   println("PASS")
 end
 
-function test_gen_res_exact_division()
-   print("Generic.Res.exact_division...")
-
+@testset "Generic.Res.exact_division..." begin
    R = Generic.ResidueRing(ZZ, 49)
 
    a = R(5)
@@ -315,23 +269,4 @@ function test_gen_res_exact_division()
          @test q*a2 == p
       end
    end
-
-   println("PASS")
-end
-
-function test_gen_res()
-   test_gen_res_constructors()
-   test_gen_res_rand()
-   test_gen_res_manipulation()
-   test_gen_res_unary_ops()
-   test_gen_res_binary_ops()
-   test_gen_res_gcd()
-   test_gen_res_adhoc_binary()
-   test_gen_res_comparison()
-   test_gen_res_adhoc_comparison()
-   test_gen_res_powering()
-   test_gen_res_inversion()
-   test_gen_res_exact_division()
-
-   println("")
 end

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -1,6 +1,4 @@
-function test_gen_res_field_constructors()
-   print("Generic.ResF.constructors...")
-
+@testset "Generic.ResF.constructors..." begin
    B = ZZ
 
    R = Generic.ResidueField(B, 16453889)
@@ -49,28 +47,17 @@ function test_gen_res_field_constructors()
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-
-   println("PASS")
 end
 
-
-function test_gen_res_field_rand()
-   print("Generic.ResF.rand...")
-
+@testset "Generic.ResF.rand..." begin
    R = Generic.ResidueField(ZZ, 16453889)
    f = rand(R, 1:9)
    @test f isa Generic.ResF
    f = rand(rng, R, 1:9)
    @test f isa Generic.ResF
-
-   println("PASS")
 end
 
-
-function test_gen_res_field_manipulation()
-   print("Generic.ResF.manipulation...")
-
+@testset "Generic.ResF.manipulation..." begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -97,13 +84,9 @@ function test_gen_res_field_manipulation()
    @test canonical_unit(T(x + 1)) == T(x + 1)
 
    @test deepcopy(h) == h
-
-   println("PASS")
 end
 
-function test_gen_res_field_unary_ops()
-   print("Generic.ResF.unary_ops...")
-
+@testset "Generic.ResF.unary_ops..." begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -112,13 +95,9 @@ function test_gen_res_field_unary_ops()
    T = ResidueField(S, x^3 + 3x + 1)
 
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
-
-   println("PASS")
 end
 
-function test_gen_res_field_binary_ops()
-   print("Generic.ResF.binary_ops...")
-
+@testset "Generic.ResF.binary_ops..." begin
    R = Generic.ResidueField(ZZ, 13)
 
    f = R(4)
@@ -142,13 +121,9 @@ function test_gen_res_field_binary_ops()
    @test n - p == T(5x^2 + 3)
 
    @test n*p == T(3x^2 + 4x + 4)
-
-   println("PASS")
 end
 
-function test_gen_res_field_gcd()
-   print("Generic.ResF.gcd...")
-
+@testset "Generic.ResF.gcd..." begin
    R = Generic.ResidueField(ZZ, 13)
 
    f = R(4)
@@ -164,13 +139,9 @@ function test_gen_res_field_gcd()
    p = T(x^2 + 2x + 1)
 
    @test gcd(n, p) == 1
-
-   println("PASS")
 end
 
-function test_gen_res_field_adhoc_binary()
-   print("Generic.ResF.adhoc_binary...")
-
+@testset "Generic.ResF.adhoc_binary..." begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -191,13 +162,9 @@ function test_gen_res_field_adhoc_binary()
    @test 4 - f == T(x^2+5*x)
 
    @test f*5 == T(2*x^2+3*x+6)
-
-   println("PASS")
 end
 
-function test_gen_res_field_comparison()
-   print("Generic.ResF.comparison...")
-
+@testset "Generic.ResF.comparison..." begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -221,13 +188,9 @@ function test_gen_res_field_comparison()
    @test h != g
 
    @test isequal(f, g)
-
-   println("PASS")
 end
 
-function test_gen_res_field_adhoc_comparison()
-   print("Generic.ResF.adhoc_comparison...")
-
+@testset "Generic.ResF.adhoc_comparison..." begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -241,13 +204,9 @@ function test_gen_res_field_adhoc_comparison()
    f = T(x^5 + 1)
 
    @test f != 5
-
-   println("PASS")
 end
 
-function test_gen_res_field_powering()
-   print("Generic.ResF.powering...")
-
+@testset "Generic.ResF.powering..." begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -260,13 +219,9 @@ function test_gen_res_field_powering()
    f = T(x^5 + 1)
 
    @test f^100 == T(x^2 + 2x + 1)
-
-   println("PASS")
 end
 
-function test_gen_res_field_inversion()
-   print("Generic.ResF.inversion...")
-
+@testset "Generic.ResF.inversion..." begin
    R = Generic.ResidueField(ZZ, 47)
 
    a = R(5)
@@ -280,13 +235,9 @@ function test_gen_res_field_inversion()
    f = T(x^5 + 1)
 
    @test inv(f) == T(26*x^2+31*x+10)
-
-   println("PASS")
 end
 
-function test_gen_res_field_exact_division()
-   print("Generic.ResF.exact_division...")
-
+@testset "Generic.ResF.exact_division..." begin
    R = Generic.ResidueField(ZZ, 47)
 
    a = R(5)
@@ -302,23 +253,4 @@ function test_gen_res_field_exact_division()
    g = T(x^4 + x + 2)
 
    @test divexact(f, g) == T(7*x^2+25*x+26)
-
-   println("PASS")
-end
-
-function test_gen_res_field()
-   test_gen_res_field_constructors()
-   test_gen_res_field_rand()
-   test_gen_res_field_manipulation()
-   test_gen_res_field_unary_ops()
-   test_gen_res_field_binary_ops()
-   test_gen_res_field_gcd()
-   test_gen_res_field_adhoc_binary()
-   test_gen_res_field_comparison()
-   test_gen_res_field_adhoc_comparison()
-   test_gen_res_field_powering()
-   test_gen_res_field_inversion()
-   test_gen_res_field_exact_division()
-
-   println("")
 end

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -1,6 +1,4 @@
-function test_submodule_constructors()
-   print("Generic.Submodule.constructors...")
-
+@testset "Generic.Submodule.constructors..." begin
    R = ZZ
    M = FreeModule(R, 2)
    m = M([R(1), R(3)])
@@ -34,7 +32,7 @@ function test_submodule_constructors()
    N, f = sub(M, [m, n])
 
    @test isa(N, Generic.Submodule)
-   
+
    V = gens(N)
    for v in V
       @test parent(f(v)) == M
@@ -53,13 +51,9 @@ function test_submodule_constructors()
 
    @test isa(S, Generic.Submodule)
    @test isa(m, Generic.submodule_elem)
-
-   println("PASS")
 end
 
-function test_submodule_manipulation()
-   print("Generic.Submodule.manipulation...")
-
+@testset "Generic.Submodule.manipulation..." begin
    R = ZZ
    M = FreeModule(R, 2)
    m = M([R(1), R(3)])
@@ -73,13 +67,9 @@ function test_submodule_manipulation()
    end
 
    @test supermodule(N) == M
-
-   println("PASS")
 end
 
-function test_submodule_unary_ops()
-   print("Generic.Submodule.unary_ops...")
-
+@testset "Generic.Submodule.unary_ops..." begin
    for R in [ZZ, QQ]
       for iter = 1:20
          M = rand_module(R, -10:10)
@@ -88,17 +78,13 @@ function test_submodule_unary_ops()
          N, f = sub(M, S)
 
          m = rand(N, -10:10)
-   
+
          @test -(-m) == m
       end
    end
-
-   println("PASS")
 end
 
-function test_submodule_binary_ops()
-   print("Generic.Submodule.binary_ops...")
-
+@testset "Generic.Submodule.binary_ops..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -113,13 +99,9 @@ function test_submodule_binary_ops()
          @test m - n == m + (-n)
       end
    end
-
-   println("PASS")
 end
 
-function test_submodule_adhoc_binary()
-   print("Generic.Submodule.adhoc_binary...")
-
+@testset "Generic.Submodule.adhoc_binary..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -137,13 +119,9 @@ function test_submodule_adhoc_binary()
          @test c*(m - n) == c*m - c*n
       end
    end
-
-   println("PASS")
 end
 
-function test_submodule_canonical_injection()
-   print("Generic.Submodule.canonical_injection...")
-
+@testset "Generic.Submodule.canonical_injection..." begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -163,17 +141,4 @@ function test_submodule_canonical_injection()
          @test pre == m
       end
    end
-
-   println("PASS")
-end
-
-function test_submodule()
-   test_submodule_constructors()
-   test_submodule_manipulation()
-   test_submodule_unary_ops()
-   test_submodule_binary_ops()
-   test_submodule_adhoc_binary()
-   test_submodule_canonical_injection()
-
-   println("")
 end

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -1,6 +1,4 @@
-function test_partition_type()
-   print("youngtabs.partition_type...")
-
+@testset "youngtabs.partition_type..." begin
    @test Partition([4,3,1]) isa Generic.Partition
    @test Partition([4,3,1]) isa AbstractVector{Int}
    @test Partition([3,4,1]) isa Generic.Partition
@@ -31,13 +29,9 @@ function test_partition_type()
 
    @test p == Partition([4,3,2])
    @test p != r
-
-   println("PASS")
 end
 
-function test_partition_iter()
-   print("youngtabs.partition_iter...")
-
+@testset "youngtabs.partition_iter..." begin
    @test [Generic._numpart(i) for i in 0:10] == [1,1,2,3,5,7,11,15,22,30,42]
    @test Generic._numpart(100) == 190_569_292
    @test Generic._numpart(1000) == 24_061_467_864_032_622_473_692_149_727_991
@@ -45,13 +39,9 @@ function test_partition_iter()
    @test collect(AllParts(2)) == [Partition([1,1]), Partition([2])]
    @test collect(AllParts(1)) == [Partition([1])]
    @test collect(AllParts(0)) == [Partition(Int[])]
-
-   println("PASS")
 end
 
-function test_ytabs_type()
-   print("youngtabs.youngtableau_type...")
-
+@testset "youngtabs.youngtableau_type..." begin
    lambda = [4,3,1]
    @test YoungTableau(Partition(lambda)) isa Generic.YoungTableau
    @test YoungTableau(Partition(lambda)) isa AbstractArray{Int, 2}
@@ -86,13 +76,9 @@ function test_ytabs_type()
    for i in 1:sum(Y.part)
      @test Y[something(findfirst(isequal(i), Y), 0)] == i
    end
-
-   println("PASS")
 end
 
-function test_conjugation()
-   print("youngtabs.conjugation...")
-
+@testset "youngtabs.conjugation..." begin
    @test conj(Partition([1,1,1,1])) == Partition([4])
    @test conj(Partition([2,1,1])) == Partition([3,1])
 
@@ -114,14 +100,10 @@ function test_conjugation()
    @test Y[2,2] == conj(Y)[2,2]
 
    @test Y[3,1] == conj(Y)[1,3]
-
-   println("PASS")
 end
 
 
-function test_ytabs_dim()
-   print("youngtabs.dim...")
-
+@testset "youngtabs.dim..." begin
    y = YoungTableau([5,4,3,3,1,1])
    # ┌───┬───┬───┬───┬───┐
    # │ 1 │ 2 │ 3 │ 4 │ 5 │
@@ -186,13 +168,9 @@ function test_ytabs_dim()
    @test dim(YoungTableau([4,3,1,1])) == 216
 
    @test dim(YoungTableau(collect(10:-1:1))) == 44261486084874072183645699204710400
-
-   println("PASS")
 end
 
-function test_skewdiags()
-   print("youngtabs.skewdiags...")
-
+@testset "youngtabs.skewdiags..." begin
    l = Partition([5,3,2,2,2,1,1])
    m = Partition([2,2,1])
    xi = l/m
@@ -244,13 +222,9 @@ function test_skewdiags()
    @test has_bottom_neighbor(xi, 5, 2) == false
    @test has_bottom_neighbor(xi, 6, 1) == true
    @test has_bottom_neighbor(xi, 7, 1) == false
-
-   println("PASS")
 end
 
-function test_rimhooks()
-   print("youngtabs.rimhooks...")
-
+@testset "youngtabs.rimhooks..." begin
    xi = Partition([2,1])/Partition(Int[], false)
    @test isrimhook(xi) == true
 
@@ -297,12 +271,9 @@ function test_rimhooks()
    mu = Partition([2,2,1])
 
    @test isrimhook(lambda/mu) == false # is disconnected
-
-   println("PASS")
 end
 
-function test_partitionseqs()
-   print("youngtabs.partitionseqs...")
+@testset "youngtabs.partitionseqs..." begin
    @test partitionseq(Partition([1])) == BitVector([true, false])
    @test partitionseq([1]) == BitVector([true, false])
    @test partitionseq(Partition([1,1])) == BitVector([true, false, false])
@@ -316,19 +287,4 @@ function test_partitionseqs()
    R[1] = false
    R[end] = true
    @test partitionseq(R) == BitVector([true,false,true,true,false])
-
-   println("PASS")
-end
-
-function test_youngtabs()
-   test_partition_type()
-   test_partition_iter()
-   test_ytabs_type()
-   test_conjugation()
-   test_ytabs_dim()
-   test_skewdiags()
-   test_rimhooks()
-   test_partitionseqs()
-
-   println("")
 end

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -1,6 +1,4 @@
-function test_Floats_constructors()
-   print("Julia.Floats.constructors...")
-
+@testset "Julia.Floats.constructors..." begin
    R = RDF
    S = RealField
 
@@ -32,13 +30,9 @@ function test_Floats_constructors()
 
    @test isa(R(a), Float64)
    @test isa(S(b), BigFloat)
-
-   println("PASS")
 end
 
-function test_Floats_rand()
-   print("Julia.Floats.rand...")
-
+@testset "Julia.Floats.rand..." begin
    R = RealField
    f = rand(R, 1:9)
    @test f isa elem_type(R)
@@ -48,13 +42,9 @@ function test_Floats_rand()
    @test f isa elem_type(R)
    f = rand(rng, R, UnitRange{AbstractFloat}(1.0, 9.0))
    @test f isa elem_type(R)
-
-   println("PASS")
 end
 
-function test_Floats_manipulation()
-   print("Julia.Floats.manipulation...")
-
+@testset "Julia.Floats.manipulation..." begin
    R = RDF
    S = RealField
 
@@ -68,13 +58,9 @@ function test_Floats_manipulation()
    @test !isunit(S())
    @test isunit(R(3))
    @test isunit(S(3))
-
-   println("PASS")
 end
 
-function test_Floats_exact_division()
-   print("Julia.Floats.exact_division...")
-
+@testset "Julia.Floats.exact_division..." begin
    R = RDF
    S = RealField
 
@@ -95,13 +81,9 @@ function test_Floats_exact_division()
       @test c1 == 0 || isapprox(divexact(c1, R(1)*c1), R(1))
       @test c2 == 0 || isapprox(divexact(c2, S(1)*c2), S(1))
    end
-
-   println("PASS")
 end
 
-function test_Floats_divrem()
-   print("Julia.Float.divrem...")
-
+@testset "Julia.Floats.divrem..." begin
    R = RealField
 
    for iter = 1:1000
@@ -113,13 +95,9 @@ function test_Floats_divrem()
 
       @test AbstractAlgebra.divrem(r,s) == (r/s,0)
    end
-
-   println("PASS")
 end
 
-function test_Floats_gcd()
-   print("Julia.Floats.gcd...")
-
+@testset "Julia.Floats.gcd..." begin
    R = RDF
    S = RealField
 
@@ -132,18 +110,4 @@ function test_Floats_gcd()
       @test (r1 == 0 && r2 == 0) || gcd(r1, r2) == 1
       @test (s1 == 0 && s2 == 0) || gcd(s1, s2) == 1
    end
-
-   println("PASS")
-end
-
-
-function test_Floats()
-   test_Floats_constructors()
-   test_Floats_rand()
-   test_Floats_manipulation()
-   test_Floats_exact_division()
-   test_Floats_divrem()
-   test_Floats_gcd()
-
-   println("")
 end

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -1,6 +1,4 @@
-function test_Integers_constructors()
-   print("Julia.Integers.constructors...")
-
+@testset "Julia.Integers.constructors..." begin
    R = zz
    S = ZZ
 
@@ -26,13 +24,9 @@ function test_Integers_constructors()
 
    @test isa(R(a), Int)
    @test isa(S(b), BigInt)
-
-   println("PASS")
 end
 
-function test_Integers_manipulation()
-   print("Julia.Integers.manipulation...")
-
+@testset "Julia.Integers.manipulation..." begin
    R = zz
    S = ZZ
 
@@ -50,25 +44,17 @@ function test_Integers_manipulation()
    @test isunit(S(1))
    @test isunit(R(-1))
    @test isunit(S(-1))
-
-   println("PASS")
 end
 
-function test_Integers_rand()
-   print("Julia.Integers.rand...")
-
+@testset "Julia.Integers.rand..." begin
    R = ZZ
    f = rand(R, 0:22)
    @test f isa elem_type(R)
    f = rand(rng, R, 0:22)
    @test f isa elem_type(R)
-
-   println("PASS")
 end
 
-function test_Integers_modular_arithmetic()
-   print("Julia.Integers.modular_arithmetic...")
-
+@testset "Julia.Integers.modular_arithmetic..." begin
    R = zz
    S = ZZ
 
@@ -89,13 +75,9 @@ function test_Integers_modular_arithmetic()
          b = mod(b*s, modS)
       end
    end
-
-   println("PASS")
 end
 
-function test_Integers_exact_division()
-   print("Julia.Integers.exact_division...")
-
+@testset "Julia.Integers.exact_division..." begin
    R = zz
    S = ZZ
 
@@ -122,13 +104,9 @@ function test_Integers_exact_division()
          @test qS == b2
       end
    end
-
-   println("PASS")
 end
 
-function test_Integers_gcd()
-   print("Julia.Integers.gcd...")
-
+@testset "Julia.Integers.gcd..." begin
    R = zz
    S = ZZ
 
@@ -149,13 +127,9 @@ function test_Integers_gcd()
       @test gS == gcd(s, modS)
       @test gS != 1 || mod(sS*s, modS) == 1
    end
-
-   println("PASS")
 end
 
-function test_Integers_square_root()
-   print("Julia.Integers.square_root...")
-
+@testset "Julia.Integers.square_root..." begin
    R = zz
    S = ZZ
 
@@ -169,18 +143,4 @@ function test_Integers_square_root()
       @test AbstractAlgebra.sqrt(f)^2 == f
       @test AbstractAlgebra.sqrt(g)^2 == g
    end
-
-   println("PASS")
-end
-
-function test_Integers()
-   test_Integers_constructors()
-   test_Integers_rand()
-   test_Integers_manipulation()
-   test_Integers_modular_arithmetic()
-   test_Integers_exact_division()
-   test_Integers_gcd()
-   test_Integers_square_root()
-
-   println("")
 end

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -1,6 +1,4 @@
-function test_Rationals_constructors()
-   print("Julia.Rationals.constructors...")
-
+@testset "Julia.Rationals.constructors..." begin
    R = qq
    S = QQ
 
@@ -35,25 +33,17 @@ function test_Rationals_constructors()
 
    @test isa(R(a), Rational{Int})
    @test isa(S(b), Rational{BigInt})
-
-   println("PASS")
 end
 
-function test_Rationals_rand()
-   print("Julia.Rationals.rand...")
-
+@testset "Julia.Rationals.rand..." begin
    R = QQ
    f = rand(R, 1:9)
    @test f isa elem_type(R)
    f = rand(rng, R, 1:9)
    @test f isa elem_type(R)
-
-   println("PASS")
 end
 
-function test_Rationals_manipulation()
-   print("Julia.Rationals.manipulation...")
-
+@testset "Julia.Rationals.manipulation..." begin
    R = qq
    S = QQ
 
@@ -67,13 +57,9 @@ function test_Rationals_manipulation()
    @test !isunit(S())
    @test isunit(R(3))
    @test isunit(S(3))
-
-   println("PASS")
 end
 
-function test_Rationals_exact_division()
-   print("Julia.Rationals.exact_division...")
-
+@testset "Julia.Rationals.exact_division..." begin
    R = qq
    S = QQ
 
@@ -108,13 +94,9 @@ function test_Rationals_exact_division()
       @test a1 == 0 || divexact(c1, a1)*a1 == c1
       @test b1 == 0 || divexact(c2, b1)*b1 == c2
    end
-
-   println("PASS")
 end
 
-function test_Rationals_gcd()
-   print("Julia.Rationals.gcd...")
-
+@testset "Julia.Rationals.gcd..." begin
    R = qq
    S = QQ
 
@@ -129,13 +111,9 @@ function test_Rationals_gcd()
       @test gcd(r1, gcd(r2, r3)) == gcd(gcd(r1, r2), r3)
       @test gcd(s1, gcd(s2, s3)) == gcd(gcd(s1, s2), s3)
    end
-
-   println("PASS")
 end
 
-function test_Rationals_square_root()
-   print("Julia.Rationals.square_root...")
-
+@testset "Julia.Rationals.square_root..." begin
    R = qq
    S = QQ
 
@@ -149,13 +127,9 @@ function test_Rationals_square_root()
       @test AbstractAlgebra.sqrt(f)^2 == f
       @test AbstractAlgebra.sqrt(g)^2 == g
    end
-
-   println("PASS")
 end
 
-function test_Rationals_divrem()
-   print("Julia.Rationals.divrem...")
-
+@testset "Julia.Rationals.divrem..." begin
    R = qq
    S = QQ
 
@@ -168,18 +142,4 @@ function test_Rationals_divrem()
 
       @test AbstractAlgebra.divrem(r,s) == (r/s,0)
    end
-
-   println("PASS")
-end
-
-function test_Rationals()
-   test_Rationals_constructors()
-   test_Rationals_rand()
-   test_Rationals_manipulation()
-   test_Rationals_exact_division()
-   test_Rationals_gcd()
-   test_Rationals_square_root()
-   test_Rationals_divrem()
-
-   println("")
 end

--- a/test/julia/gfelem-test.jl
+++ b/test/julia/gfelem-test.jl
@@ -1,6 +1,4 @@
-function test_gfelem_constructors()
-   print("Julia.gfelem.constructors...")
-
+@testset "Julia.gfelem.constructors..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -27,13 +25,9 @@ function test_gfelem_constructors()
 
    @test isa(R(a), AbstractAlgebra.gfelem)
    @test isa(S(b), AbstractAlgebra.gfelem)
-
-   println("PASS")
 end
 
-function test_gfelem_printing()
-   print("Julia.gfelem.printing...")
-
+@testset "Julia.gfelem.printing..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -41,13 +35,9 @@ function test_gfelem_printing()
    @test string(R()) == "0"
    @test string(S(3)) == "3"
    @test string(S()) == "0"
-
-   println("PASS")
 end
 
-function test_gfelem_manipulation()
-   print("Julia.gfelem.manipulation...")
-
+@testset "Julia.gfelem.manipulation..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -79,25 +69,17 @@ function test_gfelem_manipulation()
 
    @test R === R1
    @test S === S1
-
-   println("PASS")
 end
 
-function test_gfelem_rand()
-   print("Julia.gfelem.rand...")
-
+@testset "Julia.gfelem.rand..." begin
    R = GF(13)
    f = rand(R)
    @test f isa AbstractAlgebra.gfelem
    f = rand(rng, R)
    @test f isa AbstractAlgebra.gfelem
-
-   println("PASS")
 end
 
-function test_gfelem_unary_ops()
-   print("Julia.gfelem.unary_ops...")
-
+@testset "Julia.gfelem.unary_ops..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -108,13 +90,9 @@ function test_gfelem_unary_ops()
       @test a == -(-a)
       @test b == -(-b)
    end
-
-   println("PASS")
 end
 
-function test_gfelem_binary_ops()
-   print("Julia.gfelem.binary_ops...")
-
+@testset "Julia.gfelem.binary_ops..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -145,13 +123,9 @@ function test_gfelem_binary_ops()
       @test b1*S(1) == b1
       @test S(1)*b1 == b1
    end
-
-   println("PASS")
 end
 
-function test_gfelem_adhoc_binary()
-   print("Julia.gfelem.adhoc_binary...")
-
+@testset "Julia.gfelem.adhoc_binary..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -183,13 +157,9 @@ function test_gfelem_adhoc_binary()
       @test b*c1 + b*c2 == b*(c1 + c2)
       @test b*d1 + b*d2 == b*(d1 + d2)
    end
-
-   println("PASS")
 end
 
-function test_gfelem_powering()
-   print("Julia.gfelem.powering...")
-
+@testset "Julia.gfelem.powering..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -227,13 +197,9 @@ function test_gfelem_powering()
          b *= sinv
       end
    end
-
-   println("PASS")
 end
 
-function test_gfelem_comparison()
-   print("Julia.gfelem.comparison...")
-
+@testset "Julia.gfelem.comparison..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -252,13 +218,9 @@ function test_gfelem_comparison()
       @test R(d) == R(d)
       @test S(d) == S(d)
    end
-
-   println("PASS")
 end
 
-function test_gfelem_adhoc_comparison()
-   print("Julia.gfelem.adhoc_comparison...")
-
+@testset "Julia.gfelem.adhoc_comparison..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -276,13 +238,9 @@ function test_gfelem_adhoc_comparison()
       @test S(d) == d
       @test d == S(d)
    end
-
-   println("PASS")
 end
 
-function test_gfelem_inversion()
-   print("Julia.gfelem.inversion...")
-
+@testset "Julia.gfelem.inversion..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -296,13 +254,9 @@ function test_gfelem_inversion()
       @test a == 0 || a*inv(a) == one(R)
       @test b == 0 || b*inv(b) == one(S)
    end
-
-   println("PASS")
 end
 
-function test_gfelem_exact_division()
-   print("Julia.gfelem.exact_division...")
-
+@testset "Julia.gfelem.exact_division..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -315,23 +269,4 @@ function test_gfelem_exact_division()
       @test a2 == 0 || divexact(a1, a2)*a2 == a1
       @test b2 == 0 || divexact(b1, b2)*b2 == b1
    end
-
-   println("PASS")
-end
-
-function test_gfelem()
-   test_gfelem_constructors()
-   test_gfelem_rand()
-   test_gfelem_printing()
-   test_gfelem_manipulation()
-   test_gfelem_unary_ops()
-   test_gfelem_binary_ops()
-   test_gfelem_adhoc_binary()
-   test_gfelem_powering()
-   test_gfelem_comparison()
-   test_gfelem_adhoc_comparison()
-   test_gfelem_inversion()
-   test_gfelem_exact_division()
-
-   println("")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,4 @@ else
    using Test
 end
 
-include("../test/AbstractAlgebra-test.jl")
-
-test_all()
+include("AbstractAlgebra-test.jl")


### PR DESCRIPTION
My PRs yesterday on fixing test titles prompted me to finish the switch to using `@testest` that I started in June, after @wbhart agreed on principle (he told me the current format may predate the existence of `@testset`).

The advantages are:
1. it's the standard Julia way to implement grouped tests
2. it's less error prone; currently, we had to write a function name and a matching test title (the printed string), and include the call of this test in a "parent" function for the file (e.g. `test_modules()`)
3. it's faster; on my machine it's about 40% faster (from 6m15s down to 4m20s) to test AA; I guess it comes from not having to compile all the functions (so the result of the first tests are printed without delay after launching `test AbstractAlgebra`)

I used regular expressions, but I'm no expert in that and I had to do maybe 5% or 10% of this PR by hand, but I'm confident it's mostly error-free.