### PR TITLE
implement literal_pow for NCRingElem

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -92,6 +92,8 @@ end
 
 ==(x::RingElement, y::NCRingElem) = parent(y)(x) == y
 
+Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
+
 ###############################################################################
 #
 #   One and zero

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -119,8 +119,6 @@ function addmul!(z::T, x::T, y::T, c::T) where {T <: RingElem}
    return z
 end
 
-Base.literal_pow(::typeof(^), x::T, ::Val{p}) where {p, T <: RingElem} = x^p
-
 ###############################################################################
 #
 #   Delayed reduction

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -312,7 +312,9 @@ end
    end
 
    f = rand(S, 0:10, -10:10)
-   @test_throws DomainError f^identity(-1) # identity to skip calling literal_pow, which relies on inv
+   @test_throws DomainError f^-1
+   @test_throws DomainError f^-3   
+   @test_throws DomainError f^identity(-1)
    @test_throws DomainError f^-rand(2:100)
 end
 


### PR DESCRIPTION
This adjusts the error for NC polynomials to what we have for commutative polynomials:
```julia
julia> PolynomialRing(MatrixAlgebra(ZZ, 2), "x")[2]^-2 # master
ERROR: MethodError: no method matching inv(::AbstractAlgebra.Generic.NCPoly{AbstractAlgebra.Generic.MatAlgElem{BigInt}})
Closest candidates are:
[...]

julia> PolynomialRing(MatrixAlgebra(ZZ, 2), "x")[2]^-2 # PR
ERROR: DomainError with -2:
exponent must be >= 0
[...]
```