### PR TITLE
Fix incorrect reduction in powmod when exponent is 1.

### DIFF
--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -112,7 +112,7 @@ function powmod(a::T, b::Int, c::T) where T <: Integer
       while (UInt(bit) & b) == 0
          bit >>= 1
       end
-      z = a
+      z = mod(a, c)
       bit >>= 1
       while bit != 0
          z = mod(z*z, c)

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -75,6 +75,8 @@ end
          b = mod(b*s, modS)
       end
    end
+
+   @test powmod(123, 1, 5) == 3
 end
 
 @testset "Julia.Integers.exact_division..." begin


### PR DESCRIPTION
Fixes bug 10 reported on my repo (only just noticed this now).