### PR TITLE
fix typeof(tranpose(mat)) in some cases

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -955,7 +955,9 @@ end
 > Return the transpose of the given matrix.
 """
 function transpose(x::Mat)
-   return matrix(base_ring(x), permutedims(x.entries, [2, 1]))
+   y = MatSpaceElem{eltype(x)}(permutedims(x.entries))
+   y.base_ring = x.base_ring
+   y
 end
 
 ###############################################################################


### PR DESCRIPTION
We should always have `typeof(transpose(mat)) == typeof(mat)`.

Fixes part of https://github.com/Nemocas/Nemo.jl/issues/651#issuecomment-540493003