### PR TITLE
Block replacement functionality for matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -410,7 +410,7 @@ function setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T},
     startc = first(c)
     for i in r
         for j in c
-            a[i, j] = deepcopy(b[i - startr + 1, j - startc + 1])
+            a[i, j] = b[i - startr + 1, j - startc + 1]
         end
     end
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -397,6 +397,38 @@ function Base.view(M::AbstractAlgebra.MatElem{T}, rows::Colon, cols::Colon) wher
    return view(M, 1:nrows(M), 1:ncols(M))
 end
 
+###############################################################################
+#
+#   Block replacement
+#
+###############################################################################
+
+function setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, r::UnitRange{Int}, c::UnitRange{Int}) where T
+    _checkbounds(a, r, c)
+    size(b) == (length(r), length(c)) || throw(DimensionMismatch("tried to assign a $(nrows(b))x$(ncols(b)) matrix to a $(length(r))x$(length(c)) destination"))
+    startr = first(r)
+    startc = first(c)
+    for i in r
+        for j in c
+            a[i, j] = deepcopy(b[i - startr + 1, j - startc + 1])
+        end
+    end
+end
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, r::UnitRange{Int}, ::Colon) where T = setindex!(a, b, r, 1:ncols(a))
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, ::Colon, c::UnitRange{Int}) where T = setindex!(a, b, 1:nrows(a), c)
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, ::Colon, ::Colon) where T = setindex!(a, b, 1:nrows(a), 1:ncols(a))
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, r::Int, c::UnitRange{Int}) where T = setindex!(a, b, r:r, c)
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, r::UnitRange{Int}, c::Int) where T = setindex!(a, b, r, c:c)
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, r::Int, ::Colon) where T = setindex!(a, b, r:r, 1:ncols(a))
+
+setindex!(a::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}, ::Colon, c::Int) where T = setindex!(a, b, 1:nrows(a), c:c)
+
 ################################################################################
 #
 #   Size, axes and issquare

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -424,6 +424,20 @@ end
    @test_throws BoundsError A[2:3, 1:10]
 end
 
+@testset "Generic.Mat.block_replacement..." begin
+   S = MatrixSpace(ZZ, 9, 9)
+   (r, c) = (rand(1:9), rand(1:9))
+   T = MatrixSpace(ZZ, r, c)
+   a = rand(S, -100:100)
+   b = rand(T, -100:100)
+   startr = rand(1:(9-r+1))
+   endr = startr + r - 1
+   startc = rand(1:(9-c+1))
+   endc = startc + c - 1
+   a[startr:endr, startc:endc] = b
+   @test a[startr:endr, startc:endc] == b
+end
+
 @testset "Generic.Mat.binary_ops..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)


### PR DESCRIPTION
In the spirit of https://github.com/Nemocas/AbstractAlgebra.jl/pull/404:
```
a = matrix(ZZ, [1 2 3; 4 5 6; 7 8 9]);
b = matrix(ZZ, [-1 -2; -3 -4]);
a[1:2, 2:3] = b; a
```
returns the matrix `a` with (the entries of) the 2x2 block in the upper right corner replaced by (`deepcopy`s of the entries of) `b`:
```
[1  -1  -2]
[4  -3  -4]
[7   8   9]
```
Also allows `Int` and `:` arguments. Throws an error if `b` does not fit exactly.