### PR TITLE
fix StackOverflowError with Perm("not an integer")

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -324,14 +324,6 @@ function AllPerms(n::T) where T
   Generic.AllPerms(n)
 end
 
-function Perm(n::T) where T
-  Generic.Perm(n)
-end
-
-function Perm(a::AbstractVector{T}, check::Bool=true) where T
-  Generic.Perm(a, check)
-end
-
 function Partition(part::AbstractVector{T}, check::Bool=true) where T
   Generic.Partition(part, check)
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -45,6 +45,9 @@ end
 
    @test similar(g) isa Perm{T}
    @test similar(g, Int) isa Perm{Int}
+
+   @test_throws MethodError Perm("error")
+   @test_throws MethodError Perm(Any[])
 end
 
 @testset "Perm.parsingGAP..." begin


### PR DESCRIPTION
These forwarding methods in AbstractAlgebra.jl were leading to infinite recursion because `AbstractAlgebra.Perm === Generic.Perm`.
As I don't know the rationale behind all these forwarding methods in this file, I don't know what fix the maintainers would like:
1. delete the faulty methods from AbstractAlgebra.jl (this PR currently)
2. stop importing `Generic.Perm` within AbstractAlgebra.

I will update according to requests.

BTW, I would love if someone can give me a pointer to an explaination for these forwarding methods (i.e. why `AbstractAlgebra.AllPerms !== Generic.AllPerms` for example). 

 