### PR TITLE
enable R["x", "y"] syntax for MPolyRing construction

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -71,6 +71,13 @@ cached. Setting the optional argument `cached` to `false` will prevent the paren
 The optional named argument `ordering` can be used to specify an ordering. The currently
 supported options are `:lex`, `:deglex` and `:degrevlex`.
 
+Like for univariate polynomials, a shorthand version of this function is provided when the number of
+generators is greater than `1`: given a base ring `R`, we abbreviate the constructor as follows:
+
+```julia
+R["x", "y", ...]
+```
+
 Here are some examples of creating multivariate polynomial rings and making use of the
 resulting parent objects to coerce various elements into the polynomial ring.
 
@@ -79,6 +86,9 @@ resulting parent objects to coerce various elements into the polynomial ring.
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(ZZ, ["x", "y"]; ordering=:deglex)
 (Multivariate Polynomial Ring in x, y over Integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y])
+
+julia> T, (z, t) = QQ["z", "t"]
+(Multivariate Polynomial Ring in z, t over Rationals, AbstractAlgebra.Generic.MPoly{Rational{BigInt}}[z, t])
 
 julia> f = R()
 0

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -595,6 +595,8 @@ export Generic
 ###############################################################################
 
 getindex(R::NCRing, s::Union{String, Char}) = PolynomialRing(R, s)
+getindex(R::NCRing, s::Union{String, Char}, ss::Union{String, Char}...) =
+   PolynomialRing(R, [s, ss...])
 
 # syntax x = R["x"]["y"]
 getindex(R::Tuple{Union{Ring, NCRing}, Union{PolyElem, NCPolyElem}}, s::Union{String, Char}) = PolynomialRing(R[1], s)

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -72,6 +72,12 @@
       @test x in keys(Dict(x => 1))
       @test !(y in keys(Dict(x => 1)))
    end
+
+   # test "getindex" syntax
+   S, (y, z) = R["y", "z"]
+   @test S isa Generic.MPolyRing{Generic.Poly{BigInt}}
+   @test y isa Generic.MPoly{Generic.Poly{BigInt}}
+   @test z isa Generic.MPoly{Generic.Poly{BigInt}}
 end
 
 @testset "Generic.MPoly.geobuckets..." begin


### PR DESCRIPTION
I will add documentation if this change gets support.