### PR TITLE
make an API to modify ZZ, QQ, RealField

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -730,6 +730,9 @@ PermutationGroup = PermGroup
 ZZ = JuliaZZ
 QQ = JuliaQQ
 
+setZZ(newZZ::Ring) = global ZZ = newZZ
+setQQ(newQQ::Ring) = global QQ = newQQ
+
 ###############################################################################
 #
 #   Set domain for RealField
@@ -737,6 +740,8 @@ QQ = JuliaQQ
 ###############################################################################
 
 RealField = JuliaRealField
+
+setRealField(newRealField::Ring) = global RealField = newRealField
 
 ###############################################################################
 #


### PR DESCRIPTION
These variables are not `const`, which suggests that they are meant to be re-assigned. On the other hand, it's not so straightforward to re-assign it:
```julia
julia> using AbstractAlgebra

julia> ZZ
Integers

julia> using Nemo

Welcome to Nemo version 0.14.3

Nemo comes with absolutely no warranty whatsoever

WARNING: using Nemo.ZZ in module Main conflicts with an existing identifier.

julia> ZZ
Integers

julia> ZZ = FlintZZ
ERROR: cannot assign a value to variable AbstractAlgebra.ZZ from module Main
Stacktrace:
 [1] top-level scope at REPL[6]:1

julia> AbstractAlgebra.ZZ = FlintZZ
ERROR: cannot assign variables in other modules
Stacktrace:
 [1] setproperty!(::Module, ::Symbol, ::FlintIntegerRing) at ./Base.jl:27
 [2] top-level scope at REPL[7]:1

julia> @eval AbstractAlgebra ZZ = FlintZZ
ERROR: UndefVarError: FlintZZ not defined
Stacktrace:
 [1] top-level scope at REPL[11]:1
 [2] eval(::Module, ::Any) at ./boot.jl:330
 [3] top-level scope at REPL[11]:1

julia> @eval AbstractAlgebra ZZ = $FlintZZ
Integer Ring

julia> ZZ === FlintZZ
true
```
So three functions are proposed here, `setZZ`, `setQQ` and `setRealField` to re-assign the corresponding variables inside `AbstractAlgebra`, which allows to do for example `AbstractAlgebra.setZZ(FlintZZ)`.