### PR TITLE
conform rand(::GFField) to the Random API

### DIFF
--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -351,13 +351,13 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::GFField{T}) where T <: Integer
-   p = R.p::T
-   d = rand(rng, 0:p - 1)
-   return gfelem{T}(d, R)
-end
+Random.Sampler(RNG::Type{<:AbstractRNG}, R::GFField, n::Random.Repetition) =
+   Random.SamplerSimple(R, Random.Sampler(RNG, 0:R.p - 1, n))
 
-rand(x::GFField) = rand(Random.GLOBAL_RNG, x)
+rand(rng::AbstractRNG, R::Random.SamplerSimple{GFField{T}}) where T =
+   gfelem{T}(rand(rng, R.data), R[])
+
+Random.gentype(T::Type{<:GFField}) = elem_type(T)
 
 ###############################################################################
 #

--- a/test/julia/gfelem-test.jl
+++ b/test/julia/gfelem-test.jl
@@ -73,10 +73,10 @@ end
 
 @testset "Julia.gfelem.rand..." begin
    R = GF(13)
-   f = rand(R)
-   @test f isa AbstractAlgebra.gfelem
-   f = rand(rng, R)
-   @test f isa AbstractAlgebra.gfelem
+   @test rand(R) isa AbstractAlgebra.gfelem
+   @test rand(rng, R) isa AbstractAlgebra.gfelem
+   @test rand(R, 2, 3) isa Matrix{<:AbstractAlgebra.gfelem}
+   @test rand(rng, R, 2, 3) isa Matrix{<:AbstractAlgebra.gfelem}
 end
 
 @testset "Julia.gfelem.unary_ops..." begin


### PR DESCRIPTION
`rand(::GFField)` seems to be the only left definition which takes only one argument and is not yet converted to using the `Random` API.