### PR TITLE
make isone(non_square_matrix) false

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -256,10 +256,11 @@ end
 
 @doc Markdown.doc"""
     isone(a::Generic.MatrixElem)
-> Return `true` if the supplied matrix $a$ is diagonal with ones along the
-> diagonal, otherwise return `false`.
+> Return `true` if `a` is an identity matrix, i.e. if $a$ is a diagonal square matrix
+> with ones along the diagonal and zeros elsewhere.
 """
 function isone(a::MatrixElem)
+   issquare(a) || return false
    for i = 1:nrows(a)
       for j = 1:ncols(a)
          if i == j


### PR DESCRIPTION
Cf. discussion at #516.

The current behavior implies that we can have `isone(a) == true` and `one(a) == a` error out, e.g. `a = ZZ[1 0]`, because `one(a)` requires a square matrix, but `isone(a)` returns `true`. So this PR makes `one` and `isone` consistent. 

I will add tests if this gets support.  