### PR TITLE
Widen some signatures for Fac, FracElem and FracField

### DIFF
--- a/src/Factor.jl
+++ b/src/Factor.jl
@@ -12,7 +12,7 @@ export Fac, unit
 #
 ################################################################################
 
-mutable struct Fac{T <: RingElem}
+mutable struct Fac{T <: RingElement}
    unit::T
    fac::Dict{T, Int}
 
@@ -46,21 +46,24 @@ unit(a::Fac) = a.unit
 ################################################################################
 
 @doc Markdown.doc"""
-    in(a::T, b::Fac{T})
+    in(a, b::Fac)
 
 > Test whether `a` is a factor of `b`.
 """
-function Base.in(a::T, b::Fac{T}) where {T}
-   a in keys(b.fac)
+function Base.in(a, b::Fac{T}) where {T}
+   # convert is necessary when T == fmpz, because hash on fmpz
+   # doesn't coincide with hash on Integer
+   convert(T, a) in keys(b.fac)
 end
 
 @doc Markdown.doc"""
-    getindex(a::Fac{T}, b::T) -> Int
+    getindex(a::Fac, b) -> Int
 
 > If `b` is a factor of `a`, the corresponding exponent is returned. Otherwise
 > an error is thrown.
 """
-function getindex(a::Fac{T}, b::T) where {T}
+function getindex(a::Fac{T}, b) where {T}
+  b = convert(T, b)
   if haskey(a.fac, b)
     return a.fac[b]
   else

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -767,7 +767,8 @@ end
 > Return the tuple $n, x$ such that $z = p^nx$ where $x$ has valuation $0$ at
 > $p$.
 """
-function remove(z::AbstractAlgebra.FracElem{T}, p::T) where {T <: RingElem}
+function remove(z::AbstractAlgebra.FracElem{T}, p) where {T}
+   p = convert(T, p)
    iszero(z) && error("Not yet implemented")
    v, d = remove(denominator(z, false), p)
    w, n = remove(numerator(z, false), p)
@@ -778,7 +779,8 @@ end
     valuation(z::AbstractAlgebra.FracElem{T}, p::T) where {T <: RingElem}
 > Return the valuation of $z$ at $p$.
 """
-function valuation(z::AbstractAlgebra.FracElem{T}, p::T) where {T <: RingElem}
+function valuation(z::AbstractAlgebra.FracElem{T}, p) where {T}
+   p = convert(T, p)
    v, _ = remove(z, p)
    return v
 end
@@ -944,7 +946,7 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.FracField{T}, v...) where {T <: RingElem}
+function rand(rng::AbstractRNG, S::AbstractAlgebra.FracField, v...)
    R = base_ring(S)
    n = rand(rng, R, v...)
    d = R()


### PR DESCRIPTION
These signatures had unnecessarily tight constraints, which can lead to more work when downstream types are used as their type parameters.