### PR TITLE
Matrix tests: comparisons

### DIFF
--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -1,4 +1,4 @@
-using Random: MersenneTwister, randsubseq
+using Random: Random, MersenneTwister, randsubseq
 
 const rng = MersenneTwister()
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1,3 +1,12 @@
+const RINGS = Dict(
+   "exact ring"          => (ZZ,                 (-1000:1000,)),
+   "exact field"         => (GF(7),              ()),
+   "inexact ring"        => (RealField["t"][1],  (0:200, -1000:1000)),
+   "inexact field"       => (RealField,          (-1000:1000,)),
+   "non-integral domain" => (ResidueRing(ZZ, 6), (0:5,)),
+   "fraction field"      => (QQ,                 (-1000:1000,)),
+)
+
 primes100 = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139,
 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227,
@@ -861,6 +870,25 @@ end
    @test A == inv(P)*(P*A)
 end
 
+######### OPTION 1 ############################################
+
+function test_comparison(R, randparams)
+   S = MatrixSpace(R, rand(1:9), rand(1:9))
+   seed = rand(1:999)
+
+   Random.seed!(seed)
+   A = rand(S, randparams...)
+   Random.seed!(seed)
+   B = rand(S, randparams...)
+
+   @test A == B
+   @test matrix(R, copy(A.entries)) == A
+
+   if !isone(A)
+      @test A != one(S)
+   end
+end
+
 @testset "Generic.Mat.comparison..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
@@ -871,7 +899,47 @@ end
    @test A == B
 
    @test A != one(S)
+
+   test_comparison(RINGS["exact ring"]...)
+   test_comparison(RINGS["exact field"]...)
+   test_comparison(RINGS["inexact ring"]...)
+   test_comparison(RINGS["inexact field"]...)
+   test_comparison(RINGS["non-integral domain"]...)
+   test_comparison(RINGS["fraction field"]...)
 end
+
+######### OPTION 2 ############################################
+
+@testset "Generic.Mat.comparison..." begin
+   R, t = PolynomialRing(QQ, "t")
+   S = MatrixSpace(R, 3, 3)
+
+   A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
+   B = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
+
+   @test A == B
+
+   @test A != one(S)
+
+   @testset "$name" for (name, (R, randparams)) in RINGS
+      S = MatrixSpace(R, rand(1:9), rand(1:9))
+      seed = rand(1:999)
+
+      Random.seed!(seed)
+      A = rand(S, randparams...)
+      Random.seed!(seed)
+      B = rand(S, randparams...)
+
+      @test A == B
+      @test matrix(R, copy(A.entries)) == A
+
+      if !isone(A)
+         @test A != one(S)
+      end   
+   end
+end
+
+#################################################################
 
 @testset "Generic.Mat.adhoc_comparison..." begin
    R, t = PolynomialRing(QQ, "t")


### PR DESCRIPTION
To avoid having to copy-paste code for testing different rings on the same operations, while keeping the ability to see easily where the potential errors come from, @fieker suggested to use functions, called repeatedly on different line with different ring arguments. This is "option 1" (cf. code). An alternative is to use `@testset for`, which is "option 2". Here is how both options look like, where `RINGS` is a predefined `Dict` mapping a name (e.g. `"exact ring"`) to an initialized ring together with parameters allowing to call `rand` on it. 

### Option 1
```julia
function test_comparison(R, randparams)
   S = MatrixSpace(R, rand(1:9), rand(1:9))
   A = rand(S, randparams...)
   @test A == A
   # ...
end

@testset "Generic.Mat.comparison..." begin
    # ... some explicit test code using one specific ring

   test_comparison(RINGS["exact ring"]...)
   test_comparison(RINGS["exact field"]...)
   # ...  
end
```

Assuming the tests fail for two rings, the error looks like:
```
Generic.Mat.comparison...: Test Failed at [...]/AbstractAlgebra/test/generic/file.jl:9
  Expression: false
Stacktrace:
 [1] test_comparison(::AbstractAlgebra.Generic.PolyRing{BigFloat}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}) at [...]/AbstractAlgebra/test/generic/file.jl:9
 [2] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:37
 [3] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [4] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:25
Generic.Mat.comparison...: Test Failed at [...]/AbstractAlgebra/test/generic/file.jl:9
  Expression: false
Stacktrace:
 [1] test_comparison(::AbstractAlgebra.Generic.PolyRing{BigFloat}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}) at [...]/AbstractAlgebra/test/generic/file.jl:9
 [2] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:38
 [3] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [4] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:25
Test Summary:             | Pass  Fail  Total
Generic.Mat.comparison... |   20     2     22
ERROR: LoadError: Some tests did not pass: 20 passed, 2 failed, 0 errored, 0 broken.
in expression starting at [...]/AbstractAlgebra/test/generic/file.jl:24
```
The exact line of the failure (containing `@test false`) is shown (line 9 here), and the entry [2] of stacktraces show the line of the call-site (lines 37 and 38 here), which allows to find out to which rings the failures correspond to. 

### Option 2
```julia
@testset "Generic.Mat.comparison..." begin
   # ... some explicit test code using one specific ring

   @testset "$name" for (name, (R, randparams)) in RINGS
      S = MatrixSpace(R, rand(1:9), rand(1:9))
      A = rand(S, randparams...)
      @test A == A
      # ...   
   end
end
```

Assuming the tests fail for two rings, the error looks like:
```
inexact field: Test Failed at [...]/AbstractAlgebra/test/generic/file.jl:61
  Expression: false
Stacktrace:
 [1] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:61
 [2] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1181
 [3] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:56
 [4] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [5] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:46
exact field: Test Failed at [...]/AbstractAlgebra/test/generic/file.jl:61
  Expression: false
Stacktrace:
 [1] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:61
 [2] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1181
 [3] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:56
 [4] top-level scope at /local/src/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [5] top-level scope at [...]/AbstractAlgebra/test/generic/file.jl:46
Test Summary:              | Pass  Fail  Total
 Generic.Mat.comparison... |   20     2     22
  fraction field           |    3            3
  non-integral domain      |    3            3
  inexact field            |    3     1      4
  inexact ring             |    3            3
  exact ring               |    3            3
  exact field              |    3     1      4
ERROR: LoadError: Some tests did not pass: 20 passed, 2 failed, 0 errored, 0 broken.
in expression starting at [...]/AbstractAlgebra/test/generic/file.jl:45
```
Note that the detailed table at the end is printed only when there is a failure, as it's a nested `@testset`. The line containing the failed test (`@test false`) is shown (line 61), and the "names" of the failed tests is indicated.

I quite prefer option 2, as creating a separate function looks a bit artificial, and we noticed that running all the tests became quite faster when we switched away from using functions to using `@testset`s, presumably because it saved compilation time. `@testset for` is a standard feature, made exactly for the purpose of running the same tests on different objects.

But in any case, I vastly prefer one these two options over copy-pasting the same code all over.