### PR TITLE
remove methods of identity_matrix which do not create an identity matrix

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -193,7 +193,6 @@ isempty(::MatElem)
 ```
 
 ```@docs
-identity_matrix(::Ring, ::Int, ::Int)
 identity_matrix(::Ring, ::Int)
 ```
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -239,7 +239,7 @@ one(a::AbstractAlgebra.MatSpace) = check_square(a)(1)
 > Construct the identity matrix in the same matrix space as `a`, i.e.
 > with ones down the diagonal and zeroes elsewhere. `a` must be square.
 """
-one(a::MatElem) = identity_matrix(check_square(a))
+one(a::MatElem) = identity_matrix(a)
 
 @doc Markdown.doc"""
     iszero(a::Generic.MatrixElem)
@@ -5213,24 +5213,13 @@ end
 identity_matrix(R::Ring, n::Int) = diagonal_matrix(one(R), n)
 
 @doc Markdown.doc"""
-    identity_matrix(R::Ring, m::Int, n::Int)
-> Return the $m \times n$ matrix over $R$ with ones down the diagonal and
-> zeroes elsewhere.
-"""
-identity_matrix(R::Ring, m::Int, n::Int) = diagonal_matrix(one(R), m, n)
-
-@doc Markdown.doc"""
     identity_matrix(M::MatElem{T}) where T <: RingElement
-> Return the matrix over the same base ring as $M$ and with the same
-> dimensions with ones down the diagonal and zeroes elsewhere.
+> Construct the identity matrix in the same matrix space as `M`, i.e.
+> with ones down the diagonal and zeroes elsewhere. `M` must be square.
+> This is an alias for `one(M)`.
 """
 function identity_matrix(M::MatElem{T}) where T <: RingElement
-   z = zero(M)
-   R = base_ring(M)
-   for i = 1:min(size(M)...)
-      z[i, i] = one(R)
-   end
-   z
+   identity_matrix(check_square(M), nrows(M))
 end
 
 function identity_matrix(M::MatElem{T}, n::Int) where T <: RingElement

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -267,19 +267,7 @@ end
    @test isa(M4, Generic.MatSpaceElem{elem_type(R)})
    @test M4.base_ring == R
 
-   M5 = identity_matrix(R, 2, 3)
-   M6 = identity_matrix(M5)
-
-   @test isa(M5, Generic.MatSpaceElem{elem_type(R)})
-   @test M5.base_ring == R
-   @test M5 == M6
-
-   M7 = identity_matrix(R, 3, 2)
-   M8 = identity_matrix(M7)
-
-   @test isa(M7, Generic.MatSpaceElem{elem_type(R)})
-   @test M7.base_ring == R
-   @test M7 == M8
+   @test_throws DomainError identity_matrix(M3) # must be square
 
    # identity_matrix should preserve the type of the input
    M9 = matrix(F2(), F2Elem[1 0; 0 1])


### PR DESCRIPTION
I suggested this change twice [here](https://github.com/Nemocas/AbstractAlgebra.jl/pull/522#issue-333536648) and [here](https://github.com/Nemocas/AbstractAlgebra.jl/pull/514#issue-331963113), without it being rejected, so here is the PR.

`identity_matrix(R::Ring, n, m)` which produces a non-square matrix has been introduced very recently, so it's unlikely that a user relies on its existence. If there is demand for such a function in the future, we can always re-introduce it, preferably with a better name. But once we have comitted this API, it's more difficult to remove.

I propose this change because `identity_matrix(R, n, m)` is a misnomer when the result is not an identity matrix, and there is now a relatively easy alternative:
`diagonal_matrix(one(R), n, m)`.

The other version, `identity_matrix(mat::MatrixElem)` is also disallowed here if `mat` is non square; the alternative is a bit more verbose:
`diagonal_matrix(one(base_ring(mat)), nrows(mat), ncols(mat))`. We could easily introduce `diagonal_matrix(mat, 1)` as a shorcut (provided `1` can be converted to `base_ring(mat)`). But I didn't find instances where this was used (except maybe in `extended_weak_popov`, which is not tested, and I havn't figured out yet how it's supposed to deal with non-square matrices).