### PR TITLE
fix show_minus_one for matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -460,8 +460,6 @@ function show(io::IO, a::MatrixElem)
    end
 end
 
-show_minus_one(::Type{AbstractAlgebra.MatElem{T}}) where {T <: RingElement} = false
-
 ###############################################################################
 #
 #   Unary operations

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -155,7 +155,7 @@ function show(io::IO, a::AbstractAlgebra.MatAlgebra)
    print(IOContext(io, :compact => true), base_ring(a))
 end
 
-show_minus_one(::Type{AbstractAlgebra.MatAlgElem{T}}) where T <: RingElement = false
+show_minus_one(::Type{<:AbstractAlgebra.MatAlgElem{T}}) where T <: RingElement = false
 
 needs_parentheses(a::AbstractAlgebra.MatAlgElem{T}) where T <: RingElement = true
 

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2545,3 +2545,9 @@ end
    ps = map_coeffs(z -> z^2, p)
    @test ps == Zx([i^2 for i in 1:10])
 end
+
+@testset "Generic.Poly.show..." begin
+   M = MatrixAlgebra(ZZ, 3)
+   _, x = M['x']
+   @test string(M(-1)*x) == "-x"
+end


### PR DESCRIPTION
It was only defined for an abstract type (`AbstractAlgebra.MatAlgElem{T}`), so didn't work with the type of actual instances.
Two questions:
1. is this function useful for `AbstractAlgebra.MatElem`? It seems it's used only for polynomials of matrices, which works only with matrix algebras... If not, should I delete this method?
2. would we consider defining this method for instances, instead of for types, as the related functions `displayed_with_minus_in_front` and `needs_parentheses` are defined on instances?  