### PR TITLE
optimize reduce(vcat, vector_of_matrices)

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -4757,6 +4757,8 @@ function Base.vcat(A::MatrixElem...)
   return _vcat(A)
 end
 
+Base.reduce(::typeof(vcat), A::AbstractVector{<:MatrixElem}) = _vcat(A)
+
 function _vcat(A)
   if length(A) == 0
     error("Number of matrices to concatenate must be positive")
@@ -4791,6 +4793,8 @@ end
 function Base.hcat(A::MatrixElem...)
   return _hcat(A)
 end
+
+Base.reduce(::typeof(hcat), A::AbstractVector{<:MatrixElem}) = _hcat(A)
 
 function _hcat(A)
   if length(A) == 0
@@ -5232,4 +5236,3 @@ function MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int, cached::Bool = tru
    T = elem_type(R)
    return MatSpace{T}(R, r, c, cached)
 end
-

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1600,6 +1600,7 @@ end
                                   0 1 0;
                                   0 1 2;])
    @test hcat(B, C) == [B C]
+   @test hcat(B, C, C, B) == reduce(hcat, [B, C, C, B])
    let BC = hcat([B, C])
       @test size(BC) == (2, 1)
       @test BC[1] == B
@@ -1614,12 +1615,12 @@ end
                                   0 1;])
 
    @test vcat(A, B) == [A; B]
+   @test vcat(A, B, B, A) == reduce(vcat, [A, B, B, A])
    let AB = vcat([A, B])
       @test size(AB) == (2,)
       @test AB[1] == A
       @test AB[2] == B
    end
-
 
    @test [A D; B B C] == matrix(R, [1 2 1 2 3;
                                     3 4 4 5 6;


### PR DESCRIPTION
This is the idiomatic way to call vcat on a vector of matrices,
at least when performance matters (as opposed to
`vcat(vector_of_matrices...)`).
Let's optimize this case, like it's done in `Base` for `Vector`
and `Matrix`.
Similarly for `hcat`.

This is an alternative solution to the special implementation `vcat(A::Vector{<: MatrixElem})` which was removed in #409. 