### PR TITLE
add eltype(::MatrixElem)

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -196,6 +196,8 @@ Base.@propagate_inbounds function setindex!(a::MatrixElem, d::T, r::Int,
     a.entries[r, c] = base_ring(a)(d)
 end
 
+Base.eltype(::Type{<:MatrixElem{T}}) where T <: RingElem = T
+
 Base.isassigned(a::Union{Mat,MatAlgElem}, i, j) = isassigned(a.entries, i, j)
 
 function Base.isassigned(a::MatrixElem, i, j)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -218,6 +218,11 @@ end
 
    @test dense_matrix_type(R) == elem_type(S)
 
+   let ET = AbstractAlgebra.Generic.Poly{Rational{BigInt}}
+      @test eltype(typeof(A)) == eltype(A) == elem_type(base_ring(A)) == ET
+      @test eltype(typeof(B)) == eltype(B) == elem_type(base_ring(B)) == ET
+   end
+
    @test iszero(zero(S))
    @test isone(one(S))
 
@@ -254,7 +259,14 @@ end
    @test !any(isempty, (A, B, C))
 
    @test length(matrix(R, zeros(Int, 2, 3))) == 6
-   @test length(matrix(R, zeros(Int, 3, 2))) == 6
+
+   n = matrix(R, zeros(Int, 3, 2))
+   @test length(n) == 6
+   let ET = AbstractAlgebra.Generic.Poly{Rational{BigInt}}
+      @test eltype(typeof(n)) == ET
+      @test eltype(n) == ET
+      @test elem_type(base_ring(n)) == ET
+   end
 
    for n = (matrix(R, zeros(Int, 2, 0)),
             matrix(R, zeros(Int, 0, 2)))
@@ -270,6 +282,10 @@ end
               randmat_with_rank(M3, 2, 0:9, -9:9),
               randmat_with_rank(rng, M3, 2, 0:9, -9:9)]
       @test length(m3) == 9
+      ET = AbstractAlgebra.Generic.Poly{Rational{BigInt}}
+      @test eltype(typeof(m3)) == ET
+      @test eltype(m3) == ET
+      @test elem_type(base_ring(m3)) == ET
       @test !isempty(m3)
       @test !iszero(m3)
       @test m3 isa Generic.MatAlgElem


### PR DESCRIPTION
This is a simple function which is easy to support when matrices are considered as collections/arrays.
This is already defined in Hecke for `MatElem`.