### PR TITLE
Make func/ring first argument in change_base_ring

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -225,7 +225,7 @@ isempty(::MatElem)
 ```
 
 ```@docs
-change_base_ring(::AbstractAlgebra.MatElem, ::AbstractAlgebra.Ring)
+change_base_ring(::AbstractAlgebra.Ring, ::AbstractAlgebra.MatElem)
 ```
 
 ```@docs

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -221,7 +221,10 @@ x^2*y^2+x+1//1
 Incase a specific parent ring is constructed, it can also be passed to the function.
 
 ```@docs
-change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+change_base_ring(R::Ring, p::AbstractAlgebra.MPolyElem{T}, Rx::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+change_base_ring(R::Ring, p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
+map(g, p::AbstractAlgebra.MPolyElem{T}, Rx::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+map(g, p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
 ```
 
 **Examples**
@@ -236,7 +239,7 @@ julia> S,  = PolynomialRing(QQ, ["x", "y"])
 julia> fz = x^5 + y^3
 x^5+y^3+1
 
-julia> fq = change_base_ring(fz, QQ, S)
+julia> fq = change_base_ring(QQ, fz, S)
 x^5+y^3+1//1
 
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -177,7 +177,7 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row, add_ro
                  to_univariate, trail, truncate, typed_hcat, typed_hvcat,
                  upscale, valuation, var, var_index, vars, weak_popov,
                  weak_popov_with_transform, zero, zero!, zero_matrix,
-                 @PolynomialRing
+                 @PolynomialRing, MatrixElem
 
 # Do not export divrem, exp, sqrt, numerator and denominator as we define our own
 export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, add_column!, add_row, add_row!, base_ring, cached,
@@ -256,7 +256,7 @@ export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, ad
                  total_degree, tr, trail, truncate, typed_hcat, typed_hvcat,
                  upscale, valuation, var, var_index, vars, weak_popov,
                  weak_popov_with_transform, zero, zero!, zero_matrix,
-                 @PolynomialRing
+                 @PolynomialRing, MatrixElem
 
 function exp(a::T) where T
    return Base.exp(a)

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -90,59 +90,6 @@ function gen(a::MPolyRing{T}, i::Int) where {T <: RingElement}
 end
 
 @doc Markdown.doc"""
-    change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::MPolyRing)
-       where T <: RingElement
-> Return the polynomial in R obtained by applying g to the coefficients of p.
-"""
-function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g, R::AbstractAlgebra.MPolyRing) where {T <: RingElement}
-
-   z = g(zero(base_ring(p.parent)))
-   base_ring(R) != parent(z) && error("Base rings do not match.")
-
-   cvzip = zip(coeffs(p), exponent_vectors(p))
-   M = MPolyBuildCtx(R)
-   for (c, v) in cvzip
-      push_term!(M, g(c), v)
-   end
-
-   return finish(M)
-end
-
-@doc Markdown.doc"""
-    change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where {T <: RingElement}
-> Return the polynomial obtained by applying g to the coefficients of p.
-"""
-function change_base_ring(p::AbstractAlgebra.MPolyElem{T}, g) where T <: RingElement
-   new_base_ring = parent(g(zero(base_ring(p.parent))))
-   new_polynomial_ring, gens_new_polynomial_ring = AbstractAlgebra.PolynomialRing(new_base_ring, [string(v) for v in symbols(p.parent)], ordering = ordering(p.parent))
-
-   return change_base_ring(p, g, new_polynomial_ring)
-end
-
-function change_base_ring(p::MPoly{T}, g) where {T <: RingElement}
-   new_base_ring = parent(g(zero(base_ring(p.parent))))
-   new_polynomial_ring, gens_new_polynomial_ring = PolynomialRing(new_base_ring, [string(
-v) for v in symbols(p.parent)], ordering = ordering(p.parent))
-
-   if typeof(gens_new_polynomial_ring[1]) <: MPoly
-      exps = deepcopy(p.exps)
-      coeffs = Array{elem_type(new_base_ring),1}(undef, length(p))
-      for i in 1:length(p)
-         coeffs[i] = g(p.coeffs[i])
-      end
-      return new_polynomial_ring(coeffs, exps)
-   else
-      new_p = zero(new_polynomial_ring)
-      for i = 1:length(p)
-         e = exponent_vector(p, i)
-         set_exponent_vector!(new_p, i, e)
-         setcoeff!(new_p, e, g(coeff(p, i)))
-      end
-      return(new_p)
-   end
-end
-
-@doc Markdown.doc"""
     vars(p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
 > Return the variables actually occuring in $p$.
 """
@@ -3558,7 +3505,7 @@ end
 > given by $g$ to the coefficients of the polynomial.
 """
 function evaluate(a::AbstractAlgebra.MPolyElem{T}, A::Vector{U}, g) where {T <: RingElement, U <: RingElement}
-   anew = change_base_ring(a, g)
+   anew = change_base_ring(g, a)
    return evaluate(anew, A)
 end
 
@@ -3569,7 +3516,7 @@ end
 > polynomial.
 """
 function evaluate(a::AbstractAlgebra.MPolyElem{T}, vars::Vector{Int}, vals::Vector{U}, g) where {T <: RingElement, U <: RingElement}
-   anew = change_base_ring(a, g)
+   anew = change_base_ring(g, a)
    return evaluate(anew, vars, vals)
 end
 
@@ -3579,7 +3526,7 @@ end
 > applying the `Map` or `Function` given by $g$ to the coefficients of the polynomial.
 """
 function evaluate(a::S, vars::Vector{S}, vals::Vector{U}, g) where {S <: AbstractAlgebra.MPolyElem{T}, U <: RingElement} where T <: RingElement
-   anew = change_base_ring(a, g)
+   anew = change_base_ring(g, a)
    varidx = [var_index(x) for x in vars]
    return evaluate(anew, varidx, vals)
 end
@@ -4687,6 +4634,69 @@ function finish(M::MPolyBuildCtx{T}) where T <: AbstractAlgebra.MPolyElem
   M.poly = sort_terms!(M.poly)
   M.poly = combine_like_terms!(M.poly)
   return M.poly
+end
+
+################################################################################
+#
+#  Change base ring and map
+#
+################################################################################
+
+@doc Markdown.doc"""
+    change_base_ring(R::Ring, p::MPolyElem{<: RingElement}, Rx::MPolyRing)
+
+> Return the polynomial of `Rx` obtained by coercing the coefficients of `p`
+> into `R`.
+"""
+function change_base_ring(R::Ring, p::AbstractAlgebra.MPolyElem{T}, Rx::AbstractAlgebra.MPolyRing) where {T <: RingElement}
+   base_ring(Rx) != R && error("Base rings do not match.")
+
+   return _map(R, p, Rx)
+end
+
+@doc Markdown.doc"""
+    change_base_ring(R::Ring, p::MPolyElem{<: RingElement})
+
+> Return the polynomial obtained by coercing the coefficients of `p` into `R`.
+"""
+function change_base_ring(R::Ring, p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+   new_polynomial_ring, gens_new_polynomial_ring = AbstractAlgebra.PolynomialRing(R, map(string, symbols(parent(p))), ordering = ordering(parent(p)))
+
+   return _map(R, p, new_polynomial_ring)
+end
+
+@doc Markdown.doc"""
+    map(f, p::MPolyElem{<: RingElement})
+
+> Transform the polynomial `p` by applying `f` on each coefficient.
+"""
+function Base.map(f, p::MPolyElem)
+   R = parent(f(zero(base_ring(p))))
+   new_poly_ring, gens_new_poly_ring = AbstractAlgebra.PolynomialRing(R, map(string, symbols(parent(p))), ordering = ordering(parent(p)))
+   return _map(f, p, new_poly_ring)
+end
+
+@doc Markdown.doc"""
+    map(f, p::MPolyElem{<: RingElement}, Rx::MPolyRing)
+
+> Transform the polynomial `p` into a polynomial of `Rx` by applying `f` on
+> each coefficient.
+"""
+function Base.map(f, p::MPolyElem, Rx::MPolyRing)
+   z = f(zero(base_ring(parent(p))))
+   base_ring(Rx) != parent(z) && error("Base rings do not match.")
+
+   return _map(f, p, Rx)
+end
+
+function _map(g, p, Rx)
+   cvzip = zip(coeffs(p), exponent_vectors(p))
+   M = MPolyBuildCtx(Rx)
+   for (c, v) in cvzip
+      push_term!(M, g(c), v)
+   end
+
+   return finish(M)
 end
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5161,10 +5161,10 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    change_base_ring(M::Generic.MatrixElem, R::AbstractAlgebra.Ring)
+    change_base_ring(R::Ring, M::Generic.MatrixElem)
 > Return the matrix obtained by coercing each entry into `R`.
 """
-function change_base_ring(M::MatrixElem, R::AbstractAlgebra.Ring)
+function change_base_ring(R::Ring, M::MatrixElem)
    N = similar(M, R)
    for i=1:nrows(M), j=1:ncols(M)
       N[i,j] = R(M[i,j])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1911,13 +1911,13 @@ end
       M = rand(P, -10:10)
       N = rand(Q, -10:10)
       for R in [QQ, ZZ, GF(2), GF(5)]
-         MQ = change_base_ring(M, R)
+         MQ = change_base_ring(R, M)
          @test MQ isa T
          @test base_ring(MQ) == R
-         NQ = change_base_ring(N, R)
+         NQ = change_base_ring(R, N)
          @test NQ isa T
          @test base_ring(NQ) == R
-         MNQ = change_base_ring(M * N, R)
+         MNQ = change_base_ring(R, M * N)
          @test MNQ isa T
          @test base_ring(MNQ) == R
          @test MQ * NQ == MNQ


### PR DESCRIPTION
I did not touch `map_from_func` etc. I am not sure the convention applies since it is a constructor. There is no object on which the function is applied. Also
`map_from_func(x -> x^2, ZZ, ZZ)` does not look as nice as `map_from_func(ZZ, ZZ, x -> x^2)`.

I don't have strong feelings about it. If someone says we want it, then I will add it here.