### PR TITLE
make eltype work on all matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -172,7 +172,7 @@ Base.@propagate_inbounds function setindex!(a::MatrixElem, d::T, r::Int,
     a.entries[r, c] = base_ring(a)(d)
 end
 
-Base.eltype(::Type{<:MatrixElem{T}}) where T <: RingElem = T
+Base.eltype(::Type{<:MatrixElem{T}}) where {T} = T
 
 Base.isassigned(a::Union{Mat,MatAlgElem}, i, j) = isassigned(a.entries, i, j)
 
@@ -5232,4 +5232,3 @@ function MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int, cached::Bool = tru
    T = elem_type(R)
    return MatSpace{T}(R, r, c, cached)
 end
-

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -179,7 +179,7 @@ Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
    M8 = identity_matrix(M7)
 
    @test isa(M7, Generic.MatSpaceElem{elem_type(R)})
-   @test M7.base_ring == R                                                               
+   @test M7.base_ring == R
    @test M7 == M8
 
    x = zero_matrix(R, 2, 2)
@@ -323,6 +323,12 @@ end
       @test !iszero(m45)
       @test m45 isa Generic.MatSpaceElem
       @test parent(m45) == M45
+   end
+
+   let m = matrix(ZZ, 2, 3, 1:6)
+      @test typeof(m[1, 1]) == BigInt # not in AbstractAlgebra's hierarchy
+      @test eltype(m) == BigInt
+      @test eltype(typeof(m)) == BigInt
    end
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1147,7 +1147,6 @@ end
       @test c isa eltype(M)
 
       @test isunit(c)
-      @test inv(c) isa eltype(M)
       @test N[i,j] == -1
       @test M*N == N*M == c*R(1)
 


### PR DESCRIPTION
Sorry, in #463 I missed the case where the `eltype` is not a `RingElem`.