### PR TITLE
rename lowercase types to CamelCase

### DIFF
--- a/docs/src/finfield.md
+++ b/docs/src/finfield.md
@@ -15,7 +15,7 @@ $1$ (prime fields). They are modelled as $\mathbb{Z}/p\mathbb{Z}$ for $p$ a prim
 
 Finite fields have type `GFField{T}` where `T` is either `Int` or `BigInt`.
 
-Elements of such a finite field have type `gfelem{T}`.
+Elements of such a finite field have type `GFElem{T}`.
 
 ## Finite field constructors
 

--- a/docs/src/module.md
+++ b/docs/src/module.md
@@ -102,7 +102,7 @@ julia> n = ngens(M)
 2
 
 julia> G = gens(M)
-2-element Array{AbstractAlgebra.Generic.free_module_elem{Rational{BigInt}},1}:
+2-element Array{AbstractAlgebra.Generic.FreeModuleElem{Rational{BigInt}},1}:
  (1//1, 0//1)
  (0//1, 1//1)
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -98,7 +98,7 @@ Here we give a list of the concrete types in AbstractAlgebra.jl.
 In parentheses we put the types of the corresponding parent objects.
 
   - `Perm{<:Integer}` (`PermGroup{<:Integer}`)
-  - `gfelem{<:Integer}` (`GFField{<:Integer}`)
+  - `GFElem{<:Integer}` (`GFField{<:Integer}`)
 
 We also think of various Julia types as though they were AbstractAlgebra.jl types:
 

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -99,7 +99,7 @@ function (N::DirectSumModule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingE
    return DirectSumModuleElem{T}(N, v)
 end
 
-function (M::DirectSumModule{T})(a::submodule_elem{T}) where T <: RingElement
+function (M::DirectSumModule{T})(a::SubmoduleElem{T}) where T <: RingElement
    R = parent(a)
    base_ring(R) != base_ring(M) && error("Incompatible modules")
    return M(R.map(a))

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export DirectSumModule, direct_sum_module_elem, summands
+export DirectSumModule, DirectSumModuleElem, summands
 
 ###############################################################################
 #
@@ -12,15 +12,15 @@ export DirectSumModule, direct_sum_module_elem, summands
 #
 ###############################################################################
 
-parent_type(::Type{direct_sum_module_elem{T}}) where T <: RingElement = DirectSumModule{T}
+parent_type(::Type{DirectSumModuleElem{T}}) where T <: RingElement = DirectSumModule{T}
 
-elem_type(::Type{DirectSumModule{T}}) where T <: RingElement = direct_sum_module_elem{T}
+elem_type(::Type{DirectSumModule{T}}) where T <: RingElement = DirectSumModuleElem{T}
 
-parent(v::direct_sum_module_elem) = v.parent
+parent(v::DirectSumModuleElem) = v.parent
 
 base_ring(N::DirectSumModule{T}) where T <: RingElement = base_ring(N.m[1])
 
-base_ring(v::direct_sum_module_elem{T}) where T <: RingElement = base_ring(v.parent)
+base_ring(v::DirectSumModuleElem{T}) where T <: RingElement = base_ring(v.parent)
 
 ngens(N::DirectSumModule{T}) where T <: RingElement = sum(ngens(M) for M in N.m)
 
@@ -53,7 +53,7 @@ function show(io::IO, N::DirectSumModule{T}) where T <: FieldElement
    print(IOContext(io, :compact => true), base_ring(N))
 end
 
-function show(io::IO, v::direct_sum_module_elem)
+function show(io::IO, v::DirectSumModuleElem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
@@ -80,7 +80,7 @@ function (N::DirectSumModule{T})(v::Vector{T}) where T <: RingElement
       mat = reduce_mod_rels(mat, rels(N.m[i]), start)
       start += ngens(N.m[i])
    end
-   return direct_sum_module_elem{T}(N, mat)
+   return DirectSumModuleElem{T}(N, mat)
 end
 
 function (M::DirectSumModule{T})(a::Vector{Any}) where T <: RingElement
@@ -90,13 +90,13 @@ end
 
 function (N::DirectSumModule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingElement
    ncols(v) != ngens(N) && error("Length of vector does not match number of generators")
-   nrows(v) != 1 && ("Not a vector in direct_sum_module_elem constructor")
+   nrows(v) != 1 && ("Not a vector in DirectSumModuleElem constructor")
    start = 1
    for i = 1:length(N.m)
       v = reduce_mod_rels(v, rels(N.m[i]), start)
       start += ngens(N.m[i])
    end
-   return direct_sum_module_elem{T}(N, v)
+   return DirectSumModuleElem{T}(N, v)
 end
 
 function (M::DirectSumModule{T})(a::submodule_elem{T}) where T <: RingElement
@@ -105,7 +105,7 @@ function (M::DirectSumModule{T})(a::submodule_elem{T}) where T <: RingElement
    return M(R.map(a))
 end
 
-function (M::DirectSumModule{T})(a::direct_sum_module_elem{T}) where T <: RingElement
+function (M::DirectSumModule{T})(a::DirectSumModuleElem{T}) where T <: RingElement
    R = parent(a)
    R != M && error("Incompatible modules")
    return a
@@ -138,7 +138,7 @@ function direct_sum_injection(m::AbstractAlgebra.FPModule{T}, D::DirectSumModule
       newv[i + start] = v[i]
    end
    matv = matrix(R, 1, length(newv), newv)
-   return direct_sum_module_elem{T}(D, matv)
+   return DirectSumModuleElem{T}(D, matv)
 end
 
 function direct_sum_projection(D::DirectSumModule{T}, m::U, v::AbstractAlgebra.FPModuleElem{T}) where {T <: RingElement, U <: AbstractAlgebra.FPModule{T}}

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -115,7 +115,7 @@ function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: Union{Ring
    return z
 end
 
-function (M::FreeModule{T})(a::submodule_elem{T}) where T <: RingElement
+function (M::FreeModule{T})(a::SubmoduleElem{T}) where T <: RingElement
    R = parent(a)
    base_ring(R) !== base_ring(M) && error("Incompatible modules")
    return M(R.map(a))

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export FreeModule, free_module_elem
+export FreeModule, FreeModuleElem
 
 ###############################################################################
 #
@@ -12,22 +12,22 @@ export FreeModule, free_module_elem
 #
 ###############################################################################
 
-parent_type(::Type{free_module_elem{T}}) where T <: Union{RingElement, NCRingElem} = FreeModule{T}
+parent_type(::Type{FreeModuleElem{T}}) where T <: Union{RingElement, NCRingElem} = FreeModule{T}
 
 base_ring(M::FreeModule{T}) where T <: Union{RingElement, NCRingElem} = M.base_ring::parent_type(T)
 
-base_ring(v::free_module_elem{T}) where T <: Union{RingElement, NCRingElem} = base_ring(parent(v))
+base_ring(v::FreeModuleElem{T}) where T <: Union{RingElement, NCRingElem} = base_ring(parent(v))
 
-elem_type(::Type{FreeModule{T}}) where T <: Union{RingElement, NCRingElem} = free_module_elem{T}
+elem_type(::Type{FreeModule{T}}) where T <: Union{RingElement, NCRingElem} = FreeModuleElem{T}
 
-parent(m::free_module_elem{T}) where T <: Union{RingElement, NCRingElem} = m.parent
+parent(m::FreeModuleElem{T}) where T <: Union{RingElement, NCRingElem} = m.parent
 
 function rels(M::FreeModule{T}) where T <: RingElement
    # there are no relations in a free module
    return Vector{dense_matrix_type(T)}(undef, 0)
 end
 
-function check_parent(m1::free_module_elem{T}, m2::free_module_elem{T}) where T <: Union{RingElement, NCRingElem}
+function check_parent(m1::FreeModuleElem{T}, m2::FreeModuleElem{T}) where T <: Union{RingElement, NCRingElem}
     parent(m1) !== parent(m2) && error("Incompatible free modules")
 end
 
@@ -74,7 +74,7 @@ function show(io::IO, M::FreeModule{T}) where T <: FieldElement
    show(IOContext(io, :compact => true), base_ring(M))
 end
 
-function show(io::IO, a::free_module_elem)
+function show(io::IO, a::FreeModuleElem)
    print(io, "(")
    M = parent(a)
    for i = 1:rank(M) - 1
@@ -97,7 +97,7 @@ function (M::FreeModule{T})(a::Vector{T}) where T <: Union{RingElement, NCRingEl
    length(a) != rank(M) && error("Number of elements does not equal rank")
    R = base_ring(M)
    v = matrix(R, 1, length(a), a)
-   z = free_module_elem{T}(M, v)
+   z = FreeModuleElem{T}(M, v)
    z.parent = M
    return z
 end
@@ -110,7 +110,7 @@ end
 function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: Union{RingElement, NCRingElem}
    ncols(a) != rank(M) && error("Number of elements does not equal rank")
    nrows(a) != 1 && error("Matrix should have single row")
-   z = free_module_elem{T}(M, a)
+   z = FreeModuleElem{T}(M, a)
    z.parent = M
    return z
 end
@@ -121,7 +121,7 @@ function (M::FreeModule{T})(a::submodule_elem{T}) where T <: RingElement
    return M(R.map(a))
 end
 
-function (M::FreeModule{T})(a::free_module_elem{T}) where T <: RingElement
+function (M::FreeModule{T})(a::FreeModuleElem{T}) where T <: RingElement
    R = parent(a)
    R !== M && error("Incompatible modules")
    return a

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1189,7 +1189,7 @@ end
 
 ###############################################################################
 #
-#   SNFModule/snf_module_elem
+#   SNFModule/SNFModuleElem
 #
 ###############################################################################
 
@@ -1205,11 +1205,11 @@ mutable struct SNFModule{T <: RingElement} <: AbstractAlgebra.FPModule{T}
    end
 end
 
-mutable struct snf_module_elem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
+mutable struct SNFModuleElem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
    v::AbstractAlgebra.MatElem{T}
    parent::SNFModule{T}
 
-   function snf_module_elem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
+   function SNFModuleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
       z = new{T}(v, m)
    end
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1056,7 +1056,7 @@ end
 
 ###############################################################################
 #
-#   FreeModule/free_module_elem
+#   FreeModule/FreeModuleElem
 #
 ###############################################################################
 
@@ -1079,11 +1079,11 @@ end
 
 const FreeModuleDict = Dict{Tuple{NCRing, Int}, FreeModule}()
 
-mutable struct free_module_elem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
+mutable struct FreeModuleElem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
     v::AbstractAlgebra.MatElem{T}
     parent::FreeModule{T}
 
-    function free_module_elem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: Union{RingElement, NCRingElem}
+    function FreeModuleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: Union{RingElement, NCRingElem}
        z = new{T}(v, m)
     end
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1151,7 +1151,7 @@ end
 
 ###############################################################################
 #
-#   QuotientModule/quotient_module_elem
+#   QuotientModule/QuotientModuleElem
 #
 ###############################################################################
 
@@ -1178,11 +1178,11 @@ mutable struct QuotientModule{T <: RingElement} <: AbstractAlgebra.FPModule{T}
    end
 end
 
-mutable struct quotient_module_elem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
+mutable struct QuotientModuleElem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
    v::AbstractAlgebra.MatElem{T}
    parent::QuotientModule{T}
 
-   function quotient_module_elem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
+   function QuotientModuleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
       z = new{T}(v, m)
    end
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1122,7 +1122,7 @@ end
 
 ###############################################################################
 #
-#   Submodule/submodule_elem
+#   Submodule/SubmoduleElem
 #
 ###############################################################################
 
@@ -1140,11 +1140,11 @@ mutable struct Submodule{T <: RingElement} <: AbstractAlgebra.FPModule{T}
    end
 end
 
-mutable struct submodule_elem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
+mutable struct SubmoduleElem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
    v::AbstractAlgebra.MatElem{T}
    parent::Submodule{T}
 
-   function submodule_elem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
+   function SubmoduleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
       z = new{T}(v, m)
    end
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1216,7 +1216,7 @@ end
 
 ###############################################################################
 #
-#   DirectSumModule/direct_sum_module_elem
+#   DirectSumModule/DirectSumModuleElem
 #
 ###############################################################################
 
@@ -1231,11 +1231,11 @@ mutable struct DirectSumModule{T <: RingElement} <: AbstractAlgebra.FPModule{T}
    end
 end
 
-mutable struct direct_sum_module_elem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
+mutable struct DirectSumModuleElem{T <: RingElement} <: AbstractAlgebra.FPModuleElem{T}
    v::AbstractAlgebra.MatElem{T}
    parent::DirectSumModule{T}
 
-   function direct_sum_module_elem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
+   function DirectSumModuleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: RingElement
       z = new{T}(v, m)
    end
 end

--- a/src/generic/InvariantFactorDecomposition.jl
+++ b/src/generic/InvariantFactorDecomposition.jl
@@ -118,7 +118,7 @@ function (N::SNFModule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingElement
    return SNFModuleElem{T}(N, v)
 end
 
-function (M::SNFModule{T})(a::submodule_elem{T}) where T <: RingElement
+function (M::SNFModule{T})(a::SubmoduleElem{T}) where T <: RingElement
    R = parent(a)
    base_ring(R) != base_ring(M) && error("Incompatible modules")
    return M(R.map(a))

--- a/src/generic/InvariantFactorDecomposition.jl
+++ b/src/generic/InvariantFactorDecomposition.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export SNFModule, snf_module_elem, invariant_factors
+export SNFModule, SNFModuleElem, invariant_factors
 
 ###############################################################################
 #
@@ -12,15 +12,15 @@ export SNFModule, snf_module_elem, invariant_factors
 #
 ###############################################################################
 
-parent_type(::Type{snf_module_elem{T}}) where T <: RingElement = SNFModule{T}
+parent_type(::Type{SNFModuleElem{T}}) where T <: RingElement = SNFModule{T}
 
-elem_type(::Type{SNFModule{T}}) where T <: RingElement = snf_module_elem{T}
+elem_type(::Type{SNFModule{T}}) where T <: RingElement = SNFModuleElem{T}
 
-parent(v::snf_module_elem) = v.parent
+parent(v::SNFModuleElem) = v.parent
 
 base_ring(N::SNFModule{T}) where T <: RingElement = N.base_ring
 
-base_ring(v::snf_module_elem{T}) where T <: RingElement = base_ring(v.parent)
+base_ring(v::SNFModuleElem{T}) where T <: RingElement = base_ring(v.parent)
 
 ngens(N::SNFModule{T}) where T <: RingElement = length(N.invariant_factors)
 
@@ -70,7 +70,7 @@ function show(io::IO, N::SNFModule{T}) where T <: FieldElement
    print(io, ngens(N))
 end
 
-function show(io::IO, v::snf_module_elem)
+function show(io::IO, v::SNFModuleElem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
@@ -103,7 +103,7 @@ function (N::SNFModule{T})(v::Vector{T}) where T <: RingElement
    length(v) != ngens(N) && error("Length of vector does not match number of generators")
    mat = matrix(base_ring(N), 1, length(v), v)
    mat = reduce_mod_invariants(mat, invariant_factors(N))
-   return snf_module_elem{T}(N, mat)
+   return SNFModuleElem{T}(N, mat)
 end
 
 function (M::SNFModule{T})(a::Vector{Any}) where T <: RingElement
@@ -113,9 +113,9 @@ end
 
 function (N::SNFModule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingElement
    ncols(v) != ngens(N) && error("Length of vector does not match number of generators")
-   nrows(v) != 1 && ("Not a vector in snf_module_elem constructor")
+   nrows(v) != 1 && ("Not a vector in SNFModuleElem constructor")
    v = reduce_mod_invariants(v, invariant_factors(N))
-   return snf_module_elem{T}(N, v)
+   return SNFModuleElem{T}(N, v)
 end
 
 function (M::SNFModule{T})(a::submodule_elem{T}) where T <: RingElement
@@ -124,7 +124,7 @@ function (M::SNFModule{T})(a::submodule_elem{T}) where T <: RingElement
    return M(R.map(a))
 end
 
-function (M::SNFModule{T})(a::snf_module_elem{T}) where T <: RingElement
+function (M::SNFModule{T})(a::SNFModuleElem{T}) where T <: RingElement
    R = parent(a)
    R != M && error("Incompatible modules")
    return a

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export QuotientModule, quotient_module_elem, quo
+export QuotientModule, QuotientModuleElem, quo
 
 ###############################################################################
 #
@@ -12,15 +12,15 @@ export QuotientModule, quotient_module_elem, quo
 #
 ###############################################################################
 
-parent_type(::Type{quotient_module_elem{T}}) where T <: RingElement = QuotientModule{T}
+parent_type(::Type{QuotientModuleElem{T}}) where T <: RingElement = QuotientModule{T}
 
-elem_type(::Type{QuotientModule{T}}) where T <: RingElement = quotient_module_elem{T}
+elem_type(::Type{QuotientModule{T}}) where T <: RingElement = QuotientModuleElem{T}
 
-parent(v::quotient_module_elem) = v.parent
+parent(v::QuotientModuleElem) = v.parent
 
 base_ring(N::QuotientModule{T}) where T <: RingElement = N.base_ring
 
-base_ring(v::quotient_module_elem{T}) where T <: RingElement = base_ring(v.parent)
+base_ring(v::QuotientModuleElem{T}) where T <: RingElement = base_ring(v.parent)
 
 ngens(N::QuotientModule{T}) where T <: RingElement = length(N.gen_cols)
 
@@ -30,7 +30,7 @@ function gen(N::QuotientModule{T}, i::Int) where T <: RingElement
    R = base_ring(N)
    mat = matrix(R, 1, ngens(N),
                 [(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])
-   return quotient_module_elem{T}(N, mat)
+   return QuotientModuleElem{T}(N, mat)
 end
 
 @doc Markdown.doc"""
@@ -73,7 +73,7 @@ function show(io::IO, N::QuotientModule{T}) where T <: FieldElement
    show_gens_rels(io, N)
 end
 
-function show(io::IO, v::quotient_module_elem)
+function show(io::IO, v::QuotientModuleElem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
@@ -129,7 +129,7 @@ function (N::QuotientModule{T})(v::Vector{T}) where T <: RingElement
    length(v) != ngens(N) && error("Length of vector does not match number of generators")
    mat = matrix(base_ring(N), 1, length(v), v)
    mat = reduce_mod_rels(mat, rels(N), 1)
-   return quotient_module_elem{T}(N, mat)
+   return QuotientModuleElem{T}(N, mat)
 end
 
 function (M::QuotientModule{T})(a::Vector{Any}) where T <: Union{RingElement, NCRingElem}
@@ -139,9 +139,9 @@ end
 
 function (N::QuotientModule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingElement
    ncols(v) != ngens(N) && error("Length of vector does not match number of generators")
-   nrows(v) != 1 && ("Not a vector in quotient_module_elem constructor")
+   nrows(v) != 1 && ("Not a vector in QuotientModuleElem constructor")
    v = reduce_mod_rels(v, rels(N), 1)
-   return quotient_module_elem{T}(N, v)
+   return QuotientModuleElem{T}(N, v)
 end
 
 function (M::QuotientModule{T})(a::AbstractAlgebra.FPModuleElem{T}) where T <: RingElement

--- a/src/generic/Submodule.jl
+++ b/src/generic/Submodule.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export Submodule, submodule_elem, ngens, gens, supermodule, sub
+export Submodule, SubmoduleElem, ngens, gens, supermodule, sub
 
 ###############################################################################
 #
@@ -12,15 +12,15 @@ export Submodule, submodule_elem, ngens, gens, supermodule, sub
 #
 ###############################################################################
 
-parent_type(::Type{submodule_elem{T}}) where T <: RingElement = Submodule{T}
+parent_type(::Type{SubmoduleElem{T}}) where T <: RingElement = Submodule{T}
 
-elem_type(::Type{Submodule{T}}) where T <: RingElement = submodule_elem{T}
+elem_type(::Type{Submodule{T}}) where T <: RingElement = SubmoduleElem{T}
 
-parent(v::submodule_elem) = v.parent
+parent(v::SubmoduleElem) = v.parent
 
 base_ring(N::Submodule{T}) where T <: RingElement = N.base_ring
 
-base_ring(v::submodule_elem{T}) where T <: RingElement = base_ring(v.parent)
+base_ring(v::SubmoduleElem{T}) where T <: RingElement = base_ring(v.parent)
 
 ngens(N::Submodule{T}) where T <: RingElement = length(N.gen_cols)
 
@@ -58,7 +58,7 @@ function show(io::IO, N::Submodule{T}) where T <: FieldElement
    show_gens_rels(io, N)
 end
 
-function show(io::IO, v::submodule_elem)
+function show(io::IO, v::SubmoduleElem)
    print(io, "(")
    len = ngens(parent(v))
    for i = 1:len - 1
@@ -81,7 +81,7 @@ function (N::Submodule{T})(v::Vector{T}) where T <: RingElement
    length(v) != ngens(N) && error("Length of vector does not match number of generators")
    mat = matrix(base_ring(N), 1, length(v), v)
    mat = reduce_mod_rels(mat, rels(N), 1)
-   return submodule_elem{T}(N, mat)
+   return SubmoduleElem{T}(N, mat)
 end
 
 function (N::Submodule{T})(v::Vector{Any}) where T <: RingElement
@@ -91,12 +91,12 @@ end
 
 function (N::Submodule{T})(v::AbstractAlgebra.MatElem{T}) where T <: RingElement
    ncols(v) != ngens(N) && error("Length of vector does not match number of generators")
-   nrows(v) != 1 && ("Not a vector in submodule_elem constructor")
+   nrows(v) != 1 && ("Not a vector in SubmoduleElem constructor")
    v = reduce_mod_rels(v, rels(N), 1)
-   return submodule_elem{T}(N, v)
+   return SubmoduleElem{T}(N, v)
 end
 
-function (M::Submodule{T})(a::submodule_elem{T}) where T <: RingElement
+function (M::Submodule{T})(a::SubmoduleElem{T}) where T <: RingElement
    R = parent(a)
    base_ring(R) != base_ring(M) && error("Incompatible modules")
    if R === M

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -12,9 +12,9 @@ export GF
 #
 ###############################################################################
 
-parent_type(::Type{gfelem{T}}) where T <: Integer = GFField{T}
+parent_type(::Type{GFElem{T}}) where T <: Integer = GFField{T}
 
-elem_type(::Type{GFField{T}}) where T <: Integer = gfelem{T}
+elem_type(::Type{GFField{T}}) where T <: Integer = GFElem{T}
 
 @doc Markdown.doc"""
     base_ring(a::GFField)
@@ -23,22 +23,22 @@ elem_type(::Type{GFField{T}}) where T <: Integer = gfelem{T}
 base_ring(a::GFField) = Union{}
 
 @doc Markdown.doc"""
-    base_ring(a::gfelem)
+    base_ring(a::GFElem)
 > Return `Union{}` as this field is not dependent on another field.
 """
-base_ring(a::gfelem) = Union{}
+base_ring(a::GFElem) = Union{}
 
 @doc Markdown.doc"""
-    parent(a::gfelem)
+    parent(a::GFElem)
 > Return the parent of the given finite field element.
 """
-parent(a::gfelem) = a.parent
+parent(a::GFElem) = a.parent
 
-isexact_type(::Type{gfelem{T}}) where T <: Integer = true
+isexact_type(::Type{GFElem{T}}) where T <: Integer = true
 
-isdomain_type(::Type{gfelem{T}}) where T <: Integer = true
+isdomain_type(::Type{GFElem{T}}) where T <: Integer = true
 
-function check_parent(a::gfelem, b::gfelem)
+function check_parent(a::GFElem, b::GFElem)
    a.parent != b.parent && error("Operations on distinct finite fields not supported")
 end
 
@@ -48,7 +48,7 @@ end
 #
 ###############################################################################
 
-function Base.hash(a::gfelem, h::UInt)
+function Base.hash(a::GFElem, h::UInt)
    b = 0xe08f2b4ea1cd2a13%UInt
    return xor(xor(hash(a.d), h), b)
 end
@@ -58,7 +58,7 @@ end
 > Return the additive identity, zero, in the given finite field.
 """
 function zero(R::GFField{T}) where T <: Integer
-   return gfelem{T}(T(0), R)
+   return GFElem{T}(T(0), R)
 end
 
 @doc Markdown.doc"""
@@ -66,7 +66,7 @@ end
 > Return the additive identity, zero, in the given finite field.
 """
 function one(R::GFField{T}) where T <: Integer
-      return gfelem{T}(T(1), R)
+      return GFElem{T}(T(1), R)
 end
 
 @doc Markdown.doc"""
@@ -74,27 +74,27 @@ end
 > Return a generator of the field. Currently this returns 1.
 """
 function gen(R::GFField{T}) where T <: Integer
-      return gfelem{T}(T(1), R)
+      return GFElem{T}(T(1), R)
 end
 
 @doc Markdown.doc"""
-    iszero(a::gfelem{T}) where T <: Integer
+    iszero(a::GFElem{T}) where T <: Integer
 > Return true if the given element of the finite field is zero.
 """
-iszero(a::gfelem{T}) where T <: Integer = a.d == 0
+iszero(a::GFElem{T}) where T <: Integer = a.d == 0
 
 @doc Markdown.doc"""
-    isone(a::gfelem{T}) where T <: Integer
+    isone(a::GFElem{T}) where T <: Integer
 > Return true if the given element of the finite field is one.
 """
-isone(a::gfelem{T}) where T <: Integer = a.d == 1
+isone(a::GFElem{T}) where T <: Integer = a.d == 1
 
 @doc Markdown.doc"""
-    isunit(a::gfelem)
+    isunit(a::GFElem)
 > Return `true` if the given finite field element is invertible, i.e. nonzero,
 > otherwise return `false`.
 """
-isunit(a::gfelem) = a.d != 0
+isunit(a::GFElem) = a.d != 0
 
 @doc Markdown.doc"""
     characteristic(R::GFField)
@@ -120,9 +120,9 @@ function degree(R::GFField)
    return 1
 end
 
-function deepcopy_internal(a::gfelem{T}, dict::IdDict) where T <: Integer
+function deepcopy_internal(a::GFElem{T}, dict::IdDict) where T <: Integer
    R = parent(a)
-   return gfelem{T}(deepcopy(a.d), R)
+   return GFElem{T}(deepcopy(a.d), R)
 end
 
 ###############################################################################
@@ -131,7 +131,7 @@ end
 #
 ###############################################################################
 
-canonical_unit(x::gfelem) = x
+canonical_unit(x::GFElem) = x
 
 ###############################################################################
 #
@@ -139,7 +139,7 @@ canonical_unit(x::gfelem) = x
 #
 ###############################################################################
 
-function show(io::IO, x::gfelem)
+function show(io::IO, x::GFElem)
    print(io, x.d)
 end
 
@@ -147,11 +147,11 @@ function show(io::IO, R::GFField)
    print(io, "Finite field F_", R.p)
 end
 
-needs_parentheses(x::gfelem) = false
+needs_parentheses(x::GFElem) = false
 
-displayed_with_minus_in_front(x::gfelem) = false
+displayed_with_minus_in_front(x::GFElem) = false
 
-show_minus_one(::Type{gfelem{T}}) where T <: Integer = true
+show_minus_one(::Type{GFElem{T}}) where T <: Integer = true
 
 ###############################################################################
 #
@@ -159,12 +159,12 @@ show_minus_one(::Type{gfelem{T}}) where T <: Integer = true
 #
 ###############################################################################
 
-function -(x::gfelem{T}) where T <: Integer
+function -(x::GFElem{T}) where T <: Integer
    if x.d == 0
       return deepcopy(x)
    else
       R = parent(x)
-      return gfelem{T}(R.p - x.d, R)
+      return GFElem{T}(R.p - x.d, R)
    end
 end
 
@@ -174,31 +174,31 @@ end
 #
 ###############################################################################
 
-function +(x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function +(x::GFElem{T}, y::GFElem{T}) where T <: Integer
    check_parent(x, y)
    R = parent(x)
    p = characteristic(R)::T
    d = x.d + y.d - p
    if d < 0
-      return gfelem{T}(d + p, R)
+      return GFElem{T}(d + p, R)
    else
-      return gfelem{T}(d, R)
+      return GFElem{T}(d, R)
    end
 end
 
-function -(x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function -(x::GFElem{T}, y::GFElem{T}) where T <: Integer
    check_parent(x, y)
    R = parent(x)
    p = characteristic(R)::T
    d = x.d - y.d
    if d < 0
-      return gfelem{T}(d + p, R)
+      return GFElem{T}(d + p, R)
    else
-      return gfelem{T}(d, R)
+      return GFElem{T}(d, R)
    end
 end
 
-function *(x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function *(x::GFElem{T}, y::GFElem{T}) where T <: Integer
    check_parent(x, y)
    R = parent(x)
    return R(widen(x.d)*widen(y.d))
@@ -210,12 +210,12 @@ end
 #
 ###############################################################################
 
-function *(x::Integer, y::gfelem{T}) where T <: Integer
+function *(x::Integer, y::GFElem{T}) where T <: Integer
    R = parent(y)
    return R(widen(x)*widen(y.d))
 end
 
-*(x::gfelem{T}, y::Integer) where T <: Integer = y*x
+*(x::GFElem{T}, y::Integer) where T <: Integer = y*x
 
 ###############################################################################
 #
@@ -223,7 +223,7 @@ end
 #
 ###############################################################################
 
-function ^(x::gfelem{T}, y::Integer) where T <: Integer
+function ^(x::GFElem{T}, y::Integer) where T <: Integer
    R = parent(x)
    p = R.p::T
    if x.d == 0
@@ -263,7 +263,7 @@ end
 #
 ###############################################################################
 
-function ==(x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function ==(x::GFElem{T}, y::GFElem{T}) where T <: Integer
    check_parent(x, y)
    return x.d == y.d
 end
@@ -274,7 +274,7 @@ end
 #
 ###############################################################################
 
-function inv(x::gfelem{T}) where T <: Integer
+function inv(x::GFElem{T}) where T <: Integer
    x == 0 && throw(DivideError())
    R = parent(x)
    p = R.p::T
@@ -289,12 +289,12 @@ end
 #
 ###############################################################################
 
-function divexact(x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function divexact(x::GFElem{T}, y::GFElem{T}) where T <: Integer
    check_parent(x, y)
    return x*inv(y)
 end
 
-divides(a::gfelem{T}, b::gfelem{T}) where T <: Integer = true, divexact(a, b)
+divides(a::GFElem{T}, b::GFElem{T}) where T <: Integer = true, divexact(a, b)
 
 ###############################################################################
 #
@@ -302,46 +302,46 @@ divides(a::gfelem{T}, b::gfelem{T}) where T <: Integer = true, divexact(a, b)
 #
 ###############################################################################
 
-function zero!(z::gfelem{T}) where T <: Integer
+function zero!(z::GFElem{T}) where T <: Integer
    R = parent(z)
    d = zero!(z.d)
-   return gfelem{T}(d, R)
+   return GFElem{T}(d, R)
 end
 
-function mul!(z::gfelem{T}, x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function mul!(z::GFElem{T}, x::GFElem{T}, y::GFElem{T}) where T <: Integer
    return x*y
 end
 
-function mul!(z::gfelem{BigInt}, x::gfelem{BigInt}, y::gfelem{BigInt})
+function mul!(z::GFElem{BigInt}, x::GFElem{BigInt}, y::GFElem{BigInt})
    R = parent(x)
    p = R.p::BigInt
    d = mul!(z.d, x.d, y.d)
    if d >= p
-      return gfelem{BigInt}(d%p, R)
+      return GFElem{BigInt}(d%p, R)
    else
-      return gfelem{BigInt}(d, R)
+      return GFElem{BigInt}(d, R)
    end
 end
 
-function addeq!(z::gfelem{T}, x::gfelem{T}) where T <: Integer
+function addeq!(z::GFElem{T}, x::GFElem{T}) where T <: Integer
    R = parent(x)
    p = R.p::T
    d = addeq!(z.d, x.d)
    if d < p
-      return gfelem{T}(d, R)
+      return GFElem{T}(d, R)
    else
-      return gfelem{T}(d - p, R)
+      return GFElem{T}(d - p, R)
    end
 end
 
-function add!(z::gfelem{T}, x::gfelem{T}, y::gfelem{T}) where T <: Integer
+function add!(z::GFElem{T}, x::GFElem{T}, y::GFElem{T}) where T <: Integer
    R = parent(x)
    p = R.p::T
    d = add!(z.d, x.d, y.d)
    if d < p
-      return gfelem{T}(d, R)
+      return GFElem{T}(d, R)
    else
-      return gfelem{T}(d - p, R)
+      return GFElem{T}(d - p, R)
    end
 end
 
@@ -355,7 +355,7 @@ Random.Sampler(RNG::Type{<:AbstractRNG}, R::GFField, n::Random.Repetition) =
    Random.SamplerSimple(R, Random.Sampler(RNG, 0:R.p - 1, n))
 
 rand(rng::AbstractRNG, R::Random.SamplerSimple{GFField{T}}) where T =
-   gfelem{T}(rand(rng, R.data), R[])
+   GFElem{T}(rand(rng, R.data), R[])
 
 Random.gentype(T::Type{<:GFField}) = elem_type(T)
 
@@ -365,7 +365,7 @@ Random.gentype(T::Type{<:GFField}) = elem_type(T)
 #
 ###############################################################################
 
-promote_rule(::Type{gfelem{S}}, ::Type{T}) where {S <: Integer, T <: Integer} = gfelem{S}
+promote_rule(::Type{GFElem{S}}, ::Type{T}) where {S <: Integer, T <: Integer} = GFElem{S}
 
 ###############################################################################
 #
@@ -374,7 +374,7 @@ promote_rule(::Type{gfelem{S}}, ::Type{T}) where {S <: Integer, T <: Integer} = 
 ###############################################################################
 
 function (R::GFField{T})() where T <: Integer
-   return gfelem{T}(T(0), R)
+   return GFElem{T}(T(0), R)
 end
 
 function (R::GFField{T})(a::Integer) where T <: Integer
@@ -383,10 +383,10 @@ function (R::GFField{T})(a::Integer) where T <: Integer
    if d < 0
       d += p
    end
-   return gfelem{T}(d, R)
+   return GFElem{T}(d, R)
 end
 
-function (R::GFField{T})(a::gfelem{T}) where T <: Integer
+function (R::GFField{T})(a::GFElem{T}) where T <: Integer
    parent(a) != R && error("Coercion between finite fields not implemented")
    return a
 end

--- a/src/julia/JuliaTypes.jl
+++ b/src/julia/JuliaTypes.jl
@@ -61,7 +61,7 @@ const FloatsID = Dict{DataType, Field}()
 
 ###############################################################################
 #
-#   GFField/gfelem
+#   GFField/GFElem
 #
 ###############################################################################
 
@@ -81,7 +81,7 @@ end
 
 const GFFieldID = Dict{Tuple{DataType, Integer}, Field}()
 
-struct gfelem{T <: Integer} <: FinFieldElem
+struct GFElem{T <: Integer} <: FinFieldElem
    d::T
    parent::GFField{T}
 end

--- a/test/Fields-test.jl
+++ b/test/Fields-test.jl
@@ -2,4 +2,4 @@ include("generic/Fraction-test.jl")
 
 include("julia/Rationals-test.jl")
 include("julia/Floats-test.jl")
-include("julia/gfelem-test.jl")
+include("julia/GFElem-test.jl")

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -16,7 +16,7 @@ include("generic/MPoly-test.jl")
 end
 
 @testset "Generic.Rings.{elem,parent}_type" begin
-   for (R, el, par) in [(GF(3), AbstractAlgebra.gfelem{Int}, AbstractAlgebra.GFField{Int}),
+   for (R, el, par) in [(GF(3), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}),
                         (ZZ["x"][1], Generic.Poly{BigInt}, Generic.PolyRing{BigInt})]
       x = R(2)
       @test elem_type(R) == el

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -19,7 +19,7 @@ using Random
    D, h = DirectSum(Q)
    m = D([])
 
-   @test isa(m, Generic.direct_sum_module_elem)
+   @test isa(m, Generic.DirectSumModuleElem)
 end
 
 @testset "Generic.DirectSum.basic_manipulation..." begin

--- a/test/generic/FreeModule-test.jl
+++ b/test/generic/FreeModule-test.jl
@@ -4,17 +4,17 @@
 
    @test isa(M, Generic.FreeModule)
 
-   @test elem_type(M) == Generic.free_module_elem{elem_type(R)}
-   @test elem_type(Generic.FreeModule{elem_type(R)}) == Generic.free_module_elem{elem_type(R)}
-   @test parent_type(Generic.free_module_elem{elem_type(R)}) == Generic.FreeModule{elem_type(R)}
+   @test elem_type(M) == Generic.FreeModuleElem{elem_type(R)}
+   @test elem_type(Generic.FreeModule{elem_type(R)}) == Generic.FreeModuleElem{elem_type(R)}
+   @test parent_type(Generic.FreeModuleElem{elem_type(R)}) == Generic.FreeModule{elem_type(R)}
 
    @test isa(M, Generic.FreeModule)
 
-   @test isa(M([x, x, x, x, x]), Generic.free_module_elem)
+   @test isa(M([x, x, x, x, x]), Generic.FreeModuleElem)
 
    F = FreeModule(ZZ, 0)
 
-   @test isa(F([]), Generic.free_module_elem)
+   @test isa(F([]), Generic.FreeModuleElem)
 end
 
 @testset "Generic.FreeModule.manipulation..." begin

--- a/test/generic/InvariantFactorDecomposition-test.jl
+++ b/test/generic/InvariantFactorDecomposition-test.jl
@@ -13,7 +13,7 @@
    D, f = snf(F)
    m = D([])
 
-   @test isa(m, Generic.snf_module_elem)
+   @test isa(m, Generic.SNFModuleElem)
 end
 
 @testset "Generic.InvariantFactorDecomposition.invariant_factors..." begin

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -16,9 +16,9 @@ end
 @testset "Generic.Module.rand..." begin
    F = FreeModule(ZZ, 3)
    f = rand(F, 1:9)
-   @test f isa Generic.free_module_elem
+   @test f isa Generic.FreeModuleElem
    f = rand(rng, F, 1:9)
-   @test f isa Generic.free_module_elem
+   @test f isa Generic.FreeModuleElem
 end
 
 @testset "Generic.Module.manipulation..." begin

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -14,11 +14,11 @@
 
    @test isa(Q, Generic.QuotientModule)
 
-   @test elem_type(Q) == Generic.quotient_module_elem{elem_type(R)}
-   @test elem_type(Generic.QuotientModule{elem_type(R)}) == Generic.quotient_module_elem{elem_type(R)}
-   @test parent_type(Generic.quotient_module_elem{elem_type(R)}) == Generic.QuotientModule{elem_type(R)}
+   @test elem_type(Q) == Generic.QuotientModuleElem{elem_type(R)}
+   @test elem_type(Generic.QuotientModule{elem_type(R)}) == Generic.QuotientModuleElem{elem_type(R)}
+   @test parent_type(Generic.QuotientModuleElem{elem_type(R)}) == Generic.QuotientModule{elem_type(R)}
 
-   @test isa(Q([R(2)]), Generic.quotient_module_elem)
+   @test isa(Q([R(2)]), Generic.QuotientModuleElem)
 
    R = QQ
    M = VectorSpace(R, 2)
@@ -60,7 +60,7 @@
    Q, g = quo(F, S)
    m = Q([])
 
-   @test isa(m, Generic.quotient_module_elem)
+   @test isa(m, Generic.QuotientModuleElem)
 end
 
 @testset "Generic.QuotientModule.manipulation..." begin

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -12,11 +12,11 @@
 
    @test isa(N, Generic.Submodule)
 
-   @test elem_type(N) == Generic.submodule_elem{elem_type(R)}
-   @test elem_type(Generic.Submodule{elem_type(R)}) == Generic.submodule_elem{elem_type(R)}
-   @test parent_type(Generic.submodule_elem{elem_type(R)}) == Generic.Submodule{elem_type(R)}
+   @test elem_type(N) == Generic.SubmoduleElem{elem_type(R)}
+   @test elem_type(Generic.Submodule{elem_type(R)}) == Generic.SubmoduleElem{elem_type(R)}
+   @test parent_type(Generic.SubmoduleElem{elem_type(R)}) == Generic.Submodule{elem_type(R)}
 
-   @test isa(N([R(2), R(7)]), Generic.submodule_elem)
+   @test isa(N([R(2), R(7)]), Generic.SubmoduleElem)
 
    F = FreeModule(R, 5)
    nsubs = rand(0:5)
@@ -50,7 +50,7 @@
    m = S([])
 
    @test isa(S, Generic.Submodule)
-   @test isa(m, Generic.submodule_elem)
+   @test isa(m, Generic.SubmoduleElem)
 end
 
 @testset "Generic.Submodule.manipulation..." begin

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -1,33 +1,33 @@
-@testset "Julia.gfelem.constructors..." begin
+@testset "Julia.GFElem.constructors..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
-   @test elem_type(R) == AbstractAlgebra.gfelem{Int}
-   @test elem_type(S) == AbstractAlgebra.gfelem{BigInt}
-   @test elem_type(AbstractAlgebra.GFField{Int}) == AbstractAlgebra.gfelem{Int}
-   @test elem_type(AbstractAlgebra.GFField{BigInt}) == AbstractAlgebra.gfelem{BigInt}
-   @test parent_type(AbstractAlgebra.gfelem{Int}) == AbstractAlgebra.GFField{Int}
-   @test parent_type(AbstractAlgebra.gfelem{BigInt}) == AbstractAlgebra.GFField{BigInt}
+   @test elem_type(R) == AbstractAlgebra.GFElem{Int}
+   @test elem_type(S) == AbstractAlgebra.GFElem{BigInt}
+   @test elem_type(AbstractAlgebra.GFField{Int}) == AbstractAlgebra.GFElem{Int}
+   @test elem_type(AbstractAlgebra.GFField{BigInt}) == AbstractAlgebra.GFElem{BigInt}
+   @test parent_type(AbstractAlgebra.GFElem{Int}) == AbstractAlgebra.GFField{Int}
+   @test parent_type(AbstractAlgebra.GFElem{BigInt}) == AbstractAlgebra.GFField{BigInt}
 
    @test isa(R, AbstractAlgebra.GFField)
    @test isa(S, AbstractAlgebra.GFField)
 
-   @test isa(R(), AbstractAlgebra.gfelem)
-   @test isa(S(), AbstractAlgebra.gfelem)
+   @test isa(R(), AbstractAlgebra.GFElem)
+   @test isa(S(), AbstractAlgebra.GFElem)
 
-   @test isa(R(11), AbstractAlgebra.gfelem)
-   @test isa(S(BigInt(11)), AbstractAlgebra.gfelem)
-   @test isa(S(11), AbstractAlgebra.gfelem)
-   @test isa(S(BigInt(11)), AbstractAlgebra.gfelem)
+   @test isa(R(11), AbstractAlgebra.GFElem)
+   @test isa(S(BigInt(11)), AbstractAlgebra.GFElem)
+   @test isa(S(11), AbstractAlgebra.GFElem)
+   @test isa(S(BigInt(11)), AbstractAlgebra.GFElem)
 
    a = R(11)
    b = S(11)
 
-   @test isa(R(a), AbstractAlgebra.gfelem)
-   @test isa(S(b), AbstractAlgebra.gfelem)
+   @test isa(R(a), AbstractAlgebra.GFElem)
+   @test isa(S(b), AbstractAlgebra.GFElem)
 end
 
-@testset "Julia.gfelem.printing..." begin
+@testset "Julia.GFElem.printing..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -37,7 +37,7 @@ end
    @test string(S()) == "0"
 end
 
-@testset "Julia.gfelem.manipulation..." begin
+@testset "Julia.GFElem.manipulation..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -71,15 +71,15 @@ end
    @test S === S1
 end
 
-@testset "Julia.gfelem.rand..." begin
+@testset "Julia.GFElem.rand..." begin
    R = GF(13)
-   @test rand(R) isa AbstractAlgebra.gfelem
-   @test rand(rng, R) isa AbstractAlgebra.gfelem
-   @test rand(R, 2, 3) isa Matrix{<:AbstractAlgebra.gfelem}
-   @test rand(rng, R, 2, 3) isa Matrix{<:AbstractAlgebra.gfelem}
+   @test rand(R) isa AbstractAlgebra.GFElem
+   @test rand(rng, R) isa AbstractAlgebra.GFElem
+   @test rand(R, 2, 3) isa Matrix{<:AbstractAlgebra.GFElem}
+   @test rand(rng, R, 2, 3) isa Matrix{<:AbstractAlgebra.GFElem}
 end
 
-@testset "Julia.gfelem.unary_ops..." begin
+@testset "Julia.GFElem.unary_ops..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -92,7 +92,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.binary_ops..." begin
+@testset "Julia.GFElem.binary_ops..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -125,7 +125,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.adhoc_binary..." begin
+@testset "Julia.GFElem.adhoc_binary..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -159,7 +159,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.powering..." begin
+@testset "Julia.GFElem.powering..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -199,7 +199,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.comparison..." begin
+@testset "Julia.GFElem.comparison..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -220,7 +220,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.adhoc_comparison..." begin
+@testset "Julia.GFElem.adhoc_comparison..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -240,7 +240,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.inversion..." begin
+@testset "Julia.GFElem.inversion..." begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -256,7 +256,7 @@ end
    end
 end
 
-@testset "Julia.gfelem.exact_division..." begin
+@testset "Julia.GFElem.exact_division..." begin
    R = GF(13)
    S = GF(BigInt(13))
 


### PR DESCRIPTION
This was quite simpler than renaming `perm` to `Perm`, which required manual renaming because `perm` occured a lot in places which shouldn't be updated. Here `sed` was enough.

rename gfelem -> GFElem
rename free_module_elem -> FreeModuleElem
rename direct_sum_module_elem -> DirectSumModuleElem
rename quotient_module_elem -> QuotientModuleElem
rename snf_module_elem -> SNFModuleElem
rename submodule_elem -> SubmoduleElem