### PR TITLE
implement parent_type on instances

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -4,7 +4,8 @@
 #
 ###############################################################################
 
-elem_type(::T) where {T <: Ring} = elem_type(T)
+elem_type(::T)   where {T <: Ring}     = elem_type(T)
+parent_type(::T) where {T <: RingElem} = parent_type(T)
 
 function isequal(a::RingElem, b::RingElem)
    return parent(a) == parent(b) && a == b
@@ -242,7 +243,7 @@ end
 @doc Markdown.doc"""
     change_base_ring(::PolyElem{T}, g::Any) where T <: RingElement
 > Return the polynomial obtained by applying `g` to the coefficients. The new
-> base ring is defined by the image of `0`. 
+> base ring is defined by the image of `0`.
 """
 function change_base_ring(p::PolyElem{T}, g) where T <: RingElement
    z = zero(base_ring(parent(p)))

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -14,3 +14,14 @@ include("generic/MPoly-test.jl")
    F = GF(3)
    @test F(2) .* [F(1), F(2)] == [F(2), F(1)]
 end
+
+@testset "Generic.Rings.{elem,parent}_type" begin
+   for (R, el, par) in [(GF(3), AbstractAlgebra.gfelem{Int}, AbstractAlgebra.GFField{Int}),
+                        (ZZ["x"][1], Generic.Poly{BigInt}, Generic.PolyRing{BigInt})]
+      x = R(2)
+      @test elem_type(R) == el
+      @test elem_type(typeof(R)) == el
+      @test parent_type(x) == par
+      @test parent_type(typeof(x)) == par
+   end
+end


### PR DESCRIPTION
I run into this inconvenience regularly. `elem_type` is already implemented on instances, like `eltype`, there is no reason not to do it for `parent_type`.