### PR TITLE
Zero and identity matrix

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -226,6 +226,15 @@ isempty(::MatElem)
 
 ```@docs
 identity_matrix(::Ring, ::Int, ::Int)
+identity_matrix(::Ring, ::Int)
+```
+
+```@docs
+identity_matrix(::MatElem{T}) where T <: RingElement
+```
+
+```@docs
+zero_matrix(::MatElem{T}) where T <: RingElement
 ```
 
 ```@docs

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -225,6 +225,10 @@ isempty(::MatElem)
 ```
 
 ```@docs
+identity_matrix(::Ring, ::Int, ::Int)
+```
+
+```@docs
 change_base_ring(::AbstractAlgebra.Ring, ::AbstractAlgebra.MatElem)
 ```
 

--- a/docs/src/matrix_algebras.md
+++ b/docs/src/matrix_algebras.md
@@ -52,7 +52,7 @@ row and column numbers (or degree, in the case of matrix algebras) and the base 
 on a per matrix basis. The parent object can then be reconstructed from this data on
 demand.
 
-## Matrix space constructors
+## Matrix algebra constructors
 
 A matrix algebra in AbstractAlgebra.jl represents a collection of all matrices with
 given degree and base ring.
@@ -95,6 +95,28 @@ julia> C = S(R(11))
 [ 0//1  11//1   0//1]
 [ 0//1   0//1  11//1]
 
+```
+
+## Matrix algebra element constructors
+
+The following additional constructors are provided for constructing various
+kinds of matrices in a matrix algebra.
+
+```@docs
+zero_matrix(::MatAlgElem{T}) where T <: RingElement
+```
+
+```@docs
+identity_matrix(::MatAlgElem{T}) where T <: RingElement                                  ```
+
+*Examples*
+
+```julia
+S = MatrixAlgebra(ZZ, 2)
+M = zero(S)
+
+N = zero_matrix(M)
+P = identity_matrix(M)
 ```
 
 ## Matrix algebra functionality provided by AbstractAlgebra.jl

--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -161,12 +161,6 @@ zero_matrix(R::Ring, r::Int, c::Int)
 
 Construct the $r\times c$ AbstractAlgebra.jl zero matrix over the ring `R`.
 
-```julia
-identity_matrix(R::Ring, n::Int)
-```
-
-Construct the $n\times n$ AbstractAlgebra.jl identity matrix over the ring `R`.
-
 **Examples**
 
 ```jldoctest
@@ -183,12 +177,6 @@ julia> P = zero_matrix(ZZ, 3, 2)
 [0  0]
 [0  0]
 [0  0]
-
-julia> Q = identity_matrix(ZZ, 4)
-[1  0  0  0]
-[0  1  0  0]
-[0  0  1  0]
-[0  0  0  1]
 
 julia> R = MatrixAlgebra(ZZ, 2)
 Matrix Algebra of degree 2 over Integers

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5116,6 +5116,15 @@ function zero_matrix(R::Ring, r::Int, c::Int)
    return z
 end
 
+@doc Markdown.doc"""
+    zero_matrix(M::MatElem{T}) where T <: RingElement
+> Return the zero matrix over the same base ring as $M$ and with the
+> same dimensions.
+"""
+function zero_matrix(M::MatElem{T}) where T <: RingElement
+   return zero_matrix(base_ring(M), nrows(M), ncols(M))
+end
+
 ################################################################################
 #
 #   Identity matrix
@@ -5136,7 +5145,7 @@ function identity_matrix(R::Ring, n::Int)
 end
 
 @doc Markdown.doc"""
-    identity_matrix(R::Ring, m::Int, n::Int) -> MatElem
+    identity_matrix(R::Ring, m::Int, n::Int)
 > Return the $m \times n$ matrix over $R$ with ones down the diagonal and
 > zeroes elsewhere.
 """
@@ -5146,6 +5155,15 @@ function identity_matrix(R::Ring, m::Int, n::Int)
       z[i, i] = one(R)
    end
    return z
+end
+
+@doc Markdown.doc"""
+    identity_matrix(M::MatElem{T}) where T <: RingElement
+> Return the matrix over the same base ring as $M$ and with the same
+> dimensions with ones down the diagonal and zeroes elsewhere.
+"""
+function identity_matrix(M::MatElem{T}) where T <: RingElement
+   return identity_matrix(base_ring(M), nrows(M), ncols(M))
 end
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -25,7 +25,7 @@ export MatrixSpace, fflu!, fflu, solve_triu, isrref, charpoly_danilevsky!,
 
 ###############################################################################
 #
-#   Similar and eye
+#   Similar
 #
 ###############################################################################
 
@@ -42,30 +42,6 @@ similar(x::AbstractAlgebra.MatElem, R::Ring, r::Int, c::Int) = _similar(x, R, r,
 similar(x::AbstractAlgebra.MatElem, R::Ring=base_ring(x)) = similar(x, R, nrows(x), ncols(x))
 
 similar(x::AbstractAlgebra.MatElem, r::Int, c::Int) = similar(x, base_ring(x), r, c)
-
-@doc Markdown.doc"""
-    eye(x::Generic.MatrixElem)
-> Return the identity matrix with the same shape as $x$.
-"""
-function eye(x::MatrixElem)
-  z = zero(x)
-  for i in 1:nrows(x)
-    z[i, i] = one(base_ring(x))
-  end
-  return z
-end
-
-@doc Markdown.doc"""
-    eye(x::Generic.MatrixElem, d::Int)
-> Return the $d$-by-$d$ identity matrix with the same base ring as $x$.
-"""
-function eye(x::MatrixElem, d::Int)
-   z = zero(x, d, d)
-   for i in 1:nrows(z)
-      z[i, i] = one(base_ring(x))
-   end
-   return z
-end
 
 ###############################################################################
 #
@@ -726,7 +702,7 @@ function ^(a::MatrixElem, b::Int)
    end
    # special case powers of x for constructing polynomials efficiently
    if b == 0
-      return eye(a)
+      return identity_matrix(a)
    elseif b == 1
       return deepcopy(a)
    else
@@ -755,7 +731,7 @@ function powers(a::MatrixElem, d::Int)
    !issquare(a) && error("Dimensions do not match in powers")
    d <= 0 && throw(DomainError(d, "Negative dimension in powers"))
    A = Array{typeof(a)}(undef, d + 1)
-   A[1] = eye(a)
+   A[1] = identity_matrix(a)
    if d > 1
       c = a
       A[2] = a
@@ -2322,7 +2298,7 @@ end
 """
 function pseudo_inv(M::MatrixElem{T}) where {T <: RingElement}
    issquare(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
-   X, d = solve_fflu(M, eye(M))
+   X, d = solve_fflu(M, identity_matrix(M))
    return X, d
 end
 
@@ -2334,7 +2310,7 @@ end
 """
 function inv(M::MatrixElem{T}) where {T <: FieldElement}
    issquare(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
-   A = solve_lu(M, eye(M))
+   A = solve_lu(M, identity_matrix(M))
    return A
 end
 
@@ -3145,7 +3121,7 @@ end
 function hnf_cohen_with_transform(A::MatrixElem{T}) where {T <: RingElement}
    H = deepcopy(A)
    m = nrows(H)
-   U = eye(A, m)
+   U = identity_matrix(A, m)
    hnf_cohen!(H, U)
    return H, U
 end
@@ -3510,7 +3486,7 @@ function _hnf_kb(A, trafo::Type{Val{T}} = Val{false}) where T
    H = deepcopy(A)
    m = nrows(H)
    if trafo == Val{true}
-      U = eye(A, m)
+      U = identity_matrix(A, m)
       hnf_kb!(H, U, true)
       return H, U
    else
@@ -3790,8 +3766,8 @@ function _snf_kb(A::MatrixElem{T}, trafo::Type{Val{V}} = Val{false}) where {V, T
    m = nrows(S)
    n = ncols(S)
    if trafo == Val{true}
-      U = eye(A, m)
-      K = eye(A, n)
+      U = identity_matrix(A, m)
+      K = identity_matrix(A, n)
       snf_kb!(S, U, K, true)
       return S, U, K
    else
@@ -3941,7 +3917,7 @@ function _weak_popov(A::Mat{T}, trafo::Type{Val{S}} = Val{false}) where {T <: Po
    m = nrows(P)
    W = similar(A, 0, 0)
    if trafo == Val{true}
-      U = eye(A, m)
+      U = identity_matrix(A, m)
       weak_popov!(P, W, U, false, true)
       return P, U
    else
@@ -3978,7 +3954,7 @@ function _extended_weak_popov(A::Mat{T}, V::Mat{T}, trafo::Type{Val{S}} = Val{fa
    W = deepcopy(V)
    m = nrows(P)
    if trafo == Val{true}
-      U = eye(A)
+      U = identity_matrix(A)
       weak_popov!(P, W, U, true, true)
       return P, W, U
    else
@@ -4205,7 +4181,7 @@ function _popov(A::Mat{T}, trafo::Type{Val{S}} = Val{false}) where {T <: PolyEle
    P = deepcopy(A)
    m = nrows(P)
    if trafo == Val{true}
-      U = eye(A, m)
+      U = identity_matrix(A, m)
       popov!(P, U, true)
       return P, U
    else
@@ -4313,7 +4289,7 @@ function _hnf_via_popov(A::Mat{T}, trafo::Type{Val{S}} = Val{false}) where {T <:
    H = deepcopy(A)
    m = nrows(H)
    if trafo == Val{true}
-      U = eye(A, m)
+      U = identity_matrix(A, m)
       hnf_via_popov!(H, U, true)
       return H, U
    else
@@ -5125,6 +5101,10 @@ function zero_matrix(M::MatElem{T}) where T <: RingElement
    return zero_matrix(base_ring(M), nrows(M), ncols(M))
 end
 
+function zero_matrix(M::MatElem{T}, n::Int) where T <: RingElement
+   return zero_matrix(base_ring(M), n, n)
+end
+
 ################################################################################
 #
 #   Identity matrix
@@ -5164,6 +5144,10 @@ end
 """
 function identity_matrix(M::MatElem{T}) where T <: RingElement
    return identity_matrix(base_ring(M), nrows(M), ncols(M))
+end
+
+function identity_matrix(M::MatElem{T}, n::Int) where T <: RingElement
+   return identity_matrix(base_ring(M), n, n)
 end
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5135,6 +5135,19 @@ function identity_matrix(R::Ring, n::Int)
    return z
 end
 
+@doc Markdown.doc"""
+    identity_matrix(R::Ring, m::Int, n::Int) -> MatElem
+> Return the $m \times n$ matrix over $R$ with ones down the diagonal and
+> zeroes elsewhere.
+"""
+function identity_matrix(R::Ring, m::Int, n::Int)
+   z = zero_matrix(R, m, n)
+   for i in 1:min(m, n)
+      z[i, i] = one(R)
+   end
+   return z
+end
+
 ###############################################################################
 #
 #   MatrixSpace constructor

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -483,6 +483,56 @@ end
 
 ###############################################################################
 #
+#   Zero matrix
+#
+###############################################################################
+
+@doc Markdown.doc"""
+    zero_matrix(M::MatAlgElem{T}) where T <: RingElement
+> Return the zero matrix over the same base ring as $M$ and with the
+> same dimensions.
+"""
+function zero_matrix(M::MatAlgElem{T}) where T <: RingElement
+   R = base_ring(M)
+   n = degree(M)
+   arr = Array{T}(undef, n, n)
+   for i in 1:n
+      for j in 1:n
+         arr[i, j] = zero(R)
+      end
+   end
+   z = MatAlgElem{T}(arr)
+   z.base_ring = R
+   return z
+end
+
+###############################################################################
+#
+#   Identity matrix
+#
+###############################################################################
+
+@doc Markdown.doc"""
+    identity_matrix(M::MatAlgElem{T}) where T <: RingElement
+> Return the identity matrix over the same base ring as $M$ and with the
+> same dimensions.
+"""
+function identity_matrix(M::MatAlgElem{T}) where T <: RingElement
+   R = base_ring(M)
+   n = degree(M)
+   arr = Array{T}(undef, n, n)
+   for i in 1:n
+      for j in 1:n
+         arr[i, j] = i == j ? one(R) : zero(R)
+      end
+   end
+   z = MatAlgElem{T}(arr)
+   z.base_ring = R
+   return z
+end
+
+###############################################################################
+#
 #   Parent object call overload
 #
 ###############################################################################

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -487,14 +487,8 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    zero_matrix(M::MatAlgElem{T}) where T <: RingElement
-> Return the zero matrix over the same base ring as $M$ and with the
-> same dimensions.
-"""
-function zero_matrix(M::MatAlgElem{T}) where T <: RingElement
+function zero_matrix(M::MatAlgElem{T}, n::Int) where T <: RingElement
    R = base_ring(M)
-   n = degree(M)
    arr = Array{T}(undef, n, n)
    for i in 1:n
       for j in 1:n
@@ -506,20 +500,23 @@ function zero_matrix(M::MatAlgElem{T}) where T <: RingElement
    return z
 end
 
+@doc Markdown.doc"""
+    zero_matrix(M::MatAlgElem{T}) where T <: RingElement
+> Return the zero matrix over the same base ring as $M$ and with the
+> same dimensions.
+"""
+function zero_matrix(M::MatAlgElem{T}) where T <: RingElement
+   return zero_matrix(M, nrows(M))
+end
+
 ###############################################################################
 #
 #   Identity matrix
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    identity_matrix(M::MatAlgElem{T}) where T <: RingElement
-> Return the identity matrix over the same base ring as $M$ and with the
-> same dimensions.
-"""
-function identity_matrix(M::MatAlgElem{T}) where T <: RingElement
+function identity_matrix(M::MatAlgElem{T}, n::Int) where T <: RingElement
    R = base_ring(M)
-   n = degree(M)
    arr = Array{T}(undef, n, n)
    for i in 1:n
       for j in 1:n
@@ -529,6 +526,15 @@ function identity_matrix(M::MatAlgElem{T}) where T <: RingElement
    z = MatAlgElem{T}(arr)
    z.base_ring = R
    return z
+end
+
+@doc Markdown.doc"""
+    identity_matrix(M::MatAlgElem{T}) where T <: RingElement
+> Return the identity matrix over the same base ring as $M$ and with the
+> same dimensions.
+"""
+function identity_matrix(M::MatAlgElem{T}) where T <: RingElement
+   return identity_matrix(M, nrows(M))
 end
 
 ###############################################################################

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -167,6 +167,16 @@ Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
    @test isa(M4, Generic.MatSpaceElem{elem_type(R)})
    @test M4.base_ring == R
 
+   M5 = identity_matrix(R, 2, 3)
+
+   @test isa(M5, Generic.MatSpaceElem{elem_type(R)})
+   @test M5.base_ring == R
+
+   M6 = identity_matrix(R, 3, 2)
+
+   @test isa(M6, Generic.MatSpaceElem{elem_type(R)})
+   @test M6.base_ring == R                                                               
+
    x = zero_matrix(R, 2, 2)
    y = zero_matrix(ZZ, 2, 3)
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -168,17 +168,22 @@ Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
    @test M4.base_ring == R
 
    M5 = identity_matrix(R, 2, 3)
+   M6 = identity_matrix(M5)
 
    @test isa(M5, Generic.MatSpaceElem{elem_type(R)})
    @test M5.base_ring == R
+   @test M5 == M6
 
-   M6 = identity_matrix(R, 3, 2)
+   M7 = identity_matrix(R, 3, 2)
+   M8 = identity_matrix(M7)
 
-   @test isa(M6, Generic.MatSpaceElem{elem_type(R)})
-   @test M6.base_ring == R                                                               
+   @test isa(M7, Generic.MatSpaceElem{elem_type(R)})
+   @test M7.base_ring == R                                                               
+   @test M7 == M8
 
    x = zero_matrix(R, 2, 2)
    y = zero_matrix(ZZ, 2, 3)
+   z = zero_matrix(x)
 
    @test x in [x, y]
    @test x in [y, x]
@@ -186,6 +191,8 @@ Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
+
+   @test z == x
 
    # Test creation from AbstractArray without setindex!
    A = MyTestMatrix(BigInt(3), 2)

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -110,6 +110,15 @@ end
 
    @test isa(m, MatAlgElem)
 
+   n = identity_matrix(m)
+   p = zero_matrix(m)
+
+   @test isa(n, MatAlgElem)
+   @test isa(p, MatAlgElem)
+
+   @test nrows(n) == degree(S)
+   @test nrows(p) == degree(S)
+
    @test_throws ErrorConstrDimMismatch S([t t^2 ; t^3 t^4])
    @test_throws ErrorConstrDimMismatch S([t t^2 t^3 ; t^4 t^5 t^6 ; t^7 t^8 t^9 ; t t^2 t^3])
    @test_throws ErrorConstrDimMismatch S([t, t^2])


### PR DESCRIPTION
* Remove eye
* Add identity_matrix(R, m, n) where m != n, setting ones down the diagonal
* Add zero_matrix(M), identity_matrix(M) where M is a matrix
* Add zero_matrix(M, n), identity_matrix(M, n) where M is a matrix

The final one is not currently documented. I can document it if you think it is desirable (I was not intending to implement it, but found it necessary after removing eye, as hnf seems to need it).

Also, do you want me to add a 2 integer version of that last one?