### PR TITLE
reduce required API for matrices

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -865,22 +865,12 @@ mutable struct MatSpaceElem{T <: RingElement} <: Mat{T}
    entries::Array{T, 2}
    base_ring::Ring
 
-   function MatSpaceElem{T}(A::Array{T, 2}) where T <: RingElement
-      return new{T}(A)
-    end
-
-   function MatSpaceElem{T}(A::AbstractArray{T, 2}) where T <: RingElement
-      return new{T}(Array(A))
+   function MatSpaceElem{T}(R::Ring, r::Int, c::Int) where T <: RingElement
+      new(Array{T}(undef, r, c), R)
    end
 
-   function MatSpaceElem{T}(r::Int, c::Int, A::Array{T, 1}) where T <: RingElement
-      t = Array{T}(undef, r, c)
-      for i = 1:r
-         for j = 1:c
-            t[i, j] = A[(i - 1) * c + j]
-         end
-      end
-      return new{T}(t)
+   function MatSpaceElem{T}(R::Ring, A::Array{T, 2}) where T <: RingElement
+      return new{T}(A, R)
    end
 end
 
@@ -918,18 +908,14 @@ mutable struct MatAlgElem{T <: RingElement} <: AbstractAlgebra.MatAlgElem{T}
    entries::Array{T, 2}
    base_ring::Ring
 
-   function MatAlgElem{T}(A::Array{T, 2}) where T <: RingElement
-      return new{T}(A)
+   function MatAlgElem{T}(R::Ring, r::Int, c::Int) where T <: RingElement
+      @assert r == c
+      new(Array{T}(undef, r, r), R)
    end
 
-   function MatAlgElem{T}(n::Int, A::Array{T, 1}) where T <: RingElement
-      t = Array{T}(undef, n, n)
-      for i = 1:n
-         for j = 1:n
-            t[i, j] = A[(i - 1) * c + j]
-         end
-      end
-      return new{T}(t)
+   function MatAlgElem{T}(R::Ring, A::Array{T, 2}) where T <: RingElement
+      @assert size(A, 1) == size(A, 2)
+      return new{T}(A, R)
    end
 end
 

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -312,10 +312,9 @@ end
 > Return the transpose of the given matrix.
 """
 function transpose(x::MatAlgElem{T}) where T <: RingElement
-   arr = permutedims(x.entries, [2, 1])
-   z = MatAlgElem{T}(arr)
-   z.base_ring = base_ring(x)
-   return z
+   y = MatAlgElem{eltype(x)}(base_ring(x), ncols(x), nrows(x))
+   permutedims!(y.entries, x.entries, [2, 1])
+   y
 end
 
 @doc Markdown.doc"""
@@ -425,26 +424,20 @@ randmat_with_rank(S::Generic.MatAlgebra{T}, rank::Int, v...) where {T <: Abstrac
 function solve_lu(M::MatAlgElem{T}, B::MatAlgElem{T}) where {T <: RingElement}
    check_parent(M, B)
    R = base_ring(M)
-   MS = MatSpaceElem{T}(M.entries) # convert to ordinary matrix
-   MS.base_ring = R
-   BS = MatSpaceElem{T}(B.entries)
-   BS.base_ring = R
+   MS = MatSpaceElem{T}(R, M.entries) # convert to ordinary matrix
+   BS = MatSpaceElem{T}(R, B.entries)
    S = solve_lu(MS, BS)
-   SA = MatAlgElem{T}(S.entries)
-   SA.base_ring = R
+   SA = MatAlgElem{T}(R, S.entries)
    return SA
 end
 
 function solve_fflu(M::MatAlgElem{T}, B::MatAlgElem{T}) where {T <: RingElement}
    check_parent(M, B)
    R = base_ring(M)
-   MS = MatSpaceElem{T}(M.entries) # convert to ordinary matrix
-   MS.base_ring = R
-   BS = MatSpaceElem{T}(B.entries)
-   BS.base_ring = R
+   MS = MatSpaceElem{T}(R, M.entries) # convert to ordinary matrix
+   BS = MatSpaceElem{T}(R, B.entries)
    S, d = solve_fflu(MS, BS)
-   SA = MatAlgElem{T}(S.entries)
-   SA.base_ring = R
+   SA = MatAlgElem{T}(R, S.entries)
    return SA, d
 end
 
@@ -461,8 +454,7 @@ end
 > of the resulting polynomial must be supplied and the matrix must be square.
 """
 function minpoly(S::Ring, M::MatAlgElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
-   MS = MatSpaceElem{T}(M.entries) # convert to ordinary matrix
-   MS.base_ring = base_ring(M)
+   MS = MatSpaceElem{T}(base_ring(M), M.entries) # convert to ordinary matrix
    return minpoly(S, MS, charpoly_only)
 end
 
@@ -523,8 +515,7 @@ function identity_matrix(M::MatAlgElem{T}, n::Int) where T <: RingElement
          arr[i, j] = i == j ? one(R) : zero(R)
       end
    end
-   z = MatAlgElem{T}(arr)
-   z.base_ring = R
+   z = MatAlgElem{T}(R, arr)
    return z
 end
 
@@ -544,33 +535,22 @@ end
 ###############################################################################
 
 function (a::MatAlgebra{T})() where {T <: RingElement}
-   R = base_ring(a)
-   entries = Array{T}(undef, a.n, a.n)
-   for i = 1:a.n
-      for j = 1:a.n
-         entries[i, j] = zero(R)
-      end
-   end
-   z = MatAlgElem{T}(entries)
-   z.base_ring = R
-   return z
+   zero!(MatAlgElem{T}(base_ring(a), nrows(a), ncols(a)))
 end
 
 function (a::MatAlgebra{T})(b::S) where {S <: RingElement, T <: RingElement}
    R = base_ring(a)
-   entries = Array{T}(undef, a.n, a.n)
+   z = MatAlgElem{T}(R, a.n, a.n)
    rb = R(b)
    for i = 1:a.n
       for j = 1:a.n
          if i != j
-            entries[i, j] = zero(R)
+            z[i, j] = zero(R)
          else
-            entries[i, j] = rb
+            z[i, j] = rb
          end
       end
    end
-   z = MatAlgElem{T}(entries)
-   z.base_ring = R
    return z
 end
 
@@ -588,8 +568,7 @@ function (a::MatAlgebra{T})(b::Array{S, 2}) where {S <: RingElement, T <: RingEl
          entries[i, j] = R(b[i, j])
       end
    end
-   z = MatAlgElem{T}(entries)
-   z.base_ring = R
+   z = MatAlgElem{T}(R, entries)
    return z
 end
 

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1232,7 +1232,8 @@ end
       @test parent(nn) == MatrixAlgebra(R, r)
       @test size(nn) == (r, r)
       @test_throws ErrorException sim_zero(m, r, r+1)
-      for S = [QQ, ZZ, GF(2), GF(5)]
+      R == GF(11) || continue
+      for S = [GF(2), GF(5)]
          n = sim_zero(m, S)
          @test !test_zero || iszero(n)
          @test parent(n) == MatrixAlgebra(S, size(n)[1])
@@ -1248,5 +1249,6 @@ end
          @test size(n) == (r, r)
          @test_throws ErrorException sim_zero(m, S, r, r+2)
       end
+      @test_throws ArgumentError sim_zero(m, QQ)
    end
 end


### PR DESCRIPTION
The required API for implemening matrix types can be significantly reduced. This PR focuses on some constructors.
Currently there have:
- matrix spaces constructors (which construct matrices)
- 2 `matrix` methods
- zero_matrix
- `similar` and/or `zero` (currently wrongly mentioned as optional, but it's actually pretty much needed) 

There are two main distinct needs for creating matrices: 
1) given a ring and dimensions, construct the best corresponding matrix type (this is used by e.g. `change_base_ring`)
2) given a matrix, construct a similar matrix, of the same type, to be used as the destination of an algorithm which must return a matrix of the same type as the input (e.g. `-mat`).

This is the reason behind the different constructors. The problem is that there is a lot of redundancy in what the implementor of a matrix type has to implement. The two points above can be made orthogonal by the following
1) `dense_matrix_type` : given a ring, return the best corresponding matrix type, say `MyMatrix`
2) `MyMatrix(Ring, c, r)` constructor: given a ring and dimensions, construct the corresponding matrix of type `MyMatrix`.

The `dense_matrix_type` function is already part of the required API, but point 2) is not, so I propose to introduce it. Compared to other currently required constructors, this is the minimal amount of work to do. From this `MyMatrix(Ring, c, r)` constructor, all other can be implemented automatically and removed from the list of required interface.

Here I don't handle the "matrix space constructors", as this is slighly more tricky: it would be possible since Julia 1.3, which implements the possibility to do call-overloading on abstract types, but we must continue to support Julia 1.0. So unless people are fine to loose this functionality (e.g. `(S::MyMatSpace{T})(A::Array{T, 2})`, at least in library code, it could still be made available to people using Julia 1.3+)), it can't be done directly, but I have another idea (for another PR though).

In addition to this new simplified constructor, there are two new one-liner functions ("trait"-like) included here in the interface:
- `is_zero_initialized(::Type{MyMatrix})`, to know if `MyMatrix(Ring, c, r)` already contains zeros (this is optional, and for optimization only)
- `parent_matrix_type`, which plays a similar role to the `parent` function in Julia `Base`: given a matrix view type, give the type of the matrix of which it is the view (currently there is no mention of that in the current API, but practically, matrix implementors already have to inject this bit of information into their implementation of `similar` for their view types; this new function is necessary to construct the destination matrix on something like `-mat` where `mat` is a view; Alternatively, or as a fall back in case this is made optional, we can just use the result of `dense_matrix_type`).

This is WIP, without documentation update (except for a couple of docstrings). 
@fieker suggested that it might be wiser to wait till the next release, so that `Hecke` is updated and the impact of this change could be understood better. The tests of `Nemo` can be made to pass easily, but I indeed didn't try yet on `Hecke`.