### PR TITLE
fix DomainError() without arguments

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -99,7 +99,7 @@ end
 ###############################################################################
 
 function powers(a::T, d::Int) where {T <: NCRingElem}
-   d <= 0 && throw(DomainError())
+   d <= 0 && throw(DomainError(d, "the second argument must be positive"))
    S = parent(a)
    A = Array{T}(undef, d + 1)
    A[1] = one(S)

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -158,7 +158,7 @@ end
 ###############################################################################
 
 function powers(a::T, d::Int) where {T <: RingElement}
-   d <= 0 && throw(DomainError())
+   d <= 0 && throw(DomainError(d, "the second argument must be positive"))
    S = parent(a)
    A = Array{T}(undef, d + 1)
    A[1] = one(S)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -23,7 +23,6 @@ function O(a::AbstractAlgebra.AbsSeriesElem{T}) where T <: RingElement
       return deepcopy(a)    # 0 + O(x^n)
    end
    prec = length(a) - 1
-   prec < 0 && throw(DomainError())
    return parent(a)(Array{T}(undef, 0), 0, prec)
 end
 
@@ -56,7 +55,7 @@ function normalise(a::AbsSeries, len::Int)
 end
 
 function coeff(a::AbsSeries, n::Int)
-   n < 0  && throw(DomainError())
+   n < 0  && throw(DomainError(n, "n must be >= 0"))
    return n >= length(a) ? zero(base_ring(a)) : a.coeffs[n + 1]
 end
 
@@ -377,7 +376,7 @@ end
 > $x^n$.
 """
 function shift_left(x::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    xlen = length(x)
    prec = precision(x) + n
    prec = min(prec, max_precision(parent(x)))
@@ -406,7 +405,7 @@ end
 > $x^n$.
 """
 function shift_right(x::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    xlen = length(x)
    if n >= xlen
       z = zero(parent(x))
@@ -433,7 +432,7 @@ end
 > Return $a$ truncated to $n$ terms.
 """
 function truncate(a::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    len = length(a)
    if precision(a) <= n
       return a

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -185,7 +185,7 @@ function set_scale!(a::LaurentSeriesElem, scale::Int)
 end
 
 function polcoeff(a::LaurentSeriesElem, n::Int)
-   n < 0  && throw(DomainError())
+   n < 0  && throw(DomainError(n, "n must be >= 0"))
    return n >= pol_length(a) ? zero(base_ring(a)) : a.coeffs[n + 1]
 end
 
@@ -231,7 +231,7 @@ end
 > for padding. It is assumed that the scale factor of $a$ is divisible by $n$.
 """
 function downscale(a::LaurentSeriesElem{T}, n::Int) where T <: RingElement
-   n <= 0 && throw(DomainError())
+   n <= 0 && throw(DomainError(n, "n must be > 0"))
    lena = pol_length(a)
    if n == 1 || lena == 0
       return a
@@ -263,7 +263,7 @@ end
 > $a$ is divisible by $n$.
 """
 function upscale(a::LaurentSeriesElem{T}, n::Int) where T <: RingElement
-   n <= 0 && throw(DomainError())
+   n <= 0 && throw(DomainError(n, "n must be > 0"))
    lena = pol_length(a)
    if n == 1 || lena == 0
       return a

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2394,7 +2394,7 @@ function pow_fps(f::MPoly{T}, k::Int, bits::Int) where {T <: RingElement}
 end
 
 function ^(a::MPoly{T}, b::Int) where {T <: RingElement}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special case powers of x for constructing polynomials efficiently
    if length(a) == 0
       return parent(a)()

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -246,7 +246,7 @@ end
 > Return $a^b$. We require $b \geq 0$.
 """
 function ^(a::AbstractAlgebra.NCPolyElem{T}, b::Int) where {T <: NCRingElem}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special case powers of x for constructing polynomials efficiently
    R = parent(a)
    if isgen(a)

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -631,7 +631,7 @@ end
 ###############################################################################
 
 function pow_multinomial(a::AbstractAlgebra.PolyElem{T}, e::Int) where {T <: RingElement}
-   e < 0 && throw(DomainError())
+   e < 0 && throw(DomainError(e, "exponent must be >= 0"))
    lena = length(a)
    lenz = (lena - 1) * e + 1
    res = Array{T}(undef, lenz)
@@ -661,7 +661,7 @@ end
 > Return $a^b$. We require $b \geq 0$.
 """
 function ^(a::AbstractAlgebra.PolyElem{T}, b::Int) where {T <: RingElement}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special case powers of x for constructing polynomials efficiently
    R = parent(a)
    if isgen(a)
@@ -911,7 +911,7 @@ end
 > `DomainError()`.
 """
 function reverse(x::PolynomialElem, len::Int)
-   len < 0 && throw(DomainError())
+   len < 0 && throw(DomainError(len, "len must be >= 0"))
    r = parent(x)()
    fit!(r, len)
    for i = 1:len
@@ -943,7 +943,7 @@ end
 > $x^n$.
 """
 function shift_left(f::PolynomialElem, n::Int)
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    if n == 0
       return f
    end
@@ -965,7 +965,7 @@ end
 > $x^n$.
 """
 function shift_right(f::PolynomialElem, n::Int)
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    flen = length(f)
    if n >= flen
       return zero(parent(f))

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -21,7 +21,7 @@ export PowerSeriesRing, O, valuation, precision, max_precision, set_prec!,
 """
 function O(a::AbstractAlgebra.RelSeriesElem{T}) where T <: RingElement
    val = pol_length(a) + valuation(a) - 1
-   val < 0 && throw(DomainError())
+   val < 0 && throw(DomainError(a, "pol_length(a) + valuation(a) must be >= 1"))
    return parent(a)(Array{T}(undef, 0), 0, val, val)
 end
 
@@ -129,7 +129,7 @@ function set_val!(a::AbstractAlgebra.RelSeriesElem, val::Int)
 end
 
 function polcoeff(a::RelSeries, n::Int)
-   n < 0  && throw(DomainError())
+   n < 0  && throw(DomainError(n, "n must be >= 0"))
    return n >= pol_length(a) ? zero(base_ring(a)) : a.coeffs[n + 1]
 end
 
@@ -547,7 +547,7 @@ end
 > $x^n$.
 """
 function shift_left(x::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    xlen = pol_length(x)
    if xlen == 0
       z = zero(parent(x))
@@ -571,7 +571,7 @@ end
 > $x^n$.
 """
 function shift_right(x::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    xlen = pol_length(x)
    xval = valuation(x)
    xprec = precision(x)
@@ -603,7 +603,7 @@ end
 > Return $a$ truncated to (absolute) precision $n$.
 """
 function truncate(a::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingElement}
-   n < 0 && throw(DomainError())
+   n < 0 && throw(DomainError(n, "n must be >= 0"))
    alen = pol_length(a)
    aprec = precision(a)
    aval = valuation(a)
@@ -670,7 +670,7 @@ end
 > Return $a^b$. We require $b \geq 0$.
 """
 function ^(a::AbstractAlgebra.RelSeriesElem{T}, b::Int) where {T <: RingElement}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special case powers of x for constructing power series efficiently
    if pol_length(a) == 0
       z = parent(a)()

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -37,7 +37,7 @@ end
 ###############################################################################
 
 function coeff(x::SparsePoly, i::Int)
-   i < 0 && throw(DomainError())
+   i < 0 && throw(DomainError(i, "cannot get the i-th coefficient with i < 0"))
    return x.coeffs[i + 1]
 end
 
@@ -784,7 +784,7 @@ function pow_fps(f::SparsePoly{T}, k::Int) where {T <: RingElement}
 end
 
 function ^(a::SparsePoly{T}, b::Int) where {T <: RingElement}
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special case powers of x for constructing polynomials efficiently
    if length(a) == 0
       return parent(a)()

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -97,7 +97,7 @@ function div(a::S, b::T) where {S <: Integer, T <: Integer}
 end
 
 function powmod(a::T, b::Int, c::T) where T <: Integer
-   b < 0 && throw(DomainError())
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
    # special cases
    if a == 0
       return T(0)
@@ -182,7 +182,7 @@ end
 > generally of use to the user, but is used internally in AbstractAlgebra.jl.
 """
 function exp(a::T) where T <: Integer
-    a != 0 && throw(DomainError())
+    a != 0 && throw(DomainError(a, "a must be 0"))
     return T(1)
  end
 

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -180,7 +180,7 @@ end
 > Return $1$ if $a = 0$, otherwise throw an exception.
 """
 function exp(a::Rational{T}) where T <: Integer
-   a != 0 && throw(DomainError())
+   a != 0 && throw(DomainError(a, "a must be 0"))
    return Rational{T}(1)
 end
 

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -8,3 +8,10 @@ include("generic/NCPoly-test.jl")
    @test z == Fx(3)
    @test parent(z) === Fx
 end
+
+@testset "NCRings.powers..." begin
+   R = MatrixAlgebra(ZZ, 2)
+   S, y = PolynomialRing(R, "y")
+   @test_throws DomainError powers(y, 0)
+   @test_throws DomainError powers(y, -rand(1:100))
+end

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -32,3 +32,10 @@ end
    @test_throws MethodError elem_type('c')
    @test_throws MethodError elem_type(Char)
 end
+
+@testset "Generic.Rings.powers..." begin
+    for T in (ZZ, AbstractFloat, Integer, Rational)
+        @test_throws DomainError powers(T(2), 0)
+        @test_throws DomainError powers(T(2), -rand(1:100))
+    end
+end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -111,6 +111,9 @@ end
    @test coeff(a, 1) == 2
    @test coeff(b, 7) == 0
 
+   @test_throws DomainError coeff(a, -1)
+   @test_throws DomainError coeff(a, -rand(2:100))
+   
    T = ResidueRing(ZZ, 7)
    U, y = PowerSeriesRing(T, 10, "y", model=:capped_absolute)
 
@@ -501,6 +504,12 @@ end
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
+   
+   f = rand(R, 0:12, -10:10)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
 
    # Inexact field
    R, x = PowerSeriesRing(RealField, 10, "x", model=:capped_absolute)
@@ -515,6 +524,12 @@ end
       @test isapprox(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
+   
+   f = rand(R, 0:12, -1:1)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
 
    # Non-integral domain
    T = ResidueRing(ZZ, 6)
@@ -530,6 +545,12 @@ end
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
+   
+   f = rand(R, 0:12, 0:5)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
 end
 
 @testset "Generic.AbsSeries.truncation..." begin
@@ -543,6 +564,12 @@ end
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
+   
+   f = rand(R, 0:12, -10:10)
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
 
    # Inexact field
    R, x = PowerSeriesRing(RealField, 10, "x", model=:capped_absolute)
@@ -554,6 +581,12 @@ end
       @test isapprox(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
+   
+   f = rand(R, 0:12, -1:1)
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
 
    # Non-integral domain
    T = ResidueRing(ZZ, 6)
@@ -566,6 +599,12 @@ end
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
+   
+   f = rand(R, 0:12, 0:5)
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))   
 end
 
 @testset "Generic.AbsSeries.inversion..." begin

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -147,6 +147,14 @@ end
    @test coeff(a, 1) == 2
    @test coeff(b, 7) == 0
 
+   @test_throws DomainError polcoeff(a, -1)
+   @test_throws DomainError polcoeff(a, -rand(2:100))
+
+   @test_throws DomainError upscale(a, 0)
+   @test_throws DomainError upscale(a, -rand(1:100))
+   @test_throws DomainError downscale(a, 0)
+   @test_throws DomainError downscale(a, -rand(1:100))
+   
    T = ResidueRing(ZZ, 7)
    U, y = LaurentSeriesRing(T, 10, "y")
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -486,6 +486,9 @@ end
 
          @test (f == 0 && expn == 0 && f^expn == 0) || f^expn == r
       end
+
+      @test_throws DomainError rand(varlist)^-1
+      @test_throws DomainError rand(varlist)^-rand(2:100)
    end
 end
 

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -307,6 +307,10 @@ end
          r2 *= f
       end
    end
+
+   f = rand(S, 0:10, -10:10)
+   @test_throws DomainError f^identity(-1) # identity to skip calling literal_pow, which relies on inv
+   @test_throws DomainError f^-rand(2:100)
 end
 
 @testset "Generic.NCPoly.exact_division..." begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -603,6 +603,10 @@ end
       @test f == reverse(frev, len)
    end
 
+   f = rand(R, 0:10, -10:10)
+   @test_throws DomainError reverse(f, -1)
+   @test_throws DomainError reverse(f, -rand(2:100))
+
    # Fake finite field of char 7, degree 2
    S, y = PolynomialRing(GF(7), "y")
    F = ResidueField(S, y^2 + 6y + 3)
@@ -624,6 +628,10 @@ end
       @test length(frev) == len - shift
       @test f == reverse(frev, len)
    end
+
+   f = rand(R, 0:10, 0:1)
+   @test_throws DomainError reverse(f, -1)
+   @test_throws DomainError reverse(f, -rand(2:100))
 
    #  Inexact field
    R, x = PolynomialRing(RealField, "x")
@@ -644,6 +652,10 @@ end
       @test f == reverse(frev, len)
    end
 
+   f = rand(R, 0:10, -1:1)
+   @test_throws DomainError reverse(f, -1)
+   @test_throws DomainError reverse(f, -rand(2:100))
+
    #  Non-integral domain
    T = ResidueRing(ZZ, 6)
    R, x = T["x"]
@@ -663,6 +675,10 @@ end
       @test length(frev) == len - shift
       @test f == reverse(frev, len)
    end
+
+   f = rand(R, 0:10, 0:5)
+   @test_throws DomainError reverse(f, -1)
+   @test_throws DomainError reverse(f, -rand(2:100))
 end
 
 @testset "Generic.Poly.shift..." begin
@@ -677,6 +693,12 @@ end
       @test shift_left(f, s) == x^s*f
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
+
+   f = rand(R, 0:10, -10:10)
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
 
    # Fake finite field of char 7, degree 2
    S, y = PolynomialRing(GF(7), "y")
@@ -693,6 +715,12 @@ end
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
 
+   f = rand(R, 0:10, 0:1)
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+
    # Inexact field
    R, x = PolynomialRing(RealField, "x")
    for iter = 1:300
@@ -704,6 +732,12 @@ end
       @test shift_left(f, s) == x^s*f
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
+
+   f = rand(R, 0:10, -1:1)
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
 
    # Non-integral domain
    T = ResidueRing(ZZ, 6)
@@ -717,6 +751,12 @@ end
       @test shift_left(f, s) == x^s*f
       @test length(shift_right(f, s)) == max(0, length(f) - s)
    end
+
+   f = rand(R, 0:10, 0:5)
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
 end
 
 @testset "Generic.Poly.powering..." begin
@@ -736,6 +776,12 @@ end
       end
    end
 
+   f = rand(R, 0:10, -10:10)
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
+   @test_throws DomainError pow_multinomial(f, -1)
+   @test_throws DomainError pow_multinomial(f, -rand(2:100))
+
    # Fake finite field of char 7, degree 2
    S, y = PolynomialRing(GF(7), "y")
    F = ResidueField(S, y^2 + 6y + 3)
@@ -755,6 +801,12 @@ end
       end
    end
 
+   f = rand(R, 0:10, 0:1)
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
+   @test_throws DomainError pow_multinomial(f, -1)
+   @test_throws DomainError pow_multinomial(f, -rand(2:100))
+
    # Inexact field
    R, x = PolynomialRing(RealField, "x")
 
@@ -770,6 +822,12 @@ end
          r2 *= f
       end
    end
+
+   f = rand(R, 0:10, -1:1)
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
+   @test_throws DomainError pow_multinomial(f, -1)
+   @test_throws DomainError pow_multinomial(f, -rand(2:100))
 
    # Non-integral domain
    for iter = 1:10
@@ -789,6 +847,12 @@ end
          r2 *= f
       end
    end
+
+   f = rand(R, 0:10, 0:rand(1:25))
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
+   @test_throws DomainError pow_multinomial(f, -1)
+   @test_throws DomainError pow_multinomial(f, -rand(2:100))
 end
 
 if false

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -78,6 +78,8 @@
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
+
+   @test_throws DomainError O(0+O(x^0))
 end
 
 @testset "Generic.RelSeries.rand..." begin
@@ -122,6 +124,9 @@ end
    @test coeff(a, 1) == 2
    @test coeff(b, 7) == 0
 
+   @test_throws DomainError polcoeff(a, -1)
+   @test_throws DomainError polcoeff(a, -rand(2:100))
+   
    T = ResidueRing(ZZ, 7)
    U, y = PowerSeriesRing(T, 10, "y")
 
@@ -462,6 +467,10 @@ end
       end
    end
 
+   f = rand(R, 0:12, -10:10)
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
+
    # Inexact field
    R, x = PowerSeriesRing(RealField, 10, "x")
 
@@ -477,6 +486,10 @@ end
          r2 *= f
       end
    end
+
+   f = rand(R, 0:12, -1:1)
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
 
    # Non-integral domain
    for iter = 1:100
@@ -496,6 +509,10 @@ end
          r2 *= f
       end
    end
+   
+   f = rand(R, 0:12, 0:rand(1:25))
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-rand(2:100)
 end
 
 @testset "Generic.RelSeries.shift..." begin
@@ -512,6 +529,12 @@ end
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
+   
+   f = rand(R, 0:12, -10:10)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
 
    # Inexact field
    R, x = PowerSeriesRing(RealField, 10, "x")
@@ -527,6 +550,12 @@ end
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
 
+   f = rand(R, 0:12, -1:1)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
+
    # Non-integral domain
    T = ResidueRing(ZZ, 6)
    R, x = PowerSeriesRing(T, 10, "x")
@@ -541,6 +570,12 @@ end
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
+
+   f = rand(R, 0:12, 0:5)
+   @test_throws DomainError shift_left(f, -1)
+   @test_throws DomainError shift_left(f, -rand(2:100))
+   @test_throws DomainError shift_right(f, -1)
+   @test_throws DomainError shift_right(f, -rand(2:100))
 end
 
 @testset "Generic.RelSeries.truncation..." begin
@@ -555,6 +590,10 @@ end
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
 
+   f = rand(R, 0:12, -10:10)   
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
+
    # Inexact field
    R, x = PowerSeriesRing(RealField, 10, "x")
    for iter = 1:300
@@ -565,6 +604,10 @@ end
       @test isapprox(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
+
+   f = rand(R, 0:12, -1:1)
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))
 
    # Non-integral domain
    T = ResidueRing(ZZ, 6)
@@ -577,6 +620,10 @@ end
       @test isequal(truncate(f, s), f + O(x^s))
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
+
+   f = rand(R, 0:12, 0:5)
+   @test_throws DomainError truncate(f, -1)
+   @test_throws DomainError truncate(f, -rand(2:100))      
 end
 
 @testset "Generic.RelSeries.inversion..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -77,6 +77,9 @@ end
    end
 
    @test powmod(123, 1, 5) == 3
+
+   @test_throws DomainError powmod(123, -1, 5)
+   @test_throws DomainError powmod(123, -rand(2:100), 5)
 end
 
 @testset "Julia.Integers.exact_division..." begin
@@ -145,4 +148,11 @@ end
       @test AbstractAlgebra.sqrt(f)^2 == f
       @test AbstractAlgebra.sqrt(g)^2 == g
    end
+end
+
+@testset "Julia.Integers.exp..." begin
+   @test AbstractAlgebra.exp(0) == 1
+   @test_throws DomainError AbstractAlgebra.exp(1)
+   @test_throws DomainError AbstractAlgebra.exp(rand(2:1000))
+   @test_throws DomainError AbstractAlgebra.exp(-rand(1:1000))
 end

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -129,6 +129,13 @@ end
    end
 end
 
+@testset "Julia.Rationals.exp..." begin
+   @test AbstractAlgebra.exp(0//1) == 1
+   @test_throws DomainError AbstractAlgebra.exp(1//1)
+   @test_throws DomainError AbstractAlgebra.exp(rand(2:1000)//rand(1:1000))
+   @test_throws DomainError AbstractAlgebra.exp(-rand(1:1000//rand(1:1000)))
+end
+
 @testset "Julia.Rationals.divrem..." begin
    R = qq
    S = QQ


### PR DESCRIPTION
The expression `throw(DomainError())` was actually throwing a `MethodError`, because `DomainError()` doesn't accept zero arguments.