### PR TITLE
fix typeof(identity_matrix(::MatElem)) in some cases

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5248,11 +5248,21 @@ end
 > dimensions with ones down the diagonal and zeroes elsewhere.
 """
 function identity_matrix(M::MatElem{T}) where T <: RingElement
-   return identity_matrix(base_ring(M), nrows(M), ncols(M))
+   z = zero(M)
+   R = base_ring(M)
+   for i = 1:min(size(M)...)
+      z[i, i] = one(R)
+   end
+   z
 end
 
 function identity_matrix(M::MatElem{T}, n::Int) where T <: RingElement
-   return identity_matrix(base_ring(M), n, n)
+   z = zero(M, n, n)
+   R = base_ring(M)
+   for i = 1:n
+      z[i, i] = one(R)
+   end
+   z
 end
 
 ###############################################################################

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -101,18 +101,28 @@ Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
 struct F2 <: AbstractAlgebra.Field end
 
 Base.zero(::F2) = F2Elem(false)
+Base.one(::F2) = F2Elem(true)
+(::F2)() = F2Elem(false)
 
 struct F2Elem <: AbstractAlgebra.FieldElem
    x::Bool
 end
 
+(::F2)(x::F2Elem) = x
 Base.:-(x::F2Elem) = x
-(f2::F2)(x::F2Elem) = x
-AbstractAlgebra.parent(x::F2Elem) = F2()
+Base.:+(x::F2Elem, y::F2Elem) = F2Elem(x.x ⊻ y.x)
+Base.inv(x::F2Elem) = x.x ? x : throw(DivideError())
+Base.:*(x::F2Elem, y::F2Elem) = F2Elem(x.x * y.x)
 
 Base.convert(::Type{F2Elem}, x::Integer) = F2Elem(x % Bool)
 Base.:(==)(x::F2Elem, y::F2Elem) = x.x == y.x
-Base.one(::F2) = F2Elem(true)
+
+AbstractAlgebra.parent_type(::Type{F2Elem}) = F2
+AbstractAlgebra.elem_type(::Type{F2}) = F2Elem
+AbstractAlgebra.parent(x::F2Elem) = F2()
+AbstractAlgebra.mul!(x::F2Elem, y::F2Elem, z::F2Elem) = y * z
+AbstractAlgebra.addeq!(x::F2Elem, y::F2Elem) = x + y
+AbstractAlgebra.divexact(x::F2Elem, y::F2Elem) = y.x ? x : throw(DivideError())
 
 struct F2Matrix <: AbstractAlgebra.MatElem{F2Elem}
    m::Generic.MatSpaceElem{F2Elem}
@@ -120,8 +130,6 @@ end
 
 AbstractAlgebra.nrows(a::F2Matrix) = nrows(a.m)
 AbstractAlgebra.ncols(a::F2Matrix) = ncols(a.m)
-AbstractAlgebra.parent_type(::Type{F2Elem}) = F2
-AbstractAlgebra.elem_type(::Type{F2}) = F2Elem
 AbstractAlgebra.base_ring(::F2Matrix) = F2()
 
 Base.getindex(a::F2Matrix, r::Int64, c::Int64) = a.m[r, c]
@@ -580,10 +588,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
@@ -596,10 +604,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
@@ -612,10 +620,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
@@ -628,10 +636,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
@@ -644,10 +652,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
@@ -660,10 +668,10 @@ end
 
    @test A[i:j, k:l] == matrix(R, A.entries[i:j, k:l])
    @test A[:, k:l] == matrix(R, A.entries[:, k:l])
-   @test A[i:j, :] == matrix(R, A.entries[i:j, :])   
+   @test A[i:j, :] == matrix(R, A.entries[i:j, :])
    @test A[[i:j;], [k:l;]] == matrix(R, A.entries[[i:j;], [k:l;]])
    @test A[i:2:j, k:2:l] == matrix(R, A.entries[i:2:j, k:2:l])
-   
+
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 end
@@ -1773,6 +1781,11 @@ end
 
       @test M*X == d*one(T)
    end
+
+   # inv should preserve the type of the input
+   M = matrix(F2(), F2Elem[1 0; 0 1])
+   @test typeof(inv(M))   == typeof(M)
+   @test typeof(inv(M.m)) == typeof(M.m)
 end
 
 @testset "Generic.Mat.hessenberg..." begin

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -112,6 +112,7 @@ AbstractAlgebra.parent(x::F2Elem) = F2()
 
 Base.convert(::Type{F2Elem}, x::Integer) = F2Elem(x % Bool)
 Base.:(==)(x::F2Elem, y::F2Elem) = x.x == y.x
+Base.one(::F2) = F2Elem(true)
 
 struct F2Matrix <: AbstractAlgebra.MatElem{F2Elem}
    m::Generic.MatSpaceElem{F2Elem}
@@ -271,6 +272,13 @@ end
    @test isa(M7, Generic.MatSpaceElem{elem_type(R)})
    @test M7.base_ring == R
    @test M7 == M8
+
+   # identity_matrix should preserve the type of the input
+   M9 = matrix(F2(), F2Elem[1 0; 0 1])
+   @test typeof(identity_matrix(M9))      == typeof(M9)
+   @test typeof(identity_matrix(M9, 3))   == typeof(M9)
+   @test typeof(identity_matrix(M9.m))    == typeof(M9.m)
+   @test typeof(identity_matrix(M9.m, 3)) == typeof(M9.m)
 
    x = zero_matrix(R, 2, 2)
    y = zero_matrix(ZZ, 2, 3)


### PR DESCRIPTION
We should always have `typeof(identity_matrix(mat)) == typeof(mat)`. As a result, we also get `typeof(inv(mat)) == typeof(mat)`.
Fix part of https://github.com/Nemocas/Nemo.jl/issues/651#issuecomment-540493003.