### PR TITLE
enable powers(x, 0)

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -113,19 +113,17 @@ zero(x::NCRingElem) = zero(parent(x))
 > Return an array $M$ of "powers" of `a` where $M[i + 1] = a^i$ for $i = 0..d$
 """
 function powers(a::T, d::Int) where {T <: Union{NCRingElement, MatElem}}
-   d <= 0 && throw(DomainError(d, "the second argument must be positive"))
+   d < 0 && throw(DomainError(d, "the second argument must be nonnegative"))
    a isa MatElem && !issquare(a) && throw(DomainError(a, "matrix must be square"))
-   A = Array{T}(undef, d + 1)
-   A[1] = one(a)
+   M = Array{T}(undef, d + 1)
+   M[1] = one(a)
    if d > 0
-      c = a
-      A[2] = a
+      M[2] = a
       for i = 2:d
-         c *= a
-         A[i + 1] = c
+         M[i + 1] = M[i] * a
       end
    end
-   return A
+   return M
 end
 
 ###############################################################################

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -32,10 +32,11 @@ end
    g = rand(G, 1:9, 1:9)
 
    @testset "$T" for (x, T) in (x => string(nameof(typeof(x))) for x in (a, b, c, d, e, f, g))
-      @test_throws DomainError powers(x, 0)
       @test_throws DomainError powers(x, -rand(1:100))
-      @test_throws DomainError powers(x, 0)
-      @test_throws DomainError powers(x, -rand(1:100))
+
+      S = powers(x, 0)
+      @test length(S) == 1
+      @test isone(S[1]) 
       
       P = powers(x, 1)
       @test length(P) == 2


### PR DESCRIPTION
There doesn't seem to be a justification to disallow `powers(x, 0)`, which would otherwise be perfectly defined according the definition in the docstring. 

This also slightly simplifies slightly the implementation by getting rid of the local variable `c`, and renames `A` to `M`, which makes it easier to compare the implementation to the specification in the docstring.