### PR TITLE
fix bug in powers and add few more tests

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -211,7 +211,7 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row, add_ro
                  newton_to_monomial!, ngens, normalise, nrows, nvars, O, one,
                  order, ordering, parent_type, parity, partitionseq, Perm, perm,
                  permtype, @perm_str, polcoeff, pol_length, powmod,
-                 pow_multinomial, popov, popov_with_transform, powers,
+                 pow_multinomial, popov, popov_with_transform, 
                  precision, preimage, preimage_map, primpart, pseudodivrem,
                  pseudo_inv, pseudorem, push_term!, rank, randmat_triu,
                  randmat_with_rank, rand_ordering, rank_profile_popov, remove,

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -98,12 +98,16 @@ end
 #
 ###############################################################################
 
-function powers(a::T, d::Int) where {T <: NCRingElem}
+@doc Markdown.doc"""
+    powers(a::Union{NCRingElement, MatElem}, d::Int)
+> Return an array $M$ of "powers" of `a` where $M[i + 1] = a^i$ for $i = 0..d$
+"""
+function powers(a::T, d::Int) where {T <: Union{NCRingElement, MatElem}}
    d <= 0 && throw(DomainError(d, "the second argument must be positive"))
-   S = parent(a)
+   a isa MatElem && !issquare(a) && throw(DomainError(a, "matrix must be square"))
    A = Array{T}(undef, d + 1)
-   A[1] = one(S)
-   if d > 1
+   A[1] = one(a)
+   if d > 0
       c = a
       A[2] = a
       for i = 2:d

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -153,28 +153,6 @@ end
 
 ###############################################################################
 #
-#   Baby-steps giant-steps powering
-#
-###############################################################################
-
-function powers(a::T, d::Int) where {T <: RingElement}
-   d <= 0 && throw(DomainError(d, "the second argument must be positive"))
-   S = parent(a)
-   A = Array{T}(undef, d + 1)
-   A[1] = one(S)
-   if d > 0
-      c = a
-      A[2] = a
-      for i = 2:d
-         c *= a
-         A[i + 1] = c
-      end
-   end
-   return A
-end
-
-###############################################################################
-#
 #   Type traits
 #
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -781,26 +781,6 @@ function ^(a::MatrixElem, b::Int)
    end
 end
 
-@doc Markdown.doc"""
-    powers(a::Generic.MatrixElem, d::Int)
-> Return an array of matrices $M$ wher $M[i + 1] = a^i$ for $i = 0..d$
-"""
-function powers(a::MatrixElem, d::Int)
-   !issquare(a) && error("Dimensions do not match in powers")
-   d <= 0 && throw(DomainError(d, "Negative dimension in powers"))
-   A = Array{typeof(a)}(undef, d + 1)
-   A[1] = identity_matrix(a)
-   if d > 1
-      c = a
-      A[2] = a
-      for i = 2:d
-         c *= a
-         A[i + 1] = c
-      end
-   end
-   return A
-end
-
 ###############################################################################
 #
 #   Comparisons

--- a/src/julia/JuliaTypes.jl
+++ b/src/julia/JuliaTypes.jl
@@ -92,7 +92,8 @@ end
 #
 ###############################################################################
 
-const RingElement = Union{RingElem, Integer, Rational, AbstractFloat}
+const RingElement   = Union{RingElem,   Integer, Rational, AbstractFloat}
+const NCRingElement = Union{NCRingElem, Integer, Rational, AbstractFloat}
 
 const FieldElement = Union{FieldElem, Rational, AbstractFloat}
 

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -10,8 +10,46 @@ include("generic/NCPoly-test.jl")
 end
 
 @testset "NCRings.powers..." begin
-   R = MatrixAlgebra(ZZ, 2)
-   S, y = PolynomialRing(R, "y")
-   @test_throws DomainError powers(y, 0)
-   @test_throws DomainError powers(y, -rand(1:100))
+   
+   # non-commutative rings
+   A = MatrixAlgebra(ZZ, rand(1:9))
+   a = rand(A, 1:9)
+
+   B, _ = PolynomialRing(A, "y")
+   b = rand(B, 1:9, 1:9)
+
+   # matrices
+   n = rand(1:9)
+   C = MatrixSpace(ZZ, n, n)
+   c = rand(C, 1:9)
+   
+   # commutative rings
+   d = rand() * rand(-9:9)
+   e = rand(big.(-9:9))
+   f = rand(1:9)//rand(1:9)
+
+   G, _ = PolynomialRing(ZZ, "x")
+   g = rand(G, 1:9, 1:9)
+
+   @testset "$T" for (x, T) in (x => string(nameof(typeof(x))) for x in (a, b, c, d, e, f, g))
+      @test_throws DomainError powers(x, 0)
+      @test_throws DomainError powers(x, -rand(1:100))
+      @test_throws DomainError powers(x, 0)
+      @test_throws DomainError powers(x, -rand(1:100))
+      
+      P = powers(x, 1)
+      @test length(P) == 2
+      @test isone(P[1])
+      @test P[2] == x
+
+      n = rand(2:9)
+      Q = powers(x, n)
+      @test length(Q) == n+1
+      @test Q[1:2] == P
+      @test Q[3] == x*x
+   end
+
+   # powers must error out on non-square matrices
+   M = MatrixSpace(ZZ, 2, rand(3:9))
+   @test_throws DomainError powers(rand(M, 1:9), rand(1:9))
 end

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -32,10 +32,3 @@ end
    @test_throws MethodError elem_type('c')
    @test_throws MethodError elem_type(Char)
 end
-
-@testset "Generic.Rings.powers..." begin
-    for T in (ZZ, AbstractFloat, Integer, Rational)
-        @test_throws DomainError powers(T(2), 0)
-        @test_throws DomainError powers(T(2), -rand(1:100))
-    end
-end


### PR DESCRIPTION
Previously, `powers(a, 1)[2]` was an undefined entry in the array. When `a::RingElem`, it was fixed in #291, but the bug remained for other objects.
I merged here the three different definitions, which were basically identical.