### PR TITLE
remove useless recursive method of crt

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -583,10 +583,8 @@ function module_isomorphism(M1::AbstractAlgebra.Module, M2::AbstractAlgebra.Modu
    Generic.ModuleIsomorphism(M1, M2, m)
 end
 
-#add empty functions so that Singular, Nemo and Hecke can import and extend.
-function crt(A...)
-  return AbstractAlgebra.crt(A...)
-end
+# add empty functions so that Singular, Nemo and Hecke can import and extend.
+function crt end
 
 export PowerSeriesRing, PolynomialRing, SparsePolynomialRing, MatrixSpace,
        MatrixAlgebra, FractionField, ResidueRing, Partition, PermGroup,


### PR DESCRIPTION
When using e.g. Nemo, and you get the argument wrong, this was leading to a stackoverflow:
```julia
julia> crt(1, 3, 1, 7)
ERROR: StackOverflowError:
Stacktrace:
[...]
```
Now:
```julia
julia> crt(1, 3, 1, 7)
ERROR: MethodError: no method matching crt(::Int64, ::Int64, ::Int64, ::Int64)
Closest candidates are:
[...]
```