### PR TITLE
Fix a bug in divides that affects Nemo #687.

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -94,6 +94,13 @@ divexact(x::RingElem, y::RingElement) = divexact(x, parent(x)(y))
 divexact(x::RingElement, y::RingElem) = divexact(parent(y)(x), y)
 
 function divides(x::T, y::T) where {T <: RingElem}
+   if iszero(y)
+      if iszero(x)
+         return true, x
+      else
+         return false, x
+      end
+   end
    q, r = divrem(x, y)
    return iszero(r), q
 end

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -95,11 +95,7 @@ divexact(x::RingElement, y::RingElem) = divexact(parent(y)(x), y)
 
 function divides(x::T, y::T) where {T <: RingElem}
    if iszero(y)
-      if iszero(x)
-         return true, x
-      else
-         return false, x
-      end
+      return iszero(x), y
    end
    q, r = divrem(x, y)
    return iszero(r), q


### PR DESCRIPTION
The test for this is in Nemo itself. It's rather hard to construct a test here as we have separate optimised code for divides within AbstractAlgebra itself.