### PR TITLE
docs: use `checkdocs = :none` option in makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(
          clean = true,
          doctest = true,
          strict = false,
+         checkdocs = :none,
          pages    = [
              "index.md",
              "constructors.md",
@@ -54,4 +55,3 @@ deploydocs(
    repo   = "github.com/Nemocas/AbstractAlgebra.jl.git",
    target = "build",
 )
-


### PR DESCRIPTION
This was wrongly documented to default to :none, but it doesn't.
This option was the cause of the huge pile of useless garbage
when running `julia docs/make.jl`, which indicates all the
docstrings that are not referenced in the docs.
We are too far from this state (all methods with docstrings
referenced in the docs) for these warnings to be
currently useful.