### PR TITLE
docs: fix wrongly placed backticks

### DIFF
--- a/docs/src/matrix_algebras.md
+++ b/docs/src/matrix_algebras.md
@@ -107,7 +107,8 @@ zero(::MatAlgebra)
 ```
 
 ```@docs
-identity_matrix(::MatAlgElem{T}) where T <: RingElement                                  ```
+identity_matrix(::MatAlgElem{T}) where T <: RingElement
+```
 
 *Examples*
 


### PR DESCRIPTION
This was messing up all the remaining of the page, see https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix_algebras/.