### PR TITLE
fix #450, safer perm_str macro

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -795,14 +795,24 @@ end
 function parse_cycles(str::AbstractString)
    ccycles = Int[]
    cptrs = Int[1]
-   if occursin(r"\n|\s| ", str)
-      str = replace(str, r"\n|\s| " => "")
+   if startswith(str, "Cycle Decomposition: ")
+      str = str[22:end]
    end
+   if occursin(r"\d\s+\d", str)
+      throw(ArgumentError("could not parse string as cycles: $str"))
+   end
+   str = replace(str, r"\s+" => "")
+   str = replace(str, "()" => "")
    cycle_regex = r"\(\d+(,\d+)*\)?"
+   parsed_size = 0
    for cycle_str in (m.match for m = eachmatch(cycle_regex, str))
+      parsed_size += sizeof(cycle_str)
       cycle = [parse(Int, a) for a in split(cycle_str[2:end-1], ",")]
       append!(ccycles, cycle)
       push!(cptrs, cptrs[end]+length(cycle))
+   end
+   if parsed_size != sizeof(str)
+      throw(ArgumentError("could not parse string as cycles: $str"))
    end
    return ccycles, cptrs
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -50,9 +50,11 @@ end
 @testset "Perm.parsingGAP..." begin
    @test Generic.parse_cycles("()") == (Int[], [1])
    @test Generic.parse_cycles("(1)(2)(3)") == ([1,2,3], [1,2,3,4])
-   @test Generic.parse_cycles("Cycle decomposition: (1)(2,3)") == ([1,2,3], [1,2,4])
+   @test Generic.parse_cycles("Cycle Decomposition: (1)(2,3)") == ([1,2,3], [1,2,4])
    @test Generic.parse_cycles("(1)(\n2, 3)") == ([1,2,3], [1,2,4])
    @test Generic.parse_cycles("(3,2,1)(4,5)") == ([3,2,1,4,5], [1,4,6])
+   @test_throws ArgumentError Generic.parse_cycles("(a,b)")
+   @test_throws ArgumentError Generic.parse_cycles("(1 2)")
 
    s = """
 ( 1, 22,73,64,78,81,  24 ,89,90,54,51,82,91,53, 18


### PR DESCRIPTION
This make `perm"(a, b)"` error out ~~and `perm"(1 2)"` equivalent to `perm"(1,2)"`. I can change the latter to producing an error if desired.~~ (EDIT: I suppressed this possibility, it was making the regex code more complicated. It can be added later.)
