### PR TITLE
sub and getindex on matrices: harmonize the arguments they accept

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -144,28 +144,6 @@ julia> P = R[1; 2; t] # create a column vector
 [   t]
 ```
 
-## Submatrices
-
-In addition to the functionality described in the Matrix interface for taking
-submatrices of a matrix, the following function variant is also available.
-
-```@docs
-sub(::MatElem, ::Int, ::Int, ::Int, ::Int)
-```
-
-**Examples**
-
-```jldoctest
-julia> M = ZZ[1 2 3; 2 3 4]
-[1  2  3]
-[2  3  4]
-
-julia> N = sub(M, 1, 1, 2, 2)
-[1  2]
-[2  3]
-
-```
-
 ## Matrix functionality provided by AbstractAlgebra.jl
 
 Most of the following generic functionality is available for both matrix spaces and

--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -325,7 +325,7 @@ performance reasons.
 The following are only available for matrix spaces, not for matrix algebras.
 
 ```julia
-sub(M::MyMat{T}, rows::UnitRange{Int}, cols::UnitRange{Int}) where T <: AbstractAlgebra.RingElem
+Base.getindex(M::MyMat, rows::AbstractVector{Int}, cols::AbstractVector{Int})
 ```
 
 Return a new matrix with the same entries as the submatrix with the given range of rows

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -369,17 +369,17 @@ function sub(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::Abstra
    return z
 end
 
-getindex(x::AbstractAlgebra.MatElem, r::UnitRange{Int}, c::UnitRange{Int}) = sub(x, r, c)
+getindex(x::AbstractAlgebra.MatElem, r::AbstractVector{Int}, c::AbstractVector{Int}) = sub(x, r, c)
 
-getindex(x::AbstractAlgebra.MatElem, r::UnitRange{Int}, ::Colon) = sub(x, r, 1:ncols(x))
+getindex(x::AbstractAlgebra.MatElem, r::AbstractVector{Int}, ::Colon) = sub(x, r, 1:ncols(x))
 
-getindex(x::AbstractAlgebra.MatElem, ::Colon, c::UnitRange{Int}) = sub(x, 1:nrows(x), c)
+getindex(x::AbstractAlgebra.MatElem, ::Colon, c::AbstractVector{Int}) = sub(x, 1:nrows(x), c)
 
 getindex(x::AbstractAlgebra.MatElem, ::Colon, ::Colon) = sub(x, 1:nrows(x), 1:ncols(x))
 
-getindex(x::AbstractAlgebra.MatElem, r::Int, c::UnitRange{Int}) = sub(x, r:r, c)
+getindex(x::AbstractAlgebra.MatElem, r::Int, c::AbstractVector{Int}) = sub(x, r:r, c)
 
-getindex(x::AbstractAlgebra.MatElem, r::UnitRange{Int}, c::Int) = sub(x, r, c:c)
+getindex(x::AbstractAlgebra.MatElem, r::AbstractVector{Int}, c::Int) = sub(x, r, c:c)
 
 getindex(x::AbstractAlgebra.MatElem, r::Int, ::Colon) = sub(x, r:r, 1:ncols(x))
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -108,7 +108,8 @@ function _checkbounds(A, i::Int, j::Int)
             Base.throw_boundserror(A, (i, j))
 end
 
-function _checkbounds(A, rows::UnitRange{Int}, cols::UnitRange{Int})
+function _checkbounds(A, rows::AbstractArray{Int}, cols::AbstractArray{Int})
+   Base.require_one_based_indexing(rows, cols)
    isempty(rows) || _checkbounds(nrows(A), first(rows)) && _checkbounds(nrows(A), last(rows)) ||
       throw(BoundsError(A, rows))
    isempty(cols) || _checkbounds(ncols(A), first(cols)) && _checkbounds(ncols(A), last(cols)) ||
@@ -354,7 +355,7 @@ canonical_unit(a::MatrixElem) = canonical_unit(a[1, 1])
 > * `:`, which is interpreted as `1:nrows(M)` or `1:ncols(M)` respectively.
 """
 function getindex(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::AbstractVector{Int})
-   Base.require_one_based_indexing(rows, cols)
+   _checkbounds(M, rows, cols)
    A = similar(M, length(rows), length(cols))
    for i in 1:length(rows)
       for j in 1:length(cols)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -344,19 +344,6 @@ canonical_unit(a::MatrixElem) = canonical_unit(a[1, 1])
 #
 ###############################################################################
 
-function sub(M::AbstractAlgebra.MatElem, rows::UnitRange{Int}, cols::UnitRange{Int})
-  _checkbounds(M, rows, cols)
-  z = similar(M, length(rows), length(cols))
-  startr = first(rows)
-  startc = first(cols)
-  for i in rows
-    for j in cols
-      z[i - startr + 1, j - startc + 1] = deepcopy(M[i, j])
-    end
-  end
-  return z
-end
-
 @doc Markdown.doc"""
     sub(M::AbstractAlgebra.MatElem, r1::Int, c1::Int, r2::Int, c2::Int)
 > Return a copy of the submatrix of $M$ from $(r1, c1)$ to $(r2, c2)$ inclusive. Note
@@ -367,15 +354,15 @@ function sub(M::AbstractAlgebra.MatElem, r1::Int, c1::Int, r2::Int, c2::Int)
 end
 
 @doc Markdown.doc"""
-    sub(M::AbstractAlgebra.MatElem, rows::Array{Int,1}, cols::Array{Int,1})
+    sub(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::AbstractVector{Int})
 > Return a copy of the submatrix $A$ of $M$ defined by A[i,j] = M[rows[i], cols[j]]
 > for i=1,...,length(rows) and j=1,...,length(cols)
 """
-function sub(M::AbstractAlgebra.MatElem, rows::Array{Int,1}, cols::Array{Int,1})
+function sub(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+   Base.require_one_based_indexing(rows, cols)
    z = similar(M, length(rows), length(cols))
    for i in 1:length(rows)
       for j in 1:length(cols)
-         Generic._checkbounds(M, rows[i], cols[j])
          z[i, j] = deepcopy(M[rows[i], cols[j]])
       end
    end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -340,21 +340,12 @@ canonical_unit(a::MatrixElem) = canonical_unit(a[1, 1])
 
 ###############################################################################
 #
-#   Sub
+#   getindex
 #
 ###############################################################################
 
 @doc Markdown.doc"""
-    sub(M::AbstractAlgebra.MatElem, r1::Int, c1::Int, r2::Int, c2::Int)
-> Return a copy of the submatrix of $M$ from $(r1, c1)$ to $(r2, c2)$ inclusive. Note
-> that if the copy is modified, the original matrix is not.
-"""
-function sub(M::AbstractAlgebra.MatElem, r1::Int, c1::Int, r2::Int, c2::Int)
-  return sub(M, r1:r2, c1:c2)
-end
-
-@doc Markdown.doc"""
-    sub(M::AbstractAlgebra.MatElem, rows, cols)
+    Base.getindex(M::AbstractAlgebra.MatElem, rows, cols)
 > When `rows` and `cols` are specified as an `AbstractVector{Int}`, return a copy of
 > the submatrix $A$ of $M$ defined by `A[i,j] = M[rows[i], cols[j]]`
 > for `i=1,...,length(rows)` and `j=1,...,length(cols)`.
@@ -362,7 +353,7 @@ end
 > * an integer `i`, which is  interpreted as `i:i`, or
 > * `:`, which is interpreted as `1:nrows(M)` or `1:ncols(M)` respectively.
 """
-function sub(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+function getindex(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::AbstractVector{Int})
    Base.require_one_based_indexing(rows, cols)
    A = similar(M, length(rows), length(cols))
    for i in 1:length(rows)
@@ -373,13 +364,9 @@ function sub(M::AbstractAlgebra.MatElem, rows::AbstractVector{Int}, cols::Abstra
    return A
 end
 
-sub(M::AbstractAlgebra.MatElem,
-    rows::Union{Int,Colon,AbstractVector{Int}},
-    cols::Union{Int,Colon,AbstractVector{Int}}) = sub(M, _to_indices(M, rows, cols)...)
-
 getindex(M::AbstractAlgebra.MatElem,
          rows::Union{Int,Colon,AbstractVector{Int}},
-         cols::Union{Int,Colon,AbstractVector{Int}}) = sub(M, _to_indices(M, rows, cols)...)
+         cols::Union{Int,Colon,AbstractVector{Int}}) = M[_to_indices(M, rows, cols)...]
 
 function _to_indices(x, rows, cols)
    if rows isa Integer
@@ -1798,7 +1785,7 @@ function minors(A::AbstractAlgebra.MatElem, k::Int)
    mins = Array{elem_type(base_ring(A)), 1}(undef, 0)
    for ri in row_indices
       for ci in col_indices
-         push!(mins, det(AbstractAlgebra.Generic.sub(A, ri, ci)))
+         push!(mins, det(A[ri, ci]))
       end
    end
    return(mins)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -109,7 +109,7 @@ function _checkbounds(A, i::Int, j::Int)
 end
 
 function _checkbounds(A, rows::AbstractArray{Int}, cols::AbstractArray{Int})
-   Base.require_one_based_indexing(rows, cols)
+   Base.has_offset_axes(rows, cols) && throw(ArgumentError("offset arrays are not supported"))
    isempty(rows) || _checkbounds(nrows(A), first(rows)) && _checkbounds(nrows(A), last(rows)) ||
       throw(BoundsError(A, rows))
    isempty(cols) || _checkbounds(ncols(A), first(cols)) && _checkbounds(ncols(A), last(cols)) ||

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -507,8 +507,10 @@ end
    @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-
+   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
 
@@ -523,6 +525,8 @@ end
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
    @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
@@ -538,6 +542,8 @@ end
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
    @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
@@ -553,6 +559,8 @@ end
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
    @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
@@ -568,6 +576,8 @@ end
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
    @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
@@ -583,6 +593,8 @@ end
    @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
    @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
    @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
+   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -442,12 +442,12 @@ end
    @test -A == S(-A.entries)
 end
 
-@testset "Generic.Mat.sub..." begin
+@testset "Generic.Mat.getindex..." begin
    S = MatrixSpace(ZZ, 3, 3)
 
    A = S([1 2 3; 4 5 6; 7 8 9])
 
-   B = @inferred sub(A, 1, 1, 2, 2)
+   B = @inferred A[1:2, 1:2]
 
    @test typeof(B) == typeof(A)
    @test B == MatrixSpace(ZZ, 2, 2)([1 2; 4 5])
@@ -455,7 +455,7 @@ end
    B[1, 1] = 10
    @test A == S([1 2 3; 4 5 6; 7 8 9])
 
-   C = @inferred sub(B, 1:2, 1:2)
+   C = @inferred B[1:2, 1:2]
 
    @test typeof(C) == typeof(A)
    @test C == MatrixSpace(ZZ, 2, 2)([10 2; 4 5])
@@ -504,15 +504,14 @@ end
    A = rand(S, -1000:1000)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])   
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
    
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
    # Exact field
    R = GF(7)
@@ -521,15 +520,14 @@ end
    A = rand(S)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
    # Inexact ring
    R = RealField["t"][1]
@@ -538,15 +536,14 @@ end
    A = rand(S, 0:200, -1000:1000)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
    # Inexact field
    R = RealField
@@ -555,15 +552,14 @@ end
    A = rand(S, -1000:1000)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
    # Non-integral domain
    R = ResidueRing(ZZ, 6)
@@ -572,15 +568,14 @@ end
    A = rand(S, 0:5)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
    # Fraction field
    R = QQ
@@ -589,15 +584,14 @@ end
    A = rand(S, -1000:1000)
    ((i, j), (k, l)) = extrema.(rand.(axes(A), 2))
 
-   @test sub(A, i, k, j, l) == sub(A, i:j, k:l) == A[i:j, k:l]
-   @test sub(A, i, k, j, l) == matrix(R, A.entries[i:j, k:l])
-   @test sub(A, 1:nrows(A), k:l) == A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test sub(A, i:j, 1:ncols(A)) == A[i:j, :] == matrix(R, A.entries[i:j, :])
-   @test sub(A, [i:j;], [k:l;]) == A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
-   @test sub(A, i:2:j, k:2:l) == A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-
+   @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
+   @test A[:, k:l] == matrix(R, A.entries[:, k:l])
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
+   @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
+   
    rows, cols = randsubseq.(axes(A), rand(2))
-   @test sub(A, rows, cols) == matrix(R, A.entries[rows, cols])
+   @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 end
 
 @testset "Generic.Mat.block_replacement..." begin


### PR DESCRIPTION
First, this relaxes `UnitRange` to `AbstractVector`, at no cost, as `sub(a, ::Vector{Int}, ::Vector{Int})` was already implemented. Then, we allow `Int` and `:` arguments in `sub`, so that `sub` and `getindex` accept exactly the same arguments (when there are two of them).

Personally, I would also remove `sub(a, r1::Int, c1::Int, r2::Int, c2::Int)`, it's too easy to get confused with the order of the arguments, and it's so easy to write instead `sub(a, r1:r2, c1:c2)`. 
I would actually remove `sub` completely, as it's redundant with `getindex`. This function was once part of Julia, and was creating views if I remember correctly, but was removed in version 0.5 I think.

DO NOT MERGE: This depends on #524.