### PR TITLE
Clean up import/export and fix #440

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -18,20 +18,71 @@ import LinearAlgebra: lu, lu!, tr
 
 export nullspace
 
-# Do not import div, divrem, exp, sqrt, numerator or denominator as we define our own
-import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh,
-             bin, ceil, checkbounds, conj, convert, cmp, cos, cosh,
-             cospi, cot, coth, dec, deepcopy, deepcopy_internal,
-             expm1, exponent, fill, floor, gcd, gcdx,
-             getindex, hash, hcat, hex, hypot, intersect, inv, invmod, isequal,
-             isfinite, isless, isone, isqrt, isreal, iszero, lcm, ldexp, length,
-             log, log1p, mod, ndigits,
-             oct, one, parent, parse, precision,
-             rand, Rational, rem, reverse,
-             setindex!, show, sincos, similar, sign, sin, sinh, sinpi, size, string,
-             tan, tanh, trailing_zeros, transpose, truncate,
-             typed_hvcat, typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^,
-             &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
+################################################################################
+#
+#  Import/export philosophy
+#
+#  For certain julia Base types and Base function, e.g. BigInt and div or exp, we
+#  need a different behavior. These functions are not exported.
+#
+#  Take for example exp. Since exp is not imported from Base, there are two exp
+#  functions, AbstractAlgebra.exp and Base.exp. Inside AbstractAlgebra, exp
+#  will always refer to AbstractAlgebra.exp. When calling the function, one
+#  should just use "exp" without namespace qualifcation.
+#
+#  On the other hand, if an AbstractAlgebra type wants to add a method to exp,
+#  it must add a method to "Base.exp".
+#
+#  The rational for this is as follows: If we do "using AbstractAlgebra" in the
+#  REPL, then "exp" will refer to the Base.exp. So if we want to make exp(a)
+#  work in the REPL for an AbstractAlgebra type, we have to overload Base.exp.
+#
+################################################################################
+
+# This is the list of functions for which we locally have a different behavior.
+const Base_import_exclude = [:exp, :sqrt, :div, :divrem, :numerator, :denominator]
+
+################################################################################
+#
+#  Functions that we do not import from Base
+#
+################################################################################
+
+function exp(a::T) where T
+   return Base.exp(a)
+end
+
+function sqrt(a::T) where T
+  return Base.sqrt(a)
+end
+
+function divrem(a::T, b::T) where T
+  return Base.divrem(a, b)
+end
+
+function div(a::T, b::T) where T
+  return Base.div(a, b)
+end
+
+function numerator(a::T, canonicalise::Bool=true) where T
+  return Base.numerator(a, canonicalise)
+end
+
+function denominator(a::T, canonicalise::Bool=true) where T
+  return Base.denominator(a, canonicalise)
+end
+
+import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh, bin,
+             ceil, checkbounds, conj, convert, cmp, cos, cosh, cospi, cot,
+             coth, dec, deepcopy, deepcopy_internal, expm1, exponent, fill,
+             floor, gcd, gcdx, getindex, hash, hcat, hex, hypot, intersect,
+             inv, invmod, isequal, isfinite, isless, isone, isqrt, isreal,
+             iszero, lcm, ldexp, length, log, log1p, mod, ndigits, oct, one,
+             parent, parse, precision, rand, Rational, rem, reverse, setindex!,
+             show, sincos, similar, sign, sin, sinh, sinpi, size, string, tan,
+             tanh, trailing_zeros, transpose, truncate, typed_hvcat,
+             typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^, &, |, <<, >>,
+             ~, <=, >=, <, >, //, /, !=
 
 using Random: Random, AbstractRNG
 
@@ -94,6 +145,7 @@ end
 ###############################################################################
 
 include("julia/JuliaTypes.jl")
+
 
 ###############################################################################
 #
@@ -258,29 +310,11 @@ export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, ad
                  weak_popov_with_transform, zero, zero!, zero_matrix,
                  @PolynomialRing, MatrixElem
 
-function exp(a::T) where T
-   return Base.exp(a)
-end
-
-function sqrt(a::T) where T
-  return Base.sqrt(a)
-end
-
-function divrem(a::T, b::T) where T
-  return Base.divrem(a, b)
-end
-
-function div(a::T, b::T) where T
-  return Base.div(a, b)
-end
-
-function numerator(a::T, canonicalise::Bool=true) where T
-  return Base.numerator(a, canonicalise)
-end
-
-function denominator(a::T, canonicalise::Bool=true) where T
-  return Base.denominator(a, canonicalise)
-end
+################################################################################
+#
+#   Parent constructors
+#
+################################################################################
 
 function PermGroup(n::T) where T
   Generic.PermGroup(n)

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -11,29 +11,30 @@ import LinearAlgebra: lu, lu!, tr
 
 using Markdown, Random, InteractiveUtils
 
-import Base: Array, abs, asin, asinh, atan, atanh, bin, checkbounds,
-             cmp, conj, convert, copy, cos, cosh, dec, deepcopy,
-             deepcopy_internal, div, divrem,
-             exp, exponent, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
-             invmod, isapprox, isempty, isequal, isfinite, isless, isqrt, isreal, iszero,
-             lcm, ldexp, length, log, mod, ndigits,
-             oct, one, parent, parse, precision,
-             rand, Rational, rem, reverse,
-             setindex!, show, similar, sign, sin, sinh, size, string,
-             tan, tanh, trailing_zeros, transpose, truncate,
-             typed_hvcat, typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^,
-             &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
+import Base: Array, abs, asin, asinh, atan, atanh, bin, checkbounds, cmp, conj,
+             convert, copy, cos, cosh, dec, deepcopy, deepcopy_internal,
+             exponent, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
+             invmod, isapprox, isempty, isequal, isfinite, isless, isqrt,
+             isreal, iszero, lcm, ldexp, length, log, mod, ndigits, oct, one,
+             parent, parse, precision, rand, Rational, rem, reverse, setindex!,
+             show, similar, sign, sin, sinh, size, string, tan, tanh,
+             trailing_zeros, transpose, truncate, typed_hvcat, typed_hcat,
+             vcat, xor, zero, zeros, +, -, *, ==, ^, &, |, <<, >>, ~, <=, >=,
+             <, >, //, /, !=
 
 if VERSION >= v"0.7.0-DEV.1144"
-import Base: isone
+  import Base: isone
 end
 
-import Base: floor, ceil, hypot, log, log1p, exp, expm1, sin, cos, sinpi,
-             cospi, tan, cot, sinh, cosh, tanh, coth, atan, asin, acos, atanh,
-             asinh, acosh, sinpi, cospi
+import Base: floor, ceil, hypot, log, log1p, expm1, sin, cos, sinpi, cospi,
+             tan, cot, sinh, cosh, tanh, coth, atan, asin, acos, atanh, asinh,
+             acosh, sinpi, cospi
 
-import ..AbstractAlgebra: Integers, Rationals, NCRing, NCRingElem, Ring, RingElem,
-       RingElement, Field, FieldElement, Map, promote_rule
+import ..AbstractAlgebra: Integers, Rationals, NCRing, NCRingElem, Ring,
+                          RingElem, RingElement, Field, FieldElement, Map,
+                          promote_rule
+
+import ..AbstractAlgebra: exp, sqrt, div, divrem, numerator, denominator
 
 using ..AbstractAlgebra
 

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -184,7 +184,7 @@ isdomain_type(R::Type{T}) where T <: RingElem = false
 #
 ###############################################################################
 
-function exp(a::T) where {T <: RingElem}
+function Base.exp(a::RingElem)
    a != 0 && error("Exponential of nonzero element")
    return one(parent(a))
 end

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export O, valuation, exp, precision, max_precision, set_prec!
+export O, valuation, precision, max_precision, set_prec!
 
 ###############################################################################
 #
@@ -754,7 +754,7 @@ function Base.sqrt(a::AbstractAlgebra.AbsSeriesElem)
       asqrt = setcoeff!(asqrt, n - 1, R())
    end
    if prec > aval2
-      g = AbstractAlgebra.sqrt(coeff(a, aval))
+      g = sqrt(coeff(a, aval))
       setcoeff!(asqrt, aval2, g)
       g2 = g + g
    end
@@ -799,7 +799,7 @@ function Base.exp(a::AbstractAlgebra.AbsSeriesElem)
    z = parent(a)()
    fit!(z, precision(a))
    set_prec!(z, precision(a))
-   z = setcoeff!(z, 0, AbstractAlgebra.exp(coeff(a, 0)))
+   z = setcoeff!(z, 0, exp(coeff(a, 0)))
    len = length(a)
    for k = 1 : precision(a) - 1
       s = zero(base_ring(a))

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -88,7 +88,7 @@ end
 function Base.hash(a::AbstractAlgebra.FracElem, h::UInt)
    b = 0x8a30b0d963237dd5%UInt
    # We canonicalise before hashing
-   return xor(b, hash(AbstractAlgebra.numerator(a, true), h), hash(AbstractAlgebra.denominator(a, true), h), h)
+   return xor(b, hash(numerator(a, true), h), hash(denominator(a, true), h), h)
 end
 
 function Base.numerator(a::Frac, canonicalise::Bool=true)
@@ -136,24 +136,24 @@ one(R::AbstractAlgebra.FracField) = R(1)
 > Return `true` if the supplied element $a$ is zero in the fraction field it
 > belongs to, otherwise return `false`.
 """
-iszero(a::AbstractAlgebra.FracElem) = iszero(AbstractAlgebra.numerator(a, false))
+iszero(a::AbstractAlgebra.FracElem) = iszero(numerator(a, false))
 
 @doc Markdown.doc"""
     isone(a::AbstractAlgebra.FracElem)
 > Return `true` if the supplied element $a$ is one in the fraction field it
 > belongs to, otherwise return `false`.
 """
-isone(a::AbstractAlgebra.FracElem) = AbstractAlgebra.numerator(a, false) == AbstractAlgebra.denominator(a, false)
+isone(a::AbstractAlgebra.FracElem) = numerator(a, false) == denominator(a, false)
 
 @doc Markdown.doc"""
     isunit(a::AbstractAlgebra.FracElem)
 > Return `true` if the supplied element $a$ is invertible in the fraction field
-> it belongs to, i.e. the AbstractAlgebra.numerator is nonzero, otherwise return `false`.
+> it belongs to, i.e. the numerator is nonzero, otherwise return `false`.
 """
-isunit(a::AbstractAlgebra.FracElem) = !iszero(AbstractAlgebra.numerator(a, false))
+isunit(a::AbstractAlgebra.FracElem) = !iszero(numerator(a, false))
 
 function deepcopy_internal(a::Frac{T}, dict::IdDict) where {T <: RingElem}
-   v = Frac{T}(deepcopy(AbstractAlgebra.numerator(a, false)), deepcopy(AbstractAlgebra.denominator(a, false)))
+   v = Frac{T}(deepcopy(numerator(a, false)), deepcopy(denominator(a, false)))
    v.parent = parent(a)
    return v
 end
@@ -174,8 +174,8 @@ canonical_unit(a::AbstractAlgebra.FracElem) = a
 
 function show(io::IO, x::AbstractAlgebra.FracElem)
    # Canonicalise for display
-   n = AbstractAlgebra.numerator(x, true)
-   d = AbstractAlgebra.denominator(x, true)
+   n = numerator(x, true)
+   d = denominator(x, true)
    if !isone(d) && needs_parentheses(n)
       print(io, "(")
    end
@@ -196,11 +196,11 @@ function show(io::IO, a::AbstractAlgebra.FracField)
 end
 
 # Parentheses are only needed for fractions if we didn't print them already
-needs_parentheses(x::AbstractAlgebra.FracElem) = isone(AbstractAlgebra.denominator(x, true)) &&
-                                     needs_parentheses(AbstractAlgebra.numerator(x, true))
+needs_parentheses(x::AbstractAlgebra.FracElem) = isone(denominator(x, true)) &&
+                                     needs_parentheses(numerator(x, true))
 
 function displayed_with_minus_in_front(x::AbstractAlgebra.FracElem)
-   n = AbstractAlgebra.numerator(x, true)
+   n = numerator(x, true)
    return !needs_parentheses(n) && displayed_with_minus_in_front(n)
 end
 
@@ -219,7 +219,7 @@ end
 > Return $-a$.
 """
 function -(a::AbstractAlgebra.FracElem)
-   return parent(a)(-AbstractAlgebra.numerator(a, false), deepcopy(AbstractAlgebra.denominator(a, false)))
+   return parent(a)(-numerator(a, false), deepcopy(denominator(a, false)))
 end
 
 ###############################################################################
@@ -234,10 +234,10 @@ end
 """
 function +(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
-   d1 = AbstractAlgebra.denominator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n1 = AbstractAlgebra.numerator(a, false)
-   n2 = AbstractAlgebra.numerator(b, false)
+   d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    if d1 == d2
       rnum = n1 + n2
       if isone(d1)
@@ -285,10 +285,10 @@ end
 """
 function -(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
-   d1 = AbstractAlgebra.denominator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n1 = AbstractAlgebra.numerator(a, false)
-   n2 = AbstractAlgebra.numerator(b, false)
+   d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    if d1 == d2
       rnum = n1 - n2
       if isone(d1)
@@ -336,10 +336,10 @@ end
 """
 function *(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
-   n1 = AbstractAlgebra.numerator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n2 = AbstractAlgebra.numerator(b, false)
-   d1 = AbstractAlgebra.denominator(a, false)
+   n1 = numerator(a, false)
+   d2 = denominator(b, false)
+   n2 = numerator(b, false)
+   d1 = denominator(a, false)
    if d1 == d2
       n = n1*n2
       d = d1*d2
@@ -390,9 +390,9 @@ end
 """
 function *(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    c = base_ring(a)(b)
-   g = gcd(AbstractAlgebra.denominator(a, false), c)
-   n = AbstractAlgebra.numerator(a, false)*divexact(c, g)
-   d = divexact(AbstractAlgebra.denominator(a, false), g)
+   g = gcd(denominator(a, false), c)
+   n = numerator(a, false)*divexact(c, g)
+   d = divexact(denominator(a, false), g)
    return parent(a)(n, d)
 end
 
@@ -402,9 +402,9 @@ end
 """
 function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
    c = base_ring(b)(a)
-   g = gcd(AbstractAlgebra.denominator(b, false), c)
-   n = AbstractAlgebra.numerator(b, false)*divexact(c, g)
-   d = divexact(AbstractAlgebra.denominator(b, false), g)
+   g = gcd(denominator(b, false), c)
+   n = numerator(b, false)*divexact(c, g)
+   d = divexact(denominator(b, false), g)
    return parent(b)(n, d)
 end
 
@@ -413,9 +413,9 @@ end
 > Return $a\times b$.
 """
 function *(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-   g = gcd(AbstractAlgebra.denominator(a, false), b)
-   n = AbstractAlgebra.numerator(a, false)*divexact(b, g)
-   d = divexact(AbstractAlgebra.denominator(a, false), g)
+   g = gcd(denominator(a, false), b)
+   n = numerator(a, false)*divexact(b, g)
+   d = divexact(denominator(a, false), g)
    return parent(a)(n, d)
 end
 
@@ -424,9 +424,9 @@ end
 > Return $a\times b$.
 """
 function *(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   g = gcd(AbstractAlgebra.denominator(b, false), a)
-   n = AbstractAlgebra.numerator(b, false)*divexact(a, g)
-   d = divexact(AbstractAlgebra.denominator(b, false), g)
+   g = gcd(denominator(b, false), a)
+   n = numerator(b, false)*divexact(a, g)
+   d = divexact(denominator(b, false), g)
    return parent(b)(n, d)
 end
 
@@ -435,8 +435,8 @@ end
 > Return $a + b$.
 """
 function +(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-   n = AbstractAlgebra.numerator(a, false) + AbstractAlgebra.denominator(a, false)*b
-   d = AbstractAlgebra.denominator(a, false)
+   n = numerator(a, false) + denominator(a, false)*b
+   d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
@@ -445,8 +445,8 @@ end
 > Return $a - b$.
 """
 function -(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-   n = AbstractAlgebra.numerator(a, false) - AbstractAlgebra.denominator(a, false)*b
-   d = AbstractAlgebra.denominator(a, false)
+   n = numerator(a, false) - denominator(a, false)*b
+   d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
@@ -461,8 +461,8 @@ end
 > Return $a - b$.
 """
 function -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
-   n = a*AbstractAlgebra.denominator(b, false) - AbstractAlgebra.numerator(b, false)
-   d = AbstractAlgebra.denominator(b, false)
+   n = a*denominator(b, false) - numerator(b, false)
+   d = denominator(b, false)
    return parent(b)(n, deepcopy(d))
 end
 
@@ -471,8 +471,8 @@ end
 > Return $a + b$.
 """
 function +(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-   n = AbstractAlgebra.numerator(a, false) + AbstractAlgebra.denominator(a, false)*b
-   d = AbstractAlgebra.denominator(a, false)
+   n = numerator(a, false) + denominator(a, false)*b
+   d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
@@ -481,8 +481,8 @@ end
 > Return $a - b$.
 """
 function -(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-   n = AbstractAlgebra.numerator(a, false) - AbstractAlgebra.denominator(a, false)*b
-   d = AbstractAlgebra.denominator(a, false)
+   n = numerator(a, false) - denominator(a, false)*b
+   d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
@@ -497,8 +497,8 @@ end
 > Return $a - b$.
 """
 function -(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   n = a*AbstractAlgebra.denominator(b, false) - AbstractAlgebra.numerator(b, false)
-   d = AbstractAlgebra.denominator(b, false)
+   n = a*denominator(b, false) - numerator(b, false)
+   d = denominator(b, false)
    return parent(b)(n, deepcopy(d))
 end
 
@@ -518,18 +518,18 @@ function ==(x::AbstractAlgebra.FracElem{T}, y::AbstractAlgebra.FracElem{T}) wher
    b  = check_parent(x, y, false)
    !b && return false
 
-   return (AbstractAlgebra.denominator(x, false) == AbstractAlgebra.denominator(y, false) &&
-           AbstractAlgebra.numerator(x, false) == AbstractAlgebra.numerator(y, false)) ||
-          (AbstractAlgebra.denominator(x, true) == AbstractAlgebra.denominator(y, true) &&
-           AbstractAlgebra.numerator(x, true) == AbstractAlgebra.numerator(y, true)) ||
-          (AbstractAlgebra.numerator(x, false)*AbstractAlgebra.denominator(y, false) ==
-           AbstractAlgebra.denominator(x, false)*AbstractAlgebra.numerator(y, false))
+   return (denominator(x, false) == denominator(y, false) &&
+           numerator(x, false) == numerator(y, false)) ||
+          (denominator(x, true) == denominator(y, true) &&
+           numerator(x, true) == numerator(y, true)) ||
+          (numerator(x, false)*denominator(y, false) ==
+           denominator(x, false)*numerator(y, false))
 end
 
 @doc Markdown.doc"""
     isequal(x::AbstractAlgebra.FracElem{T}, y::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
 > Return `true` if $x == y$ exactly, otherwise return `false`. This function is
-> useful in cases where the AbstractAlgebra.numerators and AbstractAlgebra.denominators of the fractions are
+> useful in cases where the numerators and denominators of the fractions are
 > inexact, e.g. power series. Only if the power series are precisely the same,
 > to the same precision, are they declared equal by this function.
 """
@@ -537,8 +537,8 @@ function isequal(x::AbstractAlgebra.FracElem{T}, y::AbstractAlgebra.FracElem{T})
    if parent(x) != parent(y)
       return false
    end
-   return isequal(AbstractAlgebra.numerator(x, false)*AbstractAlgebra.denominator(y, false),
-                  AbstractAlgebra.denominator(x, false)*AbstractAlgebra.numerator(y, false))
+   return isequal(numerator(x, false)*denominator(y, false),
+                  denominator(x, false)*numerator(y, false))
 end
 
 ###############################################################################
@@ -552,9 +552,9 @@ end
 > Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 function ==(x::AbstractAlgebra.FracElem, y::Union{Integer, Rational, AbstractFloat})
-   return (isone(AbstractAlgebra.denominator(x, false)) && AbstractAlgebra.numerator(x, false) == y) ||
-          (isone(AbstractAlgebra.denominator(x, true)) && AbstractAlgebra.numerator(x, true) == y) ||
-          (AbstractAlgebra.numerator(x, false) == AbstractAlgebra.denominator(x, false)*y)
+   return (isone(denominator(x, false)) && numerator(x, false) == y) ||
+          (isone(denominator(x, true)) && numerator(x, true) == y) ||
+          (numerator(x, false) == denominator(x, false)*y)
 end
 
 @doc Markdown.doc"""
@@ -568,9 +568,9 @@ end
 > Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 function ==(x::AbstractAlgebra.FracElem{T}, y::T) where {T <: RingElem}
-   return (isone(AbstractAlgebra.denominator(x, false)) && AbstractAlgebra.numerator(x, false) == y) ||
-          (isone(AbstractAlgebra.denominator(x, true)) && AbstractAlgebra.numerator(x, true) == y) ||
-          (AbstractAlgebra.numerator(x, false) == AbstractAlgebra.denominator(x, false)*y)
+   return (isone(denominator(x, false)) && numerator(x, false) == y) ||
+          (isone(denominator(x, true)) && numerator(x, true) == y) ||
+          (numerator(x, false) == denominator(x, false)*y)
 end
 
 @doc Markdown.doc"""
@@ -590,9 +590,9 @@ end
 > Return the inverse of the fraction $a$.
 """
 function inv(a::AbstractAlgebra.FracElem)
-   iszero(AbstractAlgebra.numerator(a, false)) && throw(DivideError())
-   return parent(a)(deepcopy(AbstractAlgebra.denominator(a, false)),
-                    deepcopy(AbstractAlgebra.numerator(a, false)))
+   iszero(numerator(a, false)) && throw(DivideError())
+   return parent(a)(deepcopy(denominator(a, false)),
+                    deepcopy(numerator(a, false)))
 end
 
 ###############################################################################
@@ -607,10 +607,10 @@ end
 """
 function divexact(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
-   n1 = AbstractAlgebra.numerator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n2 = AbstractAlgebra.numerator(b, false)
-   d1 = AbstractAlgebra.denominator(a, false)
+   n1 = numerator(a, false)
+   d2 = denominator(b, false)
+   n2 = numerator(b, false)
+   d1 = denominator(a, false)
    if d1 == n2
       n = n1*d2
       d = d1*n2
@@ -662,9 +662,9 @@ end
 function divexact(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    b == 0 && throw(DivideError())
    c = base_ring(a)(b)
-   g = gcd(AbstractAlgebra.numerator(a, false), c)
-   n = divexact(AbstractAlgebra.numerator(a, false), g)
-   d = AbstractAlgebra.denominator(a, false)*divexact(c, g)
+   g = gcd(numerator(a, false), c)
+   n = divexact(numerator(a, false), g)
+   d = denominator(a, false)*divexact(c, g)
    return parent(a)(n, d)
 end
 
@@ -675,9 +675,9 @@ end
 function divexact(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
    iszero(b) && throw(DivideError())
    c = base_ring(b)(a)
-   g = gcd(AbstractAlgebra.numerator(b, false), c)
-   n = AbstractAlgebra.denominator(b, false)*divexact(c, g)
-   d = divexact(AbstractAlgebra.numerator(b, false), g)
+   g = gcd(numerator(b, false), c)
+   n = denominator(b, false)*divexact(c, g)
+   d = divexact(numerator(b, false), g)
    return parent(b)(n, d)
 end
 
@@ -687,9 +687,9 @@ end
 """
 function divexact(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    iszero(b) && throw(DivideError())
-   g = gcd(AbstractAlgebra.numerator(a, false), b)
-   n = divexact(AbstractAlgebra.numerator(a, false), g)
-   d = AbstractAlgebra.denominator(a, false)*divexact(b, g)
+   g = gcd(numerator(a, false), b)
+   n = divexact(numerator(a, false), g)
+   d = denominator(a, false)*divexact(b, g)
    return parent(a)(n, d)
 end
 
@@ -699,9 +699,9 @@ end
 """
 function divexact(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    iszero(b) && throw(DivideError())
-   g = gcd(AbstractAlgebra.numerator(b, false), a)
-   n = AbstractAlgebra.denominator(b, false)*divexact(a, g)
-   d = divexact(AbstractAlgebra.numerator(b, false), g)
+   g = gcd(numerator(b, false), a)
+   n = denominator(b, false)*divexact(a, g)
+   d = divexact(numerator(b, false), g)
    return parent(b)(n, d)
 end
 
@@ -730,7 +730,7 @@ function ^(a::AbstractAlgebra.FracElem{T}, b::Int) where {T <: RingElem}
       a = inv(a)
       b = -b
    end
-   return parent(a)(AbstractAlgebra.numerator(a)^b, AbstractAlgebra.denominator(a)^b)
+   return parent(a)(numerator(a)^b, denominator(a)^b)
 end
 
 ###############################################################################
@@ -748,9 +748,9 @@ end
 """
 function gcd(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
-   gbd = gcd(AbstractAlgebra.denominator(a, false), AbstractAlgebra.denominator(b, false))
-   n = gcd(AbstractAlgebra.numerator(a, false), AbstractAlgebra.numerator(b, false))
-   d = divexact(AbstractAlgebra.denominator(a, false), gbd)*AbstractAlgebra.denominator(b, false)
+   gbd = gcd(denominator(a, false), denominator(b, false))
+   n = gcd(numerator(a, false), numerator(b, false))
+   d = divexact(denominator(a, false), gbd)*denominator(b, false)
    n = divexact(n, canonical_unit(n))
    d = divexact(d, canonical_unit(d))
    return parent(a)(n, d)
@@ -769,8 +769,8 @@ end
 """
 function remove(z::AbstractAlgebra.FracElem{T}, p::T) where {T <: RingElem}
    iszero(z) && error("Not yet implemented")
-   v, d = remove(AbstractAlgebra.denominator(z, false), p)
-   w, n = remove(AbstractAlgebra.numerator(z, false), p)
+   v, d = remove(denominator(z, false), p)
+   w, n = remove(numerator(z, false), p)
    return w-v, parent(z)(deepcopy(n), deepcopy(d))
 end
 
@@ -798,10 +798,10 @@ function zero!(c::AbstractAlgebra.FracElem)
 end
 
 function mul!(c::AbstractAlgebra.FracElem{T}, a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   n1 = AbstractAlgebra.numerator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n2 = AbstractAlgebra.numerator(b, false)
-   d1 = AbstractAlgebra.denominator(a, false)
+   n1 = numerator(a, false)
+   d2 = denominator(b, false)
+   n2 = numerator(b, false)
+   d1 = denominator(a, false)
    if d1 == d2
       c.num = n1*n2
       c.den = d1*d2
@@ -841,10 +841,10 @@ function mul!(c::AbstractAlgebra.FracElem{T}, a::AbstractAlgebra.FracElem{T}, b:
 end
 
 function addeq!(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   d1 = AbstractAlgebra.denominator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n1 = AbstractAlgebra.numerator(a, false)
-   n2 = AbstractAlgebra.numerator(b, false)
+   d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    gd = gcd(d1, d2)
    if d1 == d2
       a.num = addeq!(a.num, b.num)
@@ -893,10 +893,10 @@ function addeq!(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) 
 end
 
 function add!(c::AbstractAlgebra.FracElem{T}, a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   d1 = AbstractAlgebra.denominator(a, false)
-   d2 = AbstractAlgebra.denominator(b, false)
-   n1 = AbstractAlgebra.numerator(a, false)
-   n2 = AbstractAlgebra.numerator(b, false)
+   d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    gd = gcd(d1, d2)
    if d1 == d2
       c.num = n1 + n2

--- a/src/generic/InvariantFactorDecomposition.jl
+++ b/src/generic/InvariantFactorDecomposition.jl
@@ -93,7 +93,7 @@ function reduce_mod_invariants(v::AbstractAlgebra.MatElem{T}, invars::Vector{T})
    v = deepcopy(v) # don't modify input
    for i = 1:length(invars)
       if !iszero(invars[i])
-         q, v[1, i] = AbstractAlgebra.divrem(v[1, i], invars[i])
+         q, v[1, i] = divrem(v[1, i], invars[i])
       end
    end
    return v

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -197,7 +197,7 @@ function coeff(a::LaurentSeriesElem, n::Int)
       if mod(i, scale(a)) != 0
          return base_ring(a)()
       else
-         return polcoeff(a, AbstractAlgebra.div(i, scale(a)))
+         return polcoeff(a, div(i, scale(a)))
       end
    end
 end
@@ -792,7 +792,7 @@ function truncate(a::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
       set_scale!(z, 1)
    else
       sa = scale(a)
-      zlen = AbstractAlgebra.div(n - aval + sa - 1, sa)
+      zlen = div(n - aval + sa - 1, sa)
       zlen = min(zlen, alen)
       fit!(z, zlen)
       set_val!(z, aval)
@@ -961,8 +961,8 @@ function ==(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: RingEl
    end
    sx = scale(x)
    sy = scale(y)
-   xlen = min(pol_length(x), AbstractAlgebra.div(prec - xval + sx - 1, sx))
-   ylen = min(pol_length(y), AbstractAlgebra.div(prec - yval + sy - 1, sy))
+   xlen = min(pol_length(x), div(prec - xval + sx - 1, sx))
+   ylen = min(pol_length(y), div(prec - yval + sy - 1, sy))
    i = 0
    j = 0
    while i < xlen && j < ylen
@@ -1211,7 +1211,7 @@ function Base.sqrt(a::LaurentSeriesElem)
    !iseven(aval) && error("Not a square in sqrt")
    R = base_ring(a)
    !isdomain_type(elem_type(R)) && error("Sqrt not implemented over non-integral domains")
-   aval2 = AbstractAlgebra.div(aval, 2)
+   aval2 = div(aval, 2)
    prec = precision(a) - aval
    if prec == 0
       asqrt = parent(a)()
@@ -1222,12 +1222,12 @@ function Base.sqrt(a::LaurentSeriesElem)
    end
    asqrt = parent(a)()
    s = scale(a)
-   zlen = AbstractAlgebra.div(prec + s - 1, s)
+   zlen = div(prec + s - 1, s)
    fit!(asqrt, prec)
    set_prec!(asqrt, prec + aval2)
    set_val!(asqrt, aval2)
    if prec > 0
-      g = AbstractAlgebra.sqrt(polcoeff(a, 0))
+      g = sqrt(polcoeff(a, 0))
       asqrt = setcoeff!(asqrt, 0, g)
       g2 = g + g
    end
@@ -1265,7 +1265,7 @@ end
     exp(a::Generic.LaurentSeriesElem)
 > Return the exponential of the power series $a$.
 """
-function Base.exp(a::LaurentSeriesElem)
+function Base.exp(a::LaurentSeriesElem{T}) where {T <: RingElement}
    if iszero(a)
       z = one(parent(a))
       set_prec!(z, precision(a))
@@ -1281,8 +1281,8 @@ function Base.exp(a::LaurentSeriesElem)
       sc = gs
    end
    if sc != 1
-      vala = AbstractAlgebra.div(vala, sc)
-      preca = AbstractAlgebra.div(preca, sc)
+      vala = div(vala, sc)
+      preca = div(preca, sc)
       a = parent(a)(a.coeffs, pol_length(a), preca, vala, 1, false)
    end
    z = parent(a)()
@@ -1291,7 +1291,7 @@ function Base.exp(a::LaurentSeriesElem)
    set_prec!(z, preca)
    set_val!(z, 0)
    c = vala == 0 ? polcoeff(a, 0) : R()
-   z = setcoeff!(z, 0, AbstractAlgebra.exp(c))
+   z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala
    for k = 1 : preca - 1
       s = R()
@@ -1381,7 +1381,7 @@ function mul!(c::LaurentSeriesElem{T}, a::LaurentSeriesElem{T}, b::LaurentSeries
    b = downscale(b, db)
    lena = pol_length(a)
    lenb = pol_length(b)
-   lenc = min(lena + lenb - 1, AbstractAlgebra.div(prec + sz - 1, sz))
+   lenc = min(lena + lenb - 1, div(prec + sz - 1, sz))
    fit!(c, lenc)
    for i = 1:min(lena, lenc)
       c.coeffs[i] = polcoeff(a, i - 1) * polcoeff(b, 0)
@@ -1442,7 +1442,7 @@ function add!(c::LaurentSeriesElem{T}, a::LaurentSeriesElem{T}, b::LaurentSeries
    mina = min(vala + lena*sa, prec)
    minb = min(valb + lenb*sb, prec)
    lenr = max(mina, minb) - valr
-   lenr = AbstractAlgebra.div(lenr + sc - 1, sc)
+   lenr = div(lenr + sc - 1, sc)
    R = base_ring(c)
    fit!(c, lenr)
    c.prec = prec

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2679,7 +2679,7 @@ function div_monagan_pearce(a::MPoly{T}, b::MPoly{T}, bits::Int) where {T <: Rin
          if !d1
             k -= 1
          else
-            tq, tr = AbstractAlgebra.divrem(qc, mb)
+            tq, tr = divrem(qc, mb)
             if tq != 0
                Qc[k] = tq
                monomial_set!(Qe, k, texp, 1, N)
@@ -2718,7 +2718,7 @@ function div_monagan_pearce(a::MPoly{T}, b::MPoly{T}, bits::Int) where {T <: Rin
    return flag, parent(a)(Qc, Qe)
 end
 
-function div(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
+function Base.div(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
    v1, d1 = max_fields(a)
    v2, d2 = max_fields(b)
    d = max(d1, d2)
@@ -2895,7 +2895,7 @@ function divrem_monagan_pearce(a::MPoly{T}, b::MPoly{T}, bits::Int) where {T <: 
             monomial_set!(Re, l, exp_copy, 1, N)
             k -= 1
          else
-            tq, tr = AbstractAlgebra.divrem(qc, mb)
+            tq, tr = divrem(qc, mb)
             if tr != 0
                l += 1
                if l >= r_alloc
@@ -2942,7 +2942,7 @@ function divrem_monagan_pearce(a::MPoly{T}, b::MPoly{T}, bits::Int) where {T <: 
    return flag, parent(a)(Qc, Qe), parent(a)(Rc, Re)
 end
 
-function divrem(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
+function Base.divrem(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
    v1, d1 = max_fields(a)
    v2, d2 = max_fields(b)
    d = max(d1, d2)
@@ -3115,7 +3115,7 @@ function divrem_monagan_pearce(a::MPoly{T}, b::Array{MPoly{T}, 1}, bits::Int) wh
          for w = 1:len
             d1 = monomial_divides!(texp, 1, exp_copy, 1, b[w].exps, 1, mask, N)
             if d1
-               tq, qc = AbstractAlgebra.divrem(qc, mb[w])
+               tq, qc = divrem(qc, mb[w])
                div_flag = qc == 0
                if tq != 0
                   k[w] += 1
@@ -3175,7 +3175,7 @@ end
 > Return a tuple `(q, r)` consisting of an array of polynomials `q`, one for
 > each polynomial in `b`, and a polynomial `r` such that `a = sum_i b[i]*q[i] + r`.
 """
-function divrem(a::MPoly{T}, b::Array{MPoly{T}, 1}) where {T <: RingElement}
+function Base.divrem(a::MPoly{T}, b::Array{MPoly{T}, 1}) where {T <: RingElement}
    v1, d = max_fields(a)
    len = length(b)
    N = parent(a).N

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1711,7 +1711,7 @@ function det_interpolation(M::MatrixElem{T}) where {T <: PolyElem}
    x = Array{elem_type(base_ring(R))}(undef, bound)
    d = Array{elem_type(base_ring(R))}(undef, bound)
    X = zero_matrix(base_ring(R), n, n)
-   b2 = AbstractAlgebra.div(bound, 2)
+   b2 = div(bound, 2)
    pt1 = base_ring(R)(1 - b2)
    for i = 1:bound
       x[i] = base_ring(R)(i - b2)
@@ -2027,7 +2027,7 @@ function solve_interpolation(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.M
    X = similar(tmat, m, m)
    Y = similar(tmat, m, h)
    x = similar(b)
-   b2 = AbstractAlgebra.div(bound, 2)
+   b2 = div(bound, 2)
    pt1 = base_ring(R)(1 - b2)
    l = 1
    i = 1
@@ -2140,7 +2140,7 @@ function solve_left(a::AbstractAlgebra.MatElem{S}, b::AbstractAlgebra.MatElem{S}
          if k > ncols(H)
             continue
          end
-         q, r = AbstractAlgebra.divrem(b[i, k], H[j, k])
+         q, r = divrem(b[i, k], H[j, k])
          r != 0 && error("Unable to solve linear system")
          z[i, j] = q
          q = -q
@@ -2295,7 +2295,7 @@ function can_solve_left_reduced_triu(r::AbstractAlgebra.MatElem{T},
       if k != i
          return false, x
       end
-      x[1, j], r[1, i] = AbstractAlgebra.divrem(r[1, i], M[j, k])
+      x[1, j], r[1, i] = divrem(r[1, i], M[j, k])
       if !iszero(r[1, i])
          return false, x
       end
@@ -3204,7 +3204,7 @@ function hnf_cohen!(H::MatrixElem{T}, U::MatrixElem{T}) where {T <: RingElement}
          end
       end
       for j = 1:k-1
-         q = -AbstractAlgebra.div(H[j,i], H[k, i])
+         q = -div(H[j,i], H[k, i])
          for c = i:n
             t = mul!(t, q, H[k, c])
             H[j, c] = addeq!(H[j, c], t)
@@ -3380,7 +3380,7 @@ function _hnf_minors!(H::MatrixElem{T}, U::MatrixElem{T}, with_transform::Type{V
 
       for i in (k - 1):-1:1
          for j in (i + 1):k
-            q = AbstractAlgebra.div(H[i, j], H[j, j])
+            q = div(H[i, j], H[j, j])
             if iszero(q)
               continue
             end
@@ -3465,7 +3465,7 @@ function _hnf_minors!(H::MatrixElem{T}, U::MatrixElem{T}, with_transform::Type{V
       end
       for i in n:-1:1
          for j in (i + 1):n
-            q = AbstractAlgebra.div(H[i, j], H[j, j])
+            q = div(H[i, j], H[j, j])
             if iszero(q)
               continue
             end
@@ -3557,7 +3557,7 @@ function kb_reduce_column!(H::MatrixElem{T}, U::MatrixElem{T}, pivot::Array{Int,
       if iszero(H[p, c])
          continue
       end
-      q = -AbstractAlgebra.div(H[p, c], H[r, c])
+      q = -div(H[p, c], H[r, c])
       for j = c:ncols(H)
          t = mul!(t, q, H[r, j])
          H[p, j] = addeq!(H[p, j], t)
@@ -3763,7 +3763,7 @@ function ishnf(M::Generic.MatrixElem{T}) where T <: RingElement
       col = pivots[row]
       p = M[row, col]
       for i = 1:row - 1
-         qq, rr = AbstractAlgebra.divrem(M[i, col], p)
+         qq, rr = divrem(M[i, col], p)
          if rr != M[i, col]
             return false
          end
@@ -4051,7 +4051,7 @@ function weak_popov_with_pivots!(P::Mat{T}, W::Mat{T}, U::Mat{T}, pivots::Array{
             if j == pivotInd
                continue
             end
-            q = -AbstractAlgebra.div(P[pivots[i][j], i], P[pivot, i])
+            q = -div(P[pivots[i][j], i], P[pivot, i])
             for c = 1:n
                t = mul!(t, q, P[pivot, c])
                P[pivots[i][j], c] = addeq!(P[pivots[i][j], c], t)
@@ -4155,7 +4155,7 @@ function det_popov(A::Mat{T}) where {T <: PolyElem}
             r1, r2 = r2, r1
             pivots[c] = r2
          end
-         q = -AbstractAlgebra.div(B[r1, c], B[r2, c])
+         q = -div(B[r1, c], B[r2, c])
          for j = 1:i + 1
             t = mul!(t, q, B[r2, j])
             B[r1, j] = addeq!(B[r1, j], t)
@@ -4270,7 +4270,7 @@ function popov!(P::Mat{T}, U::Mat{T}, with_trafo::Bool = false) where {T <: Poly
          if degree(P[r,i]) < d
             continue
          end
-         q = -AbstractAlgebra.div(P[r,i],P[pivot,i])
+         q = -div(P[r,i],P[pivot,i])
          for c = 1:n
             t = mul!(t, q, P[pivot,c])
             P[r, c] = addeq!(P[r,c], t)
@@ -4333,7 +4333,7 @@ function hnf_via_popov_reduce_row!(H::Mat{T}, U::Mat{T}, pivots_hermite::Array{I
          continue
       end
       pivot = pivots_hermite[c]
-      q = -AbstractAlgebra.div(H[r, c], H[pivot, c])
+      q = -div(H[r, c], H[pivot, c])
       for j = c:n
          t = mul!(t, q, H[pivot, j])
          H[r, j] = addeq!(H[r, j], t)
@@ -4360,7 +4360,7 @@ function hnf_via_popov_reduce_column!(H::Mat{T}, U::Mat{T}, pivots_hermite::Arra
       if degree(H[i, c]) < degree(H[r, c])
          continue
       end
-      q = -AbstractAlgebra.div(H[i, c], H[r, c])
+      q = -div(H[i, c], H[r, c])
       for j = 1:n
          t = mul!(t, q, H[r, j])
          H[i, j] = addeq!(H[i, j], t)
@@ -4405,7 +4405,7 @@ function hnf_via_popov!(H::Mat{T}, U::Mat{T}, with_trafo::Bool = false) where {T
             r1, r2 = r2, r1
             pivots_popov[c] = r2
          end
-         q = -AbstractAlgebra.div(H[r1, c], H[r2, c])
+         q = -div(H[r1, c], H[r2, c])
          for j = 1:n
             t = mul!(t, q, H[r2, j])
             H[r1, j] = addeq!(H[r1, j], t)
@@ -4539,7 +4539,7 @@ end
 > where $r$ is the number of rows of $a$.
 """
 function reverse_rows!(a::MatrixElem)
-   k = AbstractAlgebra.div(nrows(a), 2)
+   k = div(nrows(a), 2)
    for i in 1:k
       swap_rows!(a, i, nrows(a) - i + 1)
    end
@@ -4563,7 +4563,7 @@ end
 > where $c$ is the number of columns of $a$.
 """
 function reverse_cols!(a::MatrixElem)
-   k = AbstractAlgebra.div(ncols(a), 2)
+   k = div(ncols(a), 2)
    for i in 1:k
       swap_cols!(a, i, ncols(a) - i + 1)
    end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1162,7 +1162,7 @@ end
 > Return a tuple $(q, r)$ such that $f = qg + r$ where $q$ is the euclidean
 > quotient of $f$ by $g$.
 """
-function divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function Base.divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
    check_parent(f, g)
    if length(g) == 0
       throw(DivideError())
@@ -1196,7 +1196,7 @@ end
     div(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
 > Return the euclidean quotient of $f$ by $g$.
 """
-function div(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function Base.div(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
    q, r = divrem(f, g)
    return q
 end

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -114,7 +114,7 @@ function reduce_mod_rels(v::AbstractAlgebra.MatElem{T}, vrels::Vector{<:Abstract
       while iszero(rel[1, i])
          i += 1
       end
-      q, v[1, start + i - 1] = AbstractAlgebra.divrem(v[1, start + i - 1], rel[1, i])
+      q, v[1, start + i - 1] = divrem(v[1, start + i - 1], rel[1, i])
       q = -q
       for j = i + 1:ncols(rel)
          t1 = mul!(t1, q, rel[1, j])

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export PowerSeriesRing, O, valuation, exp, precision, max_precision, set_prec!,
+export PowerSeriesRing, O, valuation, precision, max_precision, set_prec!,
        polcoeff, set_val!, pol_length, renormalize!
 
 ###############################################################################
@@ -980,7 +980,7 @@ function Base.sqrt(a::AbstractAlgebra.RelSeriesElem)
    set_prec!(asqrt, prec + aval2)
    set_val!(asqrt, aval2)
    if prec > 0
-      g = AbstractAlgebra.sqrt(polcoeff(a, 0))
+      g = sqrt(polcoeff(a, 0))
       asqrt = setcoeff!(asqrt, 0, g)
       g2 = g + g
    end
@@ -1016,7 +1016,7 @@ end
     exp(a::AbstractAlgebra.RelSeriesElem)
 > Return the exponential of the power series $a$.
 """
-function Base.exp(a::AbstractAlgebra.RelSeriesElem)
+function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    if iszero(a)
       z = one(parent(a))
       set_prec!(z, precision(a))
@@ -1030,7 +1030,7 @@ function Base.exp(a::AbstractAlgebra.RelSeriesElem)
    set_prec!(z, preca)
    set_val!(z, 0)
    c = vala == 0 ? polcoeff(a, 0) : R()
-   z = setcoeff!(z, 0, AbstractAlgebra.exp(c))
+   z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala
    for k = 1 : preca - 1
       s = R()

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -433,7 +433,7 @@ function divides(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) w
    m = modulus(R)
    gb = gcd(B, m)
    ub = divexact(B, gb)
-   q, r = AbstractAlgebra.divrem(A, gb)
+   q, r = divrem(A, gb)
    if !iszero(r)
      return false, b
    end

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -506,7 +506,7 @@ function divrem(a::SparsePoly{T}, b::SparsePoly{T}) where {T <: RingElement}
             Re[l] = maxn - exp
             k -= 1
          else
-            tq, tr = AbstractAlgebra.divrem(qc, mb)
+            tq, tr = divrem(qc, mb)
             if tr != 0
                l += 1
                if l >= r_alloc

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -106,7 +106,7 @@ end
 function _numpart(n::T, lookuptable::Dict{Int, T}) where T<:Integer
    s = zero(T)
    if !haskey(lookuptable, n)
-      for j in 1:floor(T, (1 + sqrt(1 + 24n))/6)
+      for j in 1:floor(T, (1 + Base.sqrt(1 + 24n))/6)
          p1 = _numpart(n - div(j*(3j - 1), 2))
          p2 = _numpart(n - div(j*(3j + 1), 2))
          s += (-1)^(j - 1)*(p1 + p2)

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -98,6 +98,10 @@ function divrem(a::Rational{T}, b::Rational{T}) where T <: Integer
    return a//b, zero(Rational{T})
 end
 
+function div(a::Rational{T}, b::Rational{T}) where T <: Integer
+   return a//b
+end
+
 ###############################################################################
 #
 #   Exact division
@@ -141,6 +145,19 @@ function gcd(p::Rational{T}, q::Rational{T}) where T <: Integer
    end
 end
 
+function gcdx(p::Rational{T}, q::Rational{T}) where {T <: Integer}
+   g = gcd(p, q)
+   if !iszero(p)
+      return (g, g//p, zero(q))
+   elseif !iszero(q)
+      return (g, zero(p), g//q)
+   else
+      @assert iszero(g)
+      return (g, zero(p), zero(p))
+   end
+end
+
+
 ###############################################################################
 #
 #   Square root
@@ -153,7 +170,7 @@ end
 > throw an error.
 """
 function sqrt(a::Rational{T}) where T <: Integer
-   return AbstractAlgebra.sqrt(numerator(a))//AbstractAlgebra.sqrt(denominator(a))
+   return sqrt(numerator(a))//sqrt(denominator(a))
 end
 
 ###############################################################################


### PR DESCRIPTION
There was more then one issue here. First of all Base does not provide `gcdx` for `Rational{<: Integer}` and also `div` for `Rational{<: Integer}` is doing weird things:
```julia
julia> div(Rational{BigInt}(1), Rational{BigInt}(2))
0

julia> typeof(ans)
BigInt
```
This was easy to fix.

The real rabbit whole were our import/export statements. I  noticed that we are not consistent with our import/export philosophy regarding `exp` and all these other troublemakers. While we did (correctly!) not do `import Base: exp` in src/AbstractAlgebra.jl we did it in src/Generic.jl. This coursed all kinds of confusion! I cleaned this up. In particular every use of these troublemakers (`exp`, `div`, `divrem`, `numerator`, `denomonator` and `sqrt`) inside the library does not need any namespace qualification.

I also documented this import/export trick that we are using.