### PR TITLE
rename perm -> Perm

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -463,7 +463,7 @@ julia> b = content(A)
 ### Permutation
 
 ```@docs
-*(::perm, ::MatElem)
+*(::Perm, ::MatElem)
 ```
 
 **Examples**

--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -9,7 +9,7 @@ end
 
 AbstractAlgebra.jl provides rudimentary native support for permutation groups (implemented in `src/generic/PermGroups.jl`). All functionality of permutations is accesible in the `Generic` submodule.
 
-Permutations are represented internally via vector of integers, wrapped in type `perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Permutation groups are singleton parent objects of type `PermGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
+Permutations are represented internally via vector of integers, wrapped in type `Perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Permutation groups are singleton parent objects of type `PermGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
 
 Permutation groups are created using the `PermGroup` (inner) constructor.
 However, for convenience we define
@@ -18,7 +18,7 @@ PermutationGroup = PermGroup
 ```
 so that permutation groups can be created using `PermutationGroup` instead of `PermGroup`.
 
-Both `PermGroup` and `perm` and can be parametrized by any type `T<:Integer` .
+Both `PermGroup` and `Perm` and can be parametrized by any type `T<:Integer` .
 By default the parameter is the `Int`-type native to the systems architecture.
 However, if you are sure that your permutations are small enough to fit into smaller integer type (such as `Int32`, `Uint16`, or even `Int8`), you may choose to change the parametrizing type accordingly.
 In practice this may result in decreased memory footprint (when storing multiple permutations) and noticable faster performance, if your workload is heavy in operations on permutations, which e.g. does not fit into cache of your cpu.
@@ -33,10 +33,10 @@ Generic.setpermstyle
 
 There are several methods to to construct permutations in AbstractAlgebra.jl.
 
-* The easiest way is to directly call to the `perm` (inner) constructor:
+* The easiest way is to directly call to the `Perm` (inner) constructor:
 
 ```@docs
-Generic.perm
+Generic.Perm
 ```
 
   Since the parent object can be reconstructed from the permutation itself, you can work with permutations without explicitly constructing the parent object.
@@ -59,13 +59,13 @@ julia> G = PermutationGroup(BigInt(5)); p = G([2,3,1,5,4])
 (1,2,3)(4,5)
 
 julia> typeof(p)
-perm{BigInt}
+Perm{BigInt}
 
 julia> H = PermutationGroup(UInt16(5)); r = H([2,3,1,5,4])
 (1,2,3)(4,5)
 
 julia> typeof(r)
-perm{UInt16}
+Perm{UInt16}
 
 julia> H()
 ()
@@ -87,26 +87,26 @@ constructions over permutation groups.
 Any custom permutation group implementation in AbstractAlgebra.jl should provide these functions along with the usual group element arithmetic and comparison.
 
 ```@docs
-parent(::perm)
+parent(::Perm)
 elem_type(::PermGroup)
-parent_type(::perm)
+parent_type(::Perm)
 ```
 
-A custom implementation also needs to implement `hash(::perm, ::UInt)` and (possibly) `deepcopy_internal(::perm, ::ObjectIdDict)`.
+A custom implementation also needs to implement `hash(::Perm, ::UInt)` and (possibly) `deepcopy_internal(::Perm, ::ObjectIdDict)`.
 
 !!! note
 
     Permutation group elements are mutable and so returning shallow copies is not sufficient.
 
 ```julia
-getindex(a::perm, n::Int)
+getindex(a::Perm, n::Int)
 ```
 
 Allows access to entry $n$ of the given permutation via the syntax `a[n]`.
 Note that entries are $1$-indexed.
 
 ```julia
-setindex!(a::perm, d::Int, n::Int)
+setindex!(a::Perm, d::Int, n::Int)
 ```
 
 Set the $n$-th entry of the given permutation to $d$.
@@ -132,7 +132,7 @@ Return the permutation whose entries are given by the elements of the supplied
 vector.
 
 ```julia
-G(p::perm)
+G(p::Perm)
 ```
 
 Take a permutation that is already in the permutation group and simply return
@@ -143,16 +143,16 @@ it. A copy of the original is not made if not necessary.
 Numerous functions are provided to manipulate permutation group elements.
 
 ```@docs
-cycles(::perm)
+cycles(::Perm)
 ```
 
 Cycle structure is cached in a permutation, since once available, it provides a convenient shortcut in many other algorithms.
 
 ```@docs
-parity(::perm)
-sign(::perm)
-permtype(::perm)
-order(::perm)
+parity(::Perm)
+sign(::Perm)
+permtype(::Perm)
+order(::Perm)
 order(::Generic.PermGroup)
 ```
 
@@ -184,9 +184,9 @@ However, since all permutations yielded by `elements!` are aliased (modified "in
 ## Arithmetic operators
 
 ```@docs
-*(::perm{T}, ::perm{T}) where T
-^(::perm, n::Integer)
-inv(::perm)
+*(::Perm{T}, ::Perm{T}) where T
+^(::Perm, n::Integer)
+inv(::Perm)
 ```
 
 Permutations parametrized by different types can be multiplied, and follow the standard julia integer promotion rules:
@@ -197,7 +197,7 @@ h = rand(PermGroup(UInt32(5)));
 typeof(g*h)
 
 # output
-perm{UInt32}
+Perm{UInt32}
 ```
 
 ## Coercion
@@ -221,7 +221,7 @@ julia> PermutationGroup(4)()
 
 
 ```julia
-(G::PermGroup)(::perm{<:Integer}[, check=true])
+(G::PermGroup)(::Perm{<:Integer}[, check=true])
 ```
 > Coerce a permutation `p` into group $G$ (performing the conversion, if necessary).
 > If `p` is already an element of `G` no copy is performed.
@@ -232,7 +232,7 @@ julia> PermutationGroup(4)()
 > Parse the string input e.g. copied from the output of GAP.
 > The method uses the same logic as `perm"..."` macro.
 > The string is sanitized and checked for disjoint cycles.
-> Both `string(p::perm)` (if `setpermstyle(:cycles)`) and `string(cycles(p::perm))` are valid input for this method.
+> Both `string(p::Perm)` (if `setpermstyle(:cycles)`) and `string(cycles(p::Perm))` are valid input for this method.
 
 ```julia
 (G::PermGroup{T})(::CycleDec{T}[, check=true]) where T
@@ -242,14 +242,14 @@ julia> PermutationGroup(4)()
 ## Comparison
 
 ```@docs
-==(::perm, ::perm)
+==(::Perm, ::Perm)
 ==(::Generic.PermGroup, ::Generic.PermGroup)
 ```
 
 ## Misc
 ```@docs
 rand(::Generic.PermGroup)
-Generic.matrix_repr(::perm)
+Generic.matrix_repr(::Perm)
 Generic.emb(::Generic.PermGroup, ::Vector{Int}, ::Bool)
-Generic.emb!(::perm, ::perm, V)
+Generic.emb!(::Perm, ::Perm, V)
 ```

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -4,9 +4,9 @@ On this page we discuss the abstract type hierarchy in AbstractAlgebra.jl and ob
 known as parents which contain additional information about groups, rings, fields and
 modules, etc., that can't be stored in types alone.
 
-These details are technical and can be skipped or skimmed by new users of 
-Julia/AbstractAlgebra.jl. Types are almost never dealt with directly when scripting 
-AbstractAlgebra.jl to do mathematical computations. 
+These details are technical and can be skipped or skimmed by new users of
+Julia/AbstractAlgebra.jl. Types are almost never dealt with directly when scripting
+AbstractAlgebra.jl to do mathematical computations.
 
 In contrast, AbstractAlgebra.jl developers will want to know how we model mathematical
 objects and their rings, fields, groups, etc.
@@ -16,8 +16,8 @@ objects and their rings, fields, groups, etc.
 Abstract types in Julia can also belong to one another in a hierarchy. We make use of
 such a hierarchy to organise the kinds of mathematical objects in AbstractAlgebra.jl.
 
-For example, the `AbstractAlgebra.Field` abstract type belongs to the 
-`AbstractAlgebra.Ring` abstract type. 
+For example, the `AbstractAlgebra.Field` abstract type belongs to the
+`AbstractAlgebra.Ring` abstract type.
 
 In practice, this means that any generic function in AbstractAlgebra.jl which is
 designed to work with ring objects will also work with field objects.
@@ -27,7 +27,7 @@ the field itself.
 
 For example, we have an object of type `Generic.PolyRing` to model a generic
 polynomial ring, and elements of that polynomial ring would have
-type `Generic.Poly`. 
+type `Generic.Poly`.
 
 For this purpose, we also have a hierarchy of abstract types, such as `FieldElem`, that
 the types of element objects can belong to.
@@ -54,7 +54,7 @@ their type, since the type no longer contains the modulus $n$.
 
 Instead, the way we get around this in AbstractAlgebra.jl is to have special (singleton)
 objects that act like types, but are really just ordinary Julia objects. These objects,
-called *parent* objects can contain extra information, such as the modulus $n$. 
+called *parent* objects can contain extra information, such as the modulus $n$.
 
 In order to create new elements of $\mathbb{Z}/n\mathbb{Z}$ as above, we overload the
 `call` operator for the parent object.
@@ -68,7 +68,7 @@ R = ResidueRing(ZZ, 7)
 a = R(3)
 ```
 
-Here, `R` is the parent object, containing the modulus $7$. So this example creates 
+Here, `R` is the parent object, containing the modulus $7$. So this example creates
 the element $a = 3 \pmod{7}$.
 
 ## More complex example of parent objects
@@ -97,7 +97,7 @@ Here we give a list of the concrete types in AbstractAlgebra.jl.
 
 In parentheses we put the types of the corresponding parent objects.
 
-  - `perm{<:Integer}` (`PermGroup{<:Integer}`)
+  - `Perm{<:Integer}` (`PermGroup{<:Integer}`)
   - `gfelem{<:Integer}` (`GFField{<:Integer}`)
 
 We also think of various Julia types as though they were AbstractAlgebra.jl types:
@@ -107,7 +107,7 @@ We also think of various Julia types as though they were AbstractAlgebra.jl type
 
 Then there are various types for generic constructions over a base ring. They are all
 parameterised by a type `T` which is the type of the *elements* of the base ring they
-are defined over. 
+are defined over.
 
   - `Generic.Poly{T}` (`Generic.PolyRing{T}`)
   - `Generic.MPoly{T}` (`Generic.MPolyRing{T}`)
@@ -118,4 +118,3 @@ are defined over.
   - `Generic.Res{T}` (`Generic.ResRing{T}`)
   - `Generic.Frac{T}` (`Generic.FracField{T}`)
   - `Generic.Mat{T}` (`Generic.MatSpace{T}`)
-

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -152,14 +152,14 @@ Irreducible characters (at least over field of characteristic $0$) of the full g
 
 ```@docs
 character(::Generic.Partition)
-character(lambda::Generic.Partition, p::Generic.perm)
+character(lambda::Generic.Partition, p::Generic.Perm)
 character(lambda::Generic.Partition, mu::Generic.Partition)
 ```
 The values computed by characters are cached in an internal dictionary `Dict{Tuple{BitVector,Vector{Int}}, BigInt}`.
 Note that all of the above functions return `BigInts`.
 If you are sure that the computations do not overflow, variants of the last two functions using `Int` are available:
 ```
-character(::Type{Int}, lambda::Partition, p::perm[, check::Bool=true])
+character(::Type{Int}, lambda::Partition, p::Perm[, check::Bool=true])
 character(::Type{Int}, lambda::Partition, mu::Partition[, check::Bool=true])
 ```
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -157,7 +157,7 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row, add_ro
                  mullow, mulmod, multiply_column, multiply_column!,
                  multiply_row, multiply_row!, needs_parentheses,
                  newton_to_monomial!, ngens, normalise, nrows, nvars, O, one,
-                 order, ordering, parent_type, parity, partitionseq, perm,
+                 order, ordering, parent_type, parity, partitionseq, Perm,
                  permtype, @perm_str, polcoeff, pol_length, powmod,
                  pow_multinomial, popov, popov_with_transform, powers,
                  precision, preimage, preimage_map, primpart, pseudodivrem,
@@ -236,7 +236,7 @@ export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, ad
                  multiply_column, multiply_column!, multiply_row,
                  multiply_row!, needs_parentheses, newton_to_monomial!, ngens,
                  normalise, nrows, nvars, O, one, order, ordering, parent_type,
-                 parity, partitionseq, perm, permtype, @perm_str, polcoeff,
+                 parity, partitionseq, Perm, permtype, @perm_str, polcoeff,
                  pol_length, powmod, pow_multinomial, popov,
                  popov_with_transform, powers, ppio, precision, preimage,
                  preimage_map, primpart, pseudo_inv, pseudodivrem, pseudorem,
@@ -290,12 +290,12 @@ function AllPerms(n::T) where T
   Generic.AllPerms(n)
 end
 
-function perm(n::T) where T
-  Generic.perm(n)
+function Perm(n::T) where T
+  Generic.Perm(n)
 end
 
-function perm(a::AbstractVector{T}, check::Bool=true) where T
-  Generic.perm(a, check)
+function Perm(a::AbstractVector{T}, check::Bool=true) where T
+  Generic.Perm(a, check)
 end
 
 function Partition(part::AbstractVector{T}, check::Bool=true) where T
@@ -556,7 +556,7 @@ end
 
 export PowerSeriesRing, PolynomialRing, SparsePolynomialRing, MatrixSpace,
        MatrixAlgebra, FractionField, ResidueRing, Partition, PermGroup,
-       YoungTableau, AllParts, SkewDiagram, AllPerms, perm, LaurentSeriesRing,
+       YoungTableau, AllParts, SkewDiagram, AllPerms, Perm, LaurentSeriesRing,
        LaurentSeriesField, ResidueField, NumberField, PuiseuxSeriesRing,
        PuiseuxSeriesField, FreeModule, VectorSpace, ModuleHomomorphism, sub,
        quo, DirectSum, ModuleIsomorphism, free_module, vector_space,

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -25,7 +25,7 @@ end
 
 ###############################################################################
 #
-#   PermGroup / perm
+#   PermGroup / Perm
 #
 ###############################################################################
 
@@ -40,13 +40,13 @@ julia> G = PermGroup(5)
 Permutation group over 5 elements
 
 julia> elem_type(G)
-perm{Int64}
+Perm{Int64}
 
 julia> H = PermGroup(UInt16(5))
 Permutation group over 5 elements
 
 julia> elem_type(H)
-perm{UInt16}
+Perm{UInt16}
 ```
 """
 struct PermGroup{T<:Integer} <: AbstractAlgebra.Group
@@ -54,7 +54,7 @@ struct PermGroup{T<:Integer} <: AbstractAlgebra.Group
 end
 
 @doc Markdown.doc"""
-    perm{T<:Integer}
+    Perm{T<:Integer}
 > The type of permutations.
 > Fieldnames:
 > * `d::Vector{T}` - vector representing the permutation
@@ -66,35 +66,35 @@ end
 > The cycle decomposition (`p.cycles`) is computed on demand and should never be
 > accessed directly. Use [`cycles(p)`](@ref) instead.
 >
-> There are two inner constructors of `perm`:
+> There are two inner constructors of `Perm`:
 >
-> * `perm(n::T)` constructs the trivial `perm{T}`-permutation of length $n$.
-> * `perm(v::Vector{T<:Integer}[,check=true])` constructs a permutation
-> represented by `v`. By default `perm` constructor checks if the vector
-> constitutes a valid permutation. To skip the check call `perm(v, false)`.
+> * `Perm(n::T)` constructs the trivial `Perm{T}`-permutation of length $n$.
+> * `Perm(v::Vector{T<:Integer}[,check=true])` constructs a permutation
+> represented by `v`. By default `Perm` constructor checks if the vector
+> constitutes a valid permutation. To skip the check call `Perm(v, false)`.
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> perm([1,2,3])
+julia> Perm([1,2,3])
 ()
 
-julia> g = perm(Int32[2,3,1])
+julia> g = Perm(Int32[2,3,1])
 (1,2,3)
 
 julia> typeof(g)
-perm{Int32}
+Perm{Int32}
 ```
 """
-mutable struct perm{T<:Integer} <: AbstractAlgebra.GroupElem
+mutable struct Perm{T<:Integer} <: AbstractAlgebra.GroupElem
    d::Array{T, 1}
    modified::Bool
    cycles::CycleDec{T}
 
-   function perm(n::T) where T<:Integer
+   function Perm(n::T) where T<:Integer
       return new{T}(collect(T, 1:n), false)
    end
 
-   function perm(v::AbstractVector{T}, check::Bool=true) where T<:Integer
+   function Perm(v::AbstractVector{T}, check::Bool=true) where T<:Integer
       if check
          Set(v) != Set(1:length(v)) && error("Unable to coerce to permutation:
          non-unique elements in array")
@@ -111,10 +111,10 @@ end
 struct AllPerms{T<:Integer}
    all::Int
    c::Vector{Int}
-   elts::perm{T}
+   elts::Perm{T}
 
    function AllPerms(n::T) where T
-      new{T}(Int(factorial(n)), ones(Int, n), perm(collect(T, 1:n), false))
+      new{T}(Int(factorial(n)), ones(Int, n), Perm(collect(T, 1:n), false))
    end
 end
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1028,7 +1028,7 @@ end
     *(P::Generic.perm, x::Generic.MatrixElem)
 > Apply the pemutation $P$ to the rows of the matrix $x$ and return the result.
 """
-function *(P::Generic.perm, x::MatrixElem)
+function *(P::Generic.Perm, x::MatrixElem)
    z = similar(x)
    m = nrows(x)
    n = ncols(x)
@@ -1046,7 +1046,7 @@ end
 #
 ###############################################################################
 
-function lu!(P::Generic.perm, A::MatrixElem{T}) where {T <: FieldElement}
+function lu!(P::Generic.Perm, A::MatrixElem{T}) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    rank = 0
@@ -1133,7 +1133,7 @@ function lu(A::MatrixElem{T}, P = PermGroup(nrows(A))) where {T <: FieldElement}
    return rank, p, L, U
 end
 
-function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: RingElement}
+function fflu!(P::Generic.Perm, A::MatrixElem{T}) where {T <: RingElement}
    if !isdomain_type(T)
       error("Not implemented")
    end
@@ -1191,7 +1191,7 @@ function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: RingElement}
    return rank, d2
 end
 
-function fflu!(P::Generic.perm, A::MatrixElem{T}) where {T <: Union{FieldElement, ResElem}}
+function fflu!(P::Generic.Perm, A::MatrixElem{T}) where {T <: Union{FieldElement, ResElem}}
    m = nrows(A)
    n = ncols(A)
    rank = 0
@@ -1840,7 +1840,7 @@ function solve_fflu(A::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
    return solve_fflu_precomp(p, FFLU, b), d
 end
 
-function solve_fflu_precomp(p::Generic.perm, FFLU::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
+function solve_fflu_precomp(p::Generic.Perm, FFLU::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
    x = p * b
    n = nrows(x)
    m = ncols(x)
@@ -1901,7 +1901,7 @@ function solve_lu(A::MatElem{T}, b::MatElem{T}) where {T <: FieldElement}
    return solve_lu_precomp(p, LU, b)
 end
 
-function solve_lu_precomp(p::Generic.perm, LU::MatElem{T}, b::MatrixElem{T}) where {T <: FieldElement}
+function solve_lu_precomp(p::Generic.Perm, LU::MatElem{T}, b::MatrixElem{T}) where {T <: FieldElement}
    x = p * b
    n = nrows(x)
    m = ncols(x)

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -5,30 +5,30 @@
 ###############################################################################
 
 @doc Markdown.doc"""
-    parent_type(::Type{perm{T}}) where T = PermGroup{T}
+    parent_type(::Type{Perm{T}}) where T = PermGroup{T}
 > Return the type of the parent of a permutation.
 """
-parent_type(::Type{perm{T}}) where T = PermGroup{T}
+parent_type(::Type{Perm{T}}) where T = PermGroup{T}
 
 @doc Markdown.doc"""
-    elem_type(::Type{PermGroup{T}}) where T = perm{T}
+    elem_type(::Type{PermGroup{T}}) where T = Perm{T}
 > Return the type of elements of a permutation group.
 """
-elem_type(::Type{PermGroup{T}}) where T = perm{T}
+elem_type(::Type{PermGroup{T}}) where T = Perm{T}
 
 @doc Markdown.doc"""
-    parent(g::perm{T}) where T = PermGroup
+    parent(g::Perm{T}) where T = PermGroup
 > Return the parent of the permutation `g`.
 
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> G = PermutationGroup(5); g = perm([3,4,5,2,1])
+julia> G = PermutationGroup(5); g = Perm([3,4,5,2,1])
 (1,3,5)(2,4)
 
 julia> parent(g) == G
 true
 ```
 """
-parent(g::perm{T}) where T = PermGroup(T(length(g.d)))
+parent(g::Perm{T}) where T = PermGroup(T(length(g.d)))
 
 ###############################################################################
 #
@@ -36,28 +36,28 @@ parent(g::perm{T}) where T = PermGroup(T(length(g.d)))
 #
 ###############################################################################
 
-# hash(perm) = 0x0d9939c64ab650ca
-Base.hash(g::perm, h::UInt) = xor(hash(g.d, h), 0x0d9939c64ab650ca)
+# hash(Perm) = 0x0d9939c64ab650ca
+Base.hash(g::Perm, h::UInt) = xor(hash(g.d, h), 0x0d9939c64ab650ca)
 
-function getindex(g::perm, n::Integer)
+function getindex(g::Perm, n::Integer)
    return g.d[n]
 end
 
-function setindex!(g::perm, v::Integer, n::Integer)
+function setindex!(g::Perm, v::Integer, n::Integer)
    g.modified = true
    g.d[n] = v
    return g
 end
 
-Base.promote_rule(::Type{perm{I}}, ::Type{perm{J}}) where {I,J} =
-   perm{promote_type(I,J)}
+Base.promote_rule(::Type{Perm{I}}, ::Type{Perm{J}}) where {I,J} =
+   Perm{promote_type(I,J)}
 
-convert(::Type{perm{T}}, p::perm) where T = perm(convert(Vector{T}, p.d), false)
+convert(::Type{Perm{T}}, p::Perm) where T = Perm(convert(Vector{T}, p.d), false)
 
-convert(::Type{Vector{T}}, p::perm{T}) where {T} = p.d
+convert(::Type{Vector{T}}, p::Perm{T}) where {T} = p.d
 
-function Base.similar(p::perm{T}, ::Type{S}=T) where {T, S<:Integer}
-   p = perm(similar(p.d, S), false)
+function Base.similar(p::Perm{T}, ::Type{S}=T) where {T, S<:Integer}
+   p = Perm(similar(p.d, S), false)
    p.modified = true
    return p
 end
@@ -69,7 +69,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    parity(g::perm{T}) where T
+    parity(g::Perm{T}) where T
 > Return the parity of the given permutation, i.e. the parity of the number of
 > transpositions in any decomposition of `g` into transpositions.
 >
@@ -80,20 +80,20 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> g = perm([3,4,1,2,5])
+julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
 julia> parity(g)
 0
 
-julia> g = perm([3,4,5,2,1,6])
+julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
 julia> parity(g)
 1
 ```
 """
-function parity(g::perm{T}) where T
+function parity(g::Perm{T}) where T
    if isdefined(g, :cycles) && !g.modified
       return T(sum([(length(c)+1)%2 for c in cycles(g)])%2)
    end
@@ -114,7 +114,7 @@ function parity(g::perm{T}) where T
 end
 
 @doc Markdown.doc"""
-    sign(g::perm{T}) where T
+    sign(g::Perm{T}) where T
 > Return the sign of permutation.
 >
 > `sign` returns $1$ if `g` is even and $-1$ if `g` is odd. `sign` represents
@@ -123,20 +123,20 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> g = perm([3,4,1,2,5])
+julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
 julia> sign(g)
 1
 
-julia> g = perm([3,4,5,2,1,6])
+julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
 julia> sign(g)
 -1
 ```
 """
-sign(g::perm{T}) where T = (-one(T))^parity(g)
+sign(g::Perm{T}) where T = (-one(T))^parity(g)
 
 ###############################################################################
 #
@@ -179,7 +179,7 @@ function Base.show(io::IO, cd::CycleDec)
 end
 
 @doc Markdown.doc"""
-    cycles(g::perm{T}) where T<:Integer
+    cycles(g::Perm{T}) where T<:Integer
 > Decompose permutation `g` into disjoint cycles.
 >
 > Return a `CycleDec` object which iterates over disjoint cycles of `g`. The
@@ -190,7 +190,7 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> g = perm([3,4,5,2,1,6])
+julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
 julia> collect(cycles(g))
@@ -200,7 +200,7 @@ julia> collect(cycles(g))
  [6]
 ```
 """
-function cycles(g::perm{T}) where T<:Integer
+function cycles(g::Perm{T}) where T<:Integer
    if !isdefined(g, :cycles) || g.modified
       ccycles, cptrs = cycledec(g.d)
       g.cycles = CycleDec{T}(ccycles, cptrs, length(cptrs)-1)
@@ -241,7 +241,7 @@ function cycledec(v::Vector{T}) where T<:Integer
 end
 
 @doc Markdown.doc"""
-    permtype(g::perm)
+    permtype(g::Perm)
 > Return the type of permutation `g`, i.e. lengths of disjoint cycles in cycle
 > decomposition of `g`.
 >
@@ -250,7 +250,7 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> g = perm([3,4,5,2,1,6])
+julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
 julia> permtype(g)
@@ -272,7 +272,7 @@ julia> permtype(e)
  1
 ```
 """
-permtype(g::perm) = sort(diff(cycles(g).cptrs), rev=true)
+permtype(g::Perm) = sort(diff(cycles(g).cptrs), rev=true)
 
 ###############################################################################
 #
@@ -307,13 +307,13 @@ const _permdisplaystyle = PermDisplayStyle(:cycles)
 julia> Generic.setpermstyle(:array)
 :array
 
-julia> perm([2,3,1,5,4])
+julia> Perm([2,3,1,5,4])
 [2, 3, 1, 5, 4]
 
 julia> Generic.setpermstyle(:cycles)
 :cycles
 
-julia> perm([2,3,1,5,4])
+julia> Perm([2,3,1,5,4])
 (1,2,3)(4,5)
 ```
 """
@@ -326,7 +326,7 @@ function setpermstyle(format::Symbol)
    return format
 end
 
-function show(io::IO, g::perm)
+function show(io::IO, g::Perm)
    if _permdisplaystyle.format == :array
       print(io, "[" * join(g.d, ", ") * "]")
    elseif _permdisplaystyle.format == :cycles
@@ -346,7 +346,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    ==(g::perm, h::perm)
+    ==(g::Perm, h::Perm)
 > Return `true` if permutations are equal, otherwise return `false`.
 >
 > Permutations parametrized by different integer types are considered equal if
@@ -354,17 +354,17 @@ end
 
 # Examples:
 ```
-julia> g = perm(Int8[2,3,1])
+julia> g = Perm(Int8[2,3,1])
 (1,2,3)
 
-julia> h = perm"(3,1,2)"
+julia> h = Perm"(3,1,2)"
 (1,2,3)
 
 julia> g == h
 true
 ```
 """
-==(g::perm, h::perm) = g.d == h.d
+==(g::Perm, h::Perm) = g.d == h.d
 
 @doc Markdown.doc"""
     ==(G::PermGroup, H::PermGroup)
@@ -392,7 +392,7 @@ false
 #   Binary operators
 #
 ###############################################################################
-function mul!(out::perm, g::perm, h::perm)
+function mul!(out::Perm, g::Perm, h::Perm)
    out = (out === g || out === h ? similar(out) : out)
    @inbounds for i in eachindex(out.d)
       out[i] = h[g[i]]
@@ -401,7 +401,7 @@ function mul!(out::perm, g::perm, h::perm)
 end
 
 @doc Markdown.doc"""
-    *(g::perm{T}, h::perm{T}) where T
+    *(g::Perm{T}, h::Perm{T}) where T
 > Return the composition ``h ∘ g`` of two permutations.
 >
 > This corresponds to the action of permutation group on the set `[1..n]`
@@ -412,15 +412,15 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> perm([2,3,1,4])*perm([1,3,4,2]) # (1,2,3)*(2,3,4)
+julia> Perm([2,3,1,4])*Perm([1,3,4,2]) # (1,2,3)*(2,3,4)
 (1,3)(2,4)
 ```
 """
-*(g::perm{T}, h::perm{T}) where T = mul!(similar(g), g, h)
-*(g::perm{S}, h::perm{T}) where {S,T} = *(promote(g,h)...)
+*(g::Perm{T}, h::Perm{T}) where T = mul!(similar(g), g, h)
+*(g::Perm{S}, h::Perm{T}) where {S,T} = *(promote(g,h)...)
 
 @doc Markdown.doc"""
-    ^(g::perm{T}, n::Integer) where T
+    ^(g::Perm{T}, n::Integer) where T
 > Return the $n$-th power of a permutation `g`.
 >
 > By default `g^n` is computed by cycle decomposition of `g` if `n > 3`.
@@ -431,7 +431,7 @@ julia> perm([2,3,1,4])*perm([1,3,4,2]) # (1,2,3)*(2,3,4)
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> g = perm([2,3,4,5,1])
+julia> g = Perm([2,3,4,5,1])
 (1,2,3,4,5)
 
 julia> g^3
@@ -441,17 +441,17 @@ julia> g^5
 ()
 ```
 """
-function ^(g::perm{T}, n::Integer) where T
+function ^(g::Perm{T}, n::Integer) where T
    if n < 0
       return inv(g)^-n
    elseif n == 0
-      return perm(T(length(g.d)))
+      return Perm(T(length(g.d)))
    elseif n == 1
       return deepcopy(g)
    elseif n == 2
-      return perm(g.d[g.d], false)
+      return Perm(g.d[g.d], false)
    elseif n == 3
-      return perm(g.d[g.d[g.d]], false)
+      return Perm(g.d[g.d[g.d]], false)
    else
       new_perm = similar(g)
 
@@ -468,17 +468,17 @@ function ^(g::perm{T}, n::Integer) where T
    end
 end
 
-function power_by_squaring(g::perm{I}, n::Integer) where {I}
+function power_by_squaring(g::Perm{I}, n::Integer) where {I}
    if n < 0
       return inv(g)^-n
    elseif n == 0
-      return perm(T(length(g.d)))
+      return Perm(T(length(g.d)))
    elseif n == 1
       return deepcopy(g)
    elseif n == 2
-      return perm(g.d[g.d], false)
+      return Perm(g.d[g.d], false)
    elseif n == 3
-      return perm(g.d[g.d[g.d]], false)
+      return Perm(g.d[g.d[g.d]], false)
    else
       bit = ~((~UInt(0)) >> 1)
       while (UInt(bit) & n) == 0
@@ -495,7 +495,7 @@ function power_by_squaring(g::perm{I}, n::Integer) where {I}
          end
          bit >>= 1
       end
-      return perm(cache1, false)
+      return Perm(cache1, false)
    end
 end
 
@@ -506,11 +506,11 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    inv(g::perm)
+    inv(g::Perm)
 > Return the inverse of the given permutation, i.e. the permuation $g^{-1}$
 > such that $g ∘ g^{-1} = g^{-1} ∘ g$ is the identity permutation.
 """
-function inv(g::perm)
+function inv(g::Perm)
    res = similar(g)
    @inbounds for i in 1:length(res.d)
       res[g[i]] = i
@@ -520,7 +520,7 @@ end
 
 # TODO: See M. Robertson, Inverting Permutations In Place
 # n+O(log^2 n) space, O(n*log n) time
-function inv!(a::perm)
+function inv!(a::Perm)
    d = similar(a.d)
    @inbounds for i in 1:length(d)
       d[a[i]] = i
@@ -565,7 +565,7 @@ end
    end
 end
 
-Base.eltype(::Type{AllPerms{T}}) where T<:Integer = perm{T}
+Base.eltype(::Type{AllPerms{T}}) where T<:Integer = Perm{T}
 
 Base.length(A::AllPerms) = A.all
 
@@ -597,7 +597,7 @@ julia> for p in Generic.elements!(PermGroup(3))
 (1,3)
 
 julia> A = collect(Generic.elements!(PermGroup(3))); A
-6-element Array{perm{Int64},1}:
+6-element Array{Perm{Int64},1}:
  (1,3)
  (1,3)
  (1,3)
@@ -606,7 +606,7 @@ julia> A = collect(Generic.elements!(PermGroup(3))); A
  (1,3)
 
 julia> unique(A)
-1-element Array{perm{Int64},1}:
+1-element Array{Perm{Int64},1}:
  (1,3)
 ```
 """
@@ -631,7 +631,7 @@ function Base.iterate(G::PermGroup, S)
   return deepcopy(s[1]), (A, s[2])
 end
 
-Base.eltype(::Type{PermGroup{T}}) where T = perm{T}
+Base.eltype(::Type{PermGroup{T}}) where T = Perm{T}
 
 Base.length(G::PermGroup) = order(G)
 
@@ -649,27 +649,27 @@ order(G::PermGroup) = order(BigInt, G)
 order(::Type{T}, G::PermGroup) where T = factorial(T(G.n))
 
 @doc Markdown.doc"""
-    order(a::perm) -> BigInt
+    order(a::Perm) -> BigInt
 > Return the order of permutation `a` as `BigInt`.
 >
 > If you are sure that computation over `T` (or its `Int` promotion) will not
-> overflow you may use the method `order(T::Type, a::perm)` which bypasses
+> overflow you may use the method `order(T::Type, a::Perm)` which bypasses
 > computation with BigInts and returns `promote(T, Int)`.
 """
-order(a::perm) = order(BigInt, a)
-function order(::Type{T}, a::perm) where T
+order(a::Perm) = order(BigInt, a)
+function order(::Type{T}, a::Perm) where T
    TT = promote_type(T, Int)
    return reduce(lcm, diff(cycles(a).cptrs), init = one(TT))
 end
 
 @doc Markdown.doc"""
-    matrix_repr(a::perm{T}) where T
+    matrix_repr(a::Perm{T}) where T
 > Return the permutation matrix as sparse matrix representing `a` via natural
 > embedding of the permutation group into general linear group over $\mathbb{Z}$.
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> p = perm([2,3,1])
+julia> p = Perm([2,3,1])
 (1,2,3)
 
 julia> matrix_repr(p)
@@ -685,10 +685,10 @@ julia> Array(ans)
  1  0  0
 ```
 """
-matrix_repr(a::perm{T}) where T = sparse(collect(T, 1:length(a.d)), a.d, ones(T,length(a.d)))
+matrix_repr(a::Perm{T}) where T = sparse(collect(T, 1:length(a.d)), a.d, ones(T,length(a.d)))
 
 @doc Markdown.doc"""
-    emb!(result::perm, p::perm, V)
+    emb!(result::Perm, p::Perm, V)
 > Embed permutation `p` into permutation `result` on the indices given by `V`.
 >
 > This corresponds to the natural embedding of $S_k$ into $S_n$ as the
@@ -696,14 +696,14 @@ matrix_repr(a::perm{T}) where T = sparse(collect(T, 1:length(a.d)), a.d, ones(T,
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> p = perm([2,1,4,3])
+julia> p = Perm([2,1,4,3])
 (1,2)(3,4)
 
-julia> Generic.emb!(perm(collect(1:5)), p, [3,1,4,5])
+julia> Generic.emb!(Perm(collect(1:5)), p, [3,1,4,5])
 (1,3)(4,5)
 ```
 """
-function emb!(result::perm, p::perm, V)
+function emb!(result::Perm, p::Perm, V)
    result.d[V] = (result.d[V])[p.d]
    return result
 end
@@ -715,7 +715,7 @@ end
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> p = perm([2,3,1])
+julia> p = Perm([2,3,1])
 (1,2,3)
 
 julia> f = Generic.emb(PermGroup(5), [3,2,5]);
@@ -737,7 +737,7 @@ end
     rand([rng=GLOBAL_RNG,] G::PermGroup{T}) where {T}
 > Return a random permutation from `G`.
 """
-rand(rng::AbstractRNG, rs::Random.SamplerTrivial{PermGroup{T}}) where {T} = perm(randperm!(rng, Vector{T}(undef, rs[].n)), false)
+rand(rng::AbstractRNG, rs::Random.SamplerTrivial{PermGroup{T}}) where {T} = Perm(randperm!(rng, Vector{T}(undef, rs[].n)), false)
 
 ###############################################################################
 #
@@ -745,20 +745,20 @@ rand(rng::AbstractRNG, rs::Random.SamplerTrivial{PermGroup{T}}) where {T} = perm
 #
 ###############################################################################
 
-(G::PermGroup)() = perm(G.n)
+(G::PermGroup)() = Perm(G.n)
 
 function (G::PermGroup{T})(a::Vector{T}, check::Bool=true) where T<:Integer
    if check
       G.n == length(a) || throw("Cannot coerce to $G: lengths differ")
    end
-   return perm(a, check)
+   return Perm(a, check)
 end
 
 function (G::PermGroup{T})(a::Vector{S}, check::Bool=true) where {S<:Integer,T}
    return G(convert(Vector{T}, a), check)
 end
 
-function (G::PermGroup{T})(p::perm{S}, check::Bool=true) where {S<:Integer, T}
+function (G::PermGroup{T})(p::Perm{S}, check::Bool=true) where {S<:Integer, T}
    if parent(p) == G
       return p
    end
@@ -774,7 +774,7 @@ function (G::PermGroup{T})(cdec::CycleDec{T}, check::Bool=true) where T
       length(cdec.ccycles) == G.n || throw("Can not coerce to $G: lengths differ")
    end
 
-   elt = perm(G.n)
+   elt = Perm(G.n)
    for c in cdec
       for i in 1:length(c)-1
          elt[c[i]] = c[i+1]
@@ -829,7 +829,7 @@ end
 
 @doc Markdown.doc"""
     perm"..."
-> String macro to parse disjoint cycles into `perm{Int}`.
+> String macro to parse disjoint cycles into `Perm{Int}`.
 >
 > Strings for the output of GAP could be copied directly into `perm"..."`.
 > Cycles of length $1$ are not necessary, but could be included. A permutation
@@ -842,7 +842,7 @@ julia> p = perm"(1,3)(2,4)"
 (1,3)(2,4)
 
 julia> typeof(p)
-perm{Int64}
+Perm{Int64}
 
 julia> parent(p) == PermutationGroup(4)
 true
@@ -886,7 +886,7 @@ const _charvalsTableBig = Dict{Tuple{BitVector,Vector{Int}}, BigInt}()
     character(lambda::Partition)
 > Return the $\lambda$-th irreducible character of permutation group on
 > `sum(lambda)` symbols. The returned character function is of the following signature:
-> > `chi(p::perm[, check::Bool=true]) -> BigInt`
+> > `chi(p::Perm[, check::Bool=true]) -> BigInt`
 > The function checks (if `p` belongs to the appropriate group) can be switched
 > off by calling `chi(p, false)`. The values computed by $\chi$ are cached in
 > look-up table.
@@ -919,7 +919,7 @@ julia> chi(perm"(1,3)(2,4)")
 function character(lambda::Partition)
    R = partitionseq(lambda)
 
-   char = function(p::perm, check::Bool=true)
+   char = function(p::Perm, check::Bool=true)
       if check
          sum(lambda) == length(p.d) || throw(ArgumentError("Can't evaluate character on $p : lengths differ."))
       end
@@ -930,18 +930,18 @@ function character(lambda::Partition)
 end
 
 @doc Markdown.doc"""
-    character(lambda::Partition, p::perm, check::Bool=true) -> BigInt
+    character(lambda::Partition, p::Perm, check::Bool=true) -> BigInt
 > Return the value of `lambda`-th irreducible character of the permutation
 > group on permutation `p`.
 """
-function character(lambda::Partition, p::perm, check::Bool=true)
+function character(lambda::Partition, p::Perm, check::Bool=true)
    if check
       sum(lambda) == length(p.d) || throw("lambda-th irreducible character can be evaluated only on permutations of length $(sum(lambda)).")
    end
    return character(BigInt, lambda, Partition(permtype(p)))
 end
 
-function character(::Type{T}, lambda::Partition, p::perm) where T <: Integer
+function character(::Type{T}, lambda::Partition, p::Perm) where T <: Integer
    return character(T, lambda, Partition(permtype(p)))
 end
 

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -1,21 +1,21 @@
 IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
 
-@testset "perm.abstract_types..." begin
-   @test Generic.perm <: GroupElem
+@testset "Perm.abstract_types..." begin
+   @test Generic.Perm <: GroupElem
 
    @test Generic.PermGroup <: AbstractAlgebra.Group
 end
 
-@testset "perm.constructors ($T)..." for T in IntTypes
-   @test elem_type(Generic.PermGroup{T}) == Generic.perm{T}
-   @test parent_type(Generic.perm{T}) == Generic.PermGroup{T}
+@testset "Perm.constructors ($T)..." for T in IntTypes
+   @test elem_type(Generic.PermGroup{T}) == Generic.Perm{T}
+   @test parent_type(Generic.Perm{T}) == Generic.PermGroup{T}
 
    @test PermutationGroup(T(10)) isa Generic.PermGroup{T}
    G = PermutationGroup(T(10))
-   @test elem_type(G) == Generic.perm{T}
+   @test elem_type(G) == Generic.Perm{T}
 
    @test G() isa GroupElem
-   @test G() isa Generic.perm{T}
+   @test G() isa Generic.Perm{T}
    a = G()
    @test parent_type(typeof(a)) == Generic.PermGroup{T}
    @test parent(a) == G
@@ -23,16 +23,16 @@ end
    z = T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]
 
    @test G(z) isa GroupElem
-   @test G(z) isa Generic.perm{T}
+   @test G(z) isa Generic.Perm{T}
    b = G(z)
-   @test typeof(b) == Generic.perm{T}
+   @test typeof(b) == Generic.Perm{T}
    @test parent_type(typeof(b)) == Generic.PermGroup{T}
    @test parent(b) == G
 
-   @test rand(G) isa Generic.perm{T}
-   @test rand(G, 3) isa Vector{Generic.perm{T}}
-   @test rand(rng, G) isa Generic.perm{T}
-   @test rand(rng, G, 2, 3) isa Matrix{Generic.perm{T}}
+   @test rand(G) isa Generic.Perm{T}
+   @test rand(G, 3) isa Vector{Generic.Perm{T}}
+   @test rand(rng, G) isa Generic.Perm{T}
+   @test rand(rng, G, 2, 3) isa Matrix{Generic.Perm{T}}
    g = rand(G)
    @test parent(g) == G
    @test parent(g) == PermutationGroup(T(10))
@@ -43,11 +43,11 @@ end
       @test parent(g) != PermutationGroup(10)
    end
 
-   @test similar(g) isa perm{T}
-   @test similar(g, Int) isa perm{Int}
+   @test similar(g) isa Perm{T}
+   @test similar(g, Int) isa Perm{Int}
 end
 
-@testset "perm.parsingGAP..." begin
+@testset "Perm.parsingGAP..." begin
    @test Generic.parse_cycles("()") == (Int[], [1])
    @test Generic.parse_cycles("(1)(2)(3)") == ([1,2,3], [1,2,3,4])
    @test Generic.parse_cycles("Cycle decomposition: (1)(2,3)") == ([1,2,3], [1,2,4])
@@ -68,12 +68,12 @@ end
    @test Generic.parse_cycles(s) == Generic.parse_cycles(s2)
 
    @test perm"(1,2,3)(5)(10)" isa GroupElem
-   @test perm"(1,2,3)(5)(10)" isa Generic.perm
-   @test perm"(1,2,3)(5)(10)" isa Generic.perm{Int}
+   @test perm"(1,2,3)(5)(10)" isa Generic.Perm
+   @test perm"(1,2,3)(5)(10)" isa Generic.Perm{Int}
    @test parent(perm"(1,2,3)(5)(10)") == PermGroup(10)
    @test parent(perm"(1,2,3)(5)(6)") == PermGroup(6)
-   @test perm"(1,2,3,4,5)" == perm([2,3,4,5,1])
-   @test perm"(3,2,1)(4,5)" == perm([3,1,2,5,4])
+   @test perm"(1,2,3,4,5)" == Perm([2,3,4,5,1])
+   @test perm"(3,2,1)(4,5)" == Perm([3,1,2,5,4])
 
    @test perm"""
 ( 1, 22,73,64,78,81,  24 ,89,90,54,51,82,91,53,18,38,19,52,44,77,62,95,94,50,43,42,
@@ -86,13 +86,13 @@ end
       G = PermutationGroup(T(5))
       @test G("()") == G()
       @test G("()()") == G()
-      @test G("(1)(2,3)") == perm(T[1,3,2,4,5])
+      @test G("(1)(2,3)") == Perm(T[1,3,2,4,5])
       @test G("(2,3)") == G("(1)(2,3)")
       @test G("(3,2)") == G("(2,3)")
-      @test G("(3,2,1)") == perm(T[3,1,2,4,5])
+      @test G("(3,2,1)") == Perm(T[3,1,2,4,5])
       @test G("(3,2,1)") == G("(1,3,2)") == G("(2,1,3)")
-      @test G("(1,2,3,4,5)") == perm(T[2,3,4,5,1])
-      @test G("(3,2,1)(4,5)") == perm(T[3,1,2,5,4])
+      @test G("(1,2,3,4,5)") == Perm(T[2,3,4,5,1])
+      @test G("(3,2,1)(4,5)") == Perm(T[3,1,2,5,4])
       gg = G("(3,2,1)(4,5)")
       @test isdefined(gg, :cycles)
 
@@ -103,7 +103,7 @@ end
    end
 end
 
-@testset "perm.printing ($T)..." for T in IntTypes
+@testset "Perm.printing ($T)..." for T in IntTypes
    G = PermutationGroup(T(10))
 
    b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
@@ -114,11 +114,11 @@ end
    Generic.setpermstyle(:cycles);
    @test string(b) == "(1,2,3,5,6,7)(8,9,10)"
 
-   @test string(perm(T[1,2,3])) == "()"
-   @test string(perm(T[3,2,1])) == "(1,3)"
+   @test string(Perm(T[1,2,3])) == "()"
+   @test string(Perm(T[3,2,1])) == "(1,3)"
 end
 
-@testset "perm.basic_manipulation ($T)..." for T in IntTypes
+@testset "Perm.basic_manipulation ($T)..." for T in IntTypes
    G = PermutationGroup(T(10))
 
    a = G()
@@ -132,14 +132,14 @@ end
 
    @test length(unique([c,deepcopy(c)])) == 1
 
-   @test setindex!(a, 5, 2) isa perm
+   @test setindex!(a, 5, 2) isa Perm
    @test a[2] == T(5)
 
    a[1] = T(5)
    @test a[1] == T(5)
 end
 
-@testset "perm.iteration ($T)..." for T in IntTypes
+@testset "Perm.iteration ($T)..." for T in IntTypes
    G = PermutationGroup(T(6))
    @test length(AllPerms(T(6))) == 720
    @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
@@ -147,7 +147,7 @@ end
    @test order(T, G) isa promote_type(T, Int)
    @test order(G) == 720
 
-   @test collect(G) isa Vector{perm{T}}
+   @test collect(G) isa Vector{Perm{T}}
 
    elts = collect(G)
 
@@ -158,11 +158,11 @@ end
    @test length(unique(collect(G))) == 720
 end
 
-@testset "perm.binary_ops ($T)..." for T in IntTypes
+@testset "Perm.binary_ops ($T)..." for T in IntTypes
    G = PermutationGroup(T(3))
 
-   a = perm(T[2,1,3]) # (1,2)
-   b = perm(T[2,3,1]) # (1,2,3)
+   a = Perm(T[2,1,3]) # (1,2)
+   b = Perm(T[2,3,1]) # (1,2,3)
 
    @test a*b == G(T[3,2,1]) # (1,2)*(1,2,3) == (1,3)
    @test b*a == G(T[1,3,2]) # (1,2,3)*(1,2) == (2,3)
@@ -170,7 +170,7 @@ end
    @test b*b*b == G()
 
    # (1,2,3)*(2,3,4) == (1,3)(2,4)
-   @test perm(T[2,3,1,4])*perm(T[1,3,4,2]) == perm(T[3,4,1,2])
+   @test Perm(T[2,3,1,4])*Perm(T[1,3,4,2]) == Perm(T[3,4,1,2])
 
    @test parity(G()) == 0
    p = parity(a)
@@ -199,7 +199,7 @@ end
    @test p^2 * p^-2 == G()
 end
 
-@testset "perm.mixed_binary_ops..." begin
+@testset "Perm.mixed_binary_ops..." begin
    G = PermutationGroup(6)
    for T in IntTypes
       H = PermutationGroup(T(6))
@@ -207,14 +207,14 @@ end
       @test G(H()) == G()
       @test H(G()) == H()
       @test G() == H()
-      @test rand(G)*rand(H) isa perm{promote_type(Int, T)}
-      @test rand(H)*rand(G) isa perm{promote_type(Int, T)}
-      @test G(rand(H)) isa perm{Int}
-      @test H(rand(G)) isa perm{T}
+      @test rand(G)*rand(H) isa Perm{promote_type(Int, T)}
+      @test rand(H)*rand(G) isa Perm{promote_type(Int, T)}
+      @test G(rand(H)) isa Perm{Int}
+      @test H(rand(G)) isa Perm{T}
    end
 end
 
-@testset "perm.inversion ($T)..." for T in IntTypes
+@testset "Perm.inversion ($T)..." for T in IntTypes
    G = PermutationGroup(T(10))
 
    a = G()
@@ -229,7 +229,7 @@ end
    end
 end
 
-@testset "perm.misc ($T)..." for T in IntTypes
+@testset "Perm.misc ($T)..." for T in IntTypes
    G = PermutationGroup(T(10))
    a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
@@ -278,7 +278,7 @@ end
    end
 end
 
-@testset "perm.characters..." begin
+@testset "Perm.characters..." begin
    for T in IntTypes
       N = T(7)
       G = PermutationGroup(N)


### PR DESCRIPTION
As a new "breaking" release of AA is in preparation, here is a breaking change.
Julia's [convention](https://docs.julialang.org/en/v1/manual/style-guide/index.html#Use-naming-conventions-consistent-with-Julia-base/-1) is for types to be CamelCase. All exported types from `AbstractAlgebra` follow this convention, except `perm`. Let's fix this.
```julia
julia> function gettypes(m::Module, only_lower=false; all=false)
           modnames = names(m, all=all)
           if only_lower
               filter!(n -> islowercase(first(String(n))), modnames)
           end
           modobjs = getfield.(Ref(m), modnames)
           filter(x -> x isa Union{DataType,UnionAll,Union}, modobjs)
       end
gettypes (generic function with 2 methods)

julia> gettypes(AbstractAlgebra)
41-element Array{Any,1}:
 AbsSeriesElem
 AccessorNotSetError
 Array
 ErrorConstrDimMismatch
 Fac
 FieldElem
 Union{FieldElem, AbstractFloat, Rational}
 FinField
 FinFieldElem
 FracElem
 FracField
 FunctionalMap
 GroupElem
 IdentityMap
 MPolyBuildCtx
 MPolyElem
 MPolyRing
 Map
 MatAlgElem
 MatAlgebra
 MatElem
 MatSpace
 ModuleElem
 NCPolyElem
 NCRingElem
 NumField
 NumFieldElem
 PolyElem
 PolyRing
 RelSeriesElem
 ResElem
 ResRing
 RingElem
 Union{RingElem, AbstractFloat, Integer, Rational}
 SeriesElem
 SeriesRing
 SetElem
 SetMap
 SimpleNumField
 SimpleNumFieldElem
 perm

julia> gettypes(AbstractAlgebra, true; all=true)
2-element Array{Any,1}:
 AbstractAlgebra.gfelem
 perm

julia> gettypes(AbstractAlgebra.Generic, true)
5-element Array{Any,1}:
 direct_sum_module_elem
 free_module_elem
 quotient_module_elem
 snf_module_elem
 submodule_elem
```

`perm` is the most urgent to fix as it's exported. But `gfelem` should also probably be capitalized. What about `Generic` types? In the list above, they are not re-exported by `AbstractAlgebra`, so they may be considered as internal. Is the end user assumed to be allowed to do `using Generic` ? If yes, exported types should also probably be CamelCased.