### PR TITLE
Enh/symmetric group

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -460,7 +460,7 @@ julia> R, t = PolynomialRing(QQ, "t")
 julia> S = MatrixSpace(R, 3, 3)
 Matrix Space of 3 rows and 3 columns over Univariate Polynomial Ring in t over Rationals
 
-julia> G = PermGroup(3)
+julia> G = SymmetricGroup(3)
 Permutation group over 3 elements
 
 julia> A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
@@ -481,11 +481,11 @@ julia> B = P*A
 ### LU factorisation
 
 ```@docs
-lu{T <: FieldElem}(::MatElem{T}, ::PermGroup)
+lu{T <: FieldElem}(::MatElem{T}, ::SymmetricGroup)
 ```
 
 ```@docs
-fflu{T <: RingElem}(::MatElem{T}, ::PermGroup)
+fflu{T <: RingElem}(::MatElem{T}, ::SymmetricGroup)
 ```
 
 **Examples**

--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -9,16 +9,11 @@ end
 
 AbstractAlgebra.jl provides rudimentary native support for permutation groups (implemented in `src/generic/PermGroups.jl`). All functionality of permutations is accesible in the `Generic` submodule.
 
-Permutations are represented internally via vector of integers, wrapped in type `Perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Permutation groups are singleton parent objects of type `PermGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
+Permutations are represented internally via vector of integers, wrapped in type `Perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Permutation groups are singleton parent objects of type `SymmetricGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
 
-Permutation groups are created using the `PermGroup` (inner) constructor.
-However, for convenience we define
-```
-PermutationGroup = PermGroup
-```
-so that permutation groups can be created using `PermutationGroup` instead of `PermGroup`.
+Permutation groups are created using the `SymmetricGroup` (inner) constructor.
 
-Both `PermGroup` and `Perm` and can be parametrized by any type `T<:Integer` .
+Both `SymmetricGroup` and `Perm` and can be parametrized by any type `T<:Integer` .
 By default the parameter is the `Int`-type native to the systems architecture.
 However, if you are sure that your permutations are small enough to fit into smaller integer type (such as `Int32`, `UInt16`, or even `Int8`), you may choose to change the parametrizing type accordingly.
 In practice this may result in decreased memory footprint (when storing multiple permutations) and noticable faster performance, if your workload is heavy in operations on permutations, which e.g. does not fit into cache of your cpu.
@@ -42,12 +37,12 @@ Generic.Perm
   Since the parent object can be reconstructed from the permutation itself, you can work with permutations without explicitly constructing the parent object.
 
 * The other way is to first construct the permutation group they belong to.
-  This is accomplished with the inner constructor `PermGroup(n::Integer)` which
+  This is accomplished with the inner constructor `SymmetricGroup(n::Integer)` which
   constructs the permutation group on $n$ symbols and returns the parent object
   representing the group.
 
 ```@docs
-Generic.PermGroup
+Generic.SymmetricGroup
 ```
 
   A vector of integers can be then coerced to a permutation by calling a parent permutation group on it.
@@ -56,13 +51,13 @@ Generic.PermGroup
   **Examples:**
 
 ```jldoctest
-julia> G = PermutationGroup(BigInt(5)); p = G([2,3,1,5,4])
+julia> G = SymmetricGroup(BigInt(5)); p = G([2,3,1,5,4])
 (1,2,3)(4,5)
 
 julia> typeof(p)
 Perm{BigInt}
 
-julia> H = PermutationGroup(UInt16(5)); r = H([2,3,1,5,4])
+julia> H = SymmetricGroup(UInt16(5)); r = H([2,3,1,5,4])
 (1,2,3)(4,5)
 
 julia> typeof(r)
@@ -89,7 +84,7 @@ Any custom permutation group implementation in AbstractAlgebra.jl should provide
 
 ```@docs
 parent(::Perm)
-elem_type(::PermGroup)
+elem_type(::SymmetricGroup)
 parent_type(::Perm)
 ```
 
@@ -154,7 +149,7 @@ parity(::Perm)
 sign(::Perm)
 permtype(::Perm)
 order(::Perm)
-order(::Generic.PermGroup)
+order(::Generic.SymmetricGroup)
 ```
 
 Note that even an `Int64` can be easily overflowed when computing with permutation groups.
@@ -162,10 +157,10 @@ Thus, by default, `order` returns (always correct) `BigInt`s.
 If you are sure that the computation will not overflow, you may use `order(::Type{T}, ...)` to perform computations with machine integers.
 Julia's standard promotion rules apply for the returned value.
 
-Since `PermGroup` implements the iterator protocol, you may iterate over all permutations via a simple loop:
+Since `SymmetricGroup` implements the iterator protocol, you may iterate over all permutations via a simple loop:
 
 ```
-for p in PermutationGroup(n)
+for p in SymmetricGroup(n)
    ...
 end
 ```
@@ -174,10 +169,10 @@ Iteration over all permutations in reasonable time, (i.e. in terms of minutes) i
 You may also use the non-allocating `Generic.elements!` function for $n ≤ 14$ (or even $15$ if you are patient enough), which is an order of magnitude faster.
 
 ```@docs
-Generic.elements!(::Generic.PermGroup)
+Generic.elements!(::Generic.SymmetricGroup)
 ```
 
-However, since all permutations yielded by `elements!` are aliased (modified "in-place"), `collect(Generic.elements!(PermGroup(n)))` returns a vector of identical permutations.
+However, since all permutations yielded by `elements!` are aliased (modified "in-place"), `collect(Generic.elements!(SymmetricGroup(n)))` returns a vector of identical permutations.
 
 !!! note
     If you intend to use or store elements yielded by `elements!` you need to **deepcopy** them explicitly.
@@ -193,8 +188,8 @@ inv(::Perm)
 Permutations parametrized by different types can be multiplied, and follow the standard julia integer promotion rules:
 
 ```jldoctest
-g = rand(PermGroup(Int8(5)));
-h = rand(PermGroup(UInt32(5)));
+g = rand(SymmetricGroup(Int8(5)));
+h = rand(SymmetricGroup(UInt32(5)));
 typeof(g*h)
 
 # output
@@ -203,32 +198,32 @@ Perm{UInt32}
 
 ## Coercion
 
-The following coercions are available for `G::PermGroup` parent objects.
+The following coercions are available for `G::SymmetricGroup` parent objects.
 Each of the methods perform basic sanity checks on the input which can be switched off by the second argument.
 
 **Examples**
 
 ```jldoctest
-julia> PermutationGroup(4)()
+julia> SymmetricGroup(4)()
 ()
 ```
 > Return the identity element of `G`.
 
 
 ```julia
-(G::PermGroup)(::Vector{<:Integer}[, check=true])
+(G::SymmetricGroup)(::AbstractVector{<:Integer}[, check=true])
 ```
 > Turn a vector of integers into a permutation (performing conversion, if necessary).
 
 
 ```julia
-(G::PermGroup)(::Perm[, check=true])
+(G::SymmetricGroup)(::Perm[, check=true])
 ```
 > Coerce a permutation `p` into group `G` (performing the conversion, if necessary).
 > If `p` is already an element of `G` no copy is performed.
 
 ```julia
-(G::PermGroup)(::String[, check=true])
+(G::SymmetricGroup)(::String[, check=true])
 ```
 > Parse the string input e.g. copied from the output of GAP.
 > The method uses the same logic as the `perm"..."` macro.
@@ -236,7 +231,7 @@ julia> PermutationGroup(4)()
 > Both `string(p::Perm)` (if `setpermstyle(:cycles)`) and `string(cycles(p::Perm))` are valid input for this method.
 
 ```julia
-(G::PermGroup{T})(::CycleDec{T}[, check=true]) where T
+(G::SymmetricGroup{T})(::CycleDec{T}[, check=true]) where T
 ```
 > Turn a cycle decomposition object into a permutation.
 
@@ -244,13 +239,13 @@ julia> PermutationGroup(4)()
 
 ```@docs
 ==(::Perm, ::Perm)
-==(::Generic.PermGroup, ::Generic.PermGroup)
+==(::Generic.SymmetricGroup, ::Generic.SymmetricGroup)
 ```
 
 ## Misc
 ```@docs
-rand(::Generic.PermGroup)
+rand(::Generic.SymmetricGroup)
 Generic.matrix_repr(::Perm)
-Generic.emb(::Generic.PermGroup, ::Vector{Int}, ::Bool)
+Generic.emb(::Generic.SymmetricGroup, ::Vector{Int}, ::Bool)
 Generic.emb!(::Perm, ::Perm, V)
 ```

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -97,7 +97,7 @@ Here we give a list of the concrete types in AbstractAlgebra.jl.
 
 In parentheses we put the types of the corresponding parent objects.
 
-  - `Perm{<:Integer}` (`PermGroup{<:Integer}`)
+  - `Perm{<:Integer}` (`SymmetricGroup{<:Integer}`)
   - `GFElem{<:Integer}` (`GFField{<:Integer}`)
 
 We also think of various Julia types as though they were AbstractAlgebra.jl types:

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -186,7 +186,7 @@ julia> @time dim(YoungTableau(λ))
   0.000038 seconds (335 allocations: 10.734 KiB)
 9079590132732747656880081324531330222983622187548672000
 
-julia> G = PermutationGroup(sum(λ))
+julia> G = SymmetricGroup(sum(λ))
 Permutation group over 78 elements
 
 julia> @time character(λ, G())

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -101,7 +101,7 @@ export PolyRing, SeriesRing, ResRing, FracField, MatSpace, MatAlgebra,
 
 export ZZ, QQ, zz, qq, RealField, RDF
 
-export PermutationGroup
+export SymmetricGroup
 
 export create_accessors, get_handle, package_handle, zeros,
        Array, sig_exists
@@ -211,7 +211,7 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row, add_ro
                  newton_to_monomial!, ngens, normalise, nrows, nvars, O, one,
                  order, ordering, parent_type, parity, partitionseq, Perm, perm,
                  permtype, @perm_str, polcoeff, pol_length, powmod,
-                 pow_multinomial, popov, popov_with_transform, 
+                 pow_multinomial, popov, popov_with_transform,
                  precision, preimage, preimage_map, primpart, pseudodivrem,
                  pseudo_inv, pseudorem, push_term!, rank, randmat_triu,
                  randmat_with_rank, rand_ordering, rank_profile_popov, remove,
@@ -316,8 +316,8 @@ export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, ad
 #
 ################################################################################
 
-function PermGroup(n::T) where T
-  Generic.PermGroup(n)
+function SymmetricGroup(n::T) where T
+  Generic.SymmetricGroup(n)
 end
 
 function AllPerms(n::T) where T
@@ -579,7 +579,7 @@ end
 function crt end
 
 export PowerSeriesRing, PolynomialRing, SparsePolynomialRing, MatrixSpace,
-       MatrixAlgebra, FractionField, ResidueRing, Partition, PermGroup,
+       MatrixAlgebra, FractionField, ResidueRing, Partition, SymmetricGroup,
        YoungTableau, AllParts, SkewDiagram, AllPerms, Perm, LaurentSeriesRing,
        LaurentSeriesField, ResidueField, NumberField, PuiseuxSeriesRing,
        PuiseuxSeriesField, FreeModule, VectorSpace, ModuleHomomorphism, sub,
@@ -699,14 +699,6 @@ function zeros(R::Ring, r::Int...)
    end
    return A
 end
-
-###############################################################################
-#
-#   Set domain for PermutationGroup
-#
-###############################################################################
-
-const PermutationGroup = PermGroup
 
 ###############################################################################
 #

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -11,6 +11,8 @@ abstract type Set end
 
 abstract type Group <: Set end
 
+abstract type AbstractPermutationGroup <: Group end
+
 abstract type NCRing <: Set end
 
 abstract type Ring <: NCRing end
@@ -22,6 +24,8 @@ abstract type Field <: Ring end
 abstract type SetElem end
 
 abstract type GroupElem <: SetElem end
+
+abstract type AbstractPerm <: GroupElem end
 
 abstract type NCRingElem <: SetElem end
 
@@ -148,4 +152,3 @@ abstract type FinFieldElem <: FieldElem end # for fq, fq_nmod, etc
 promote_rule(T, U) = Union{}
 
 promote_rule(a::Type{S}, b::Type{T}) where {S <: Real, T <: Real} = Base.promote_rule(a, b)
-

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -25,40 +25,40 @@ end
 
 ###############################################################################
 #
-#   PermGroup / Perm
+#   SymmetricGroup / Perm
 #
 ###############################################################################
 
 @doc Markdown.doc"""
-    PermGroup{T<:Integer}
-> The permutation group singleton type.
-> `PermGroup(n)` constructs the permutation group $S_n$ on $n$-symbols. The type of elements of the group is inferred from the type of `n`.
+    SymmetricGroup{T<:Integer}
+> The full symmetric group singleton type.
+> `SymmetricGroup(n)` constructs the full symmetric group $S_n$ on $n$-symbols. The type of elements of the group is inferred from the type of `n`.
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> G = PermGroup(5)
-Permutation group over 5 elements
+julia> G = SymmetricGroup(5)
+Full symmetric group over 5 elements
 
 julia> elem_type(G)
 Perm{Int64}
 
-julia> H = PermGroup(UInt16(5))
-Permutation group over 5 elements
+julia> H = SymmetricGroup(UInt16(5))
+Full symmetric group over 5 elements
 
 julia> elem_type(H)
 Perm{UInt16}
 ```
 """
-struct PermGroup{T<:Integer} <: AbstractAlgebra.Group
+struct SymmetricGroup{T<:Integer} <: AbstractAlgebra.AbstractPermutationGroup
    n::T
 
-   function PermGroup{T}(n::Integer) where T<:Integer
-      n < 0 && throw(DomainError(n, "PermGroup constructor requires a non-negative integer"))
+   function SymmetricGroup{T}(n::Integer) where T<:Integer
+      n < 0 && throw(DomainError(n, "SymmetricGroup constructor requires a non-negative integer"))
       new{T}(n)
    end
 end
 
-PermGroup(n::Integer) = PermGroup{typeof(n)}(n)
+SymmetricGroup(n::Integer) = SymmetricGroup{typeof(n)}(n)
 
 @doc Markdown.doc"""
     Perm{T<:Integer}
@@ -76,7 +76,7 @@ PermGroup(n::Integer) = PermGroup{typeof(n)}(n)
 > There are two inner constructors of `Perm`:
 >
 > * `Perm(n::T)` constructs the trivial `Perm{T}`-permutation of length $n$.
-> * `Perm(v::Vector{T<:Integer}[,check=true])` constructs a permutation
+> * `Perm(v::AbstractVector{<:Integer} [,check=true])` constructs a permutation
 >   represented by `v`. By default `Perm` constructor checks if the vector
 >   constitutes a valid permutation. To skip the check call `Perm(v, false)`.
 
@@ -92,7 +92,7 @@ julia> typeof(g)
 Perm{Int32}
 ```
 """
-mutable struct Perm{T<:Integer} <: AbstractAlgebra.GroupElem
+mutable struct Perm{T<:Integer} <: AbstractAlgebra.AbstractPerm
    d::Array{T, 1}
    modified::Bool
    cycles::CycleDec{T}

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1114,13 +1114,13 @@ function lu!(P::Generic.Perm, A::MatrixElem{T}) where {T <: FieldElement}
 end
 
 @doc Markdown.doc"""
-    lu(A::Generic.MatrixElem{T}, P = PermGroup(rows(A))) where {T <: FieldElement}
+    lu(A::Generic.MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
 > Return a tuple $r, p, L, U$ consisting of the rank of $A$, a permutation
 > $p$ of $A$ belonging to $P$, a lower triangular matrix $L$ and an upper
 > triangular matrix $U$ such that $p(A) = LU$, where $p(A)$ stands for the
 > matrix whose rows are the given permutation $p$ of the rows of $A$.
 """
-function lu(A::MatrixElem{T}, P = PermGroup(nrows(A))) where {T <: FieldElement}
+function lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
@@ -1258,7 +1258,7 @@ function fflu!(P::Generic.Perm, A::MatrixElem{T}) where {T <: Union{FieldElement
 end
 
 @doc Markdown.doc"""
-    fflu(A::Generic.MatrixElem{T}, P = PermGroup(nrows(A))) where {T <: RingElement}
+    fflu(A::Generic.MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
 > Return a tuple $r, d, p, L, U$ consisting of the rank of $A$, a
 > denominator $d$, a permutation $p$ of $A$ belonging to $P$, a lower
 > triangular matrix $L$ and an upper triangular matrix $U$ such that
@@ -1269,7 +1269,7 @@ end
 > $\pm \mbox{det}(S)$ where $S$ is an appropriate submatrix of $A$ ($S = A$ if
 > $A$ is square) and the sign is decided by the parity of the permutation.
 """
-function fflu(A::MatrixElem{T}, P = PermGroup(nrows(A))) where {T <: RingElement}
+function fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
@@ -1306,7 +1306,7 @@ function rref!(A::MatrixElem{T}) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    R = base_ring(A)
-   P = PermGroup(m)()
+   P = SymmetricGroup(m)()
    rank, d = fflu!(P, A)
    for i = rank + 1:m
       for j = 1:n
@@ -1375,7 +1375,7 @@ function rref!(A::MatrixElem{T}) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    R = base_ring(A)
-   P = PermGroup(m)()
+   P = SymmetricGroup(m)()
    rnk = lu!(P, A)
    if rnk == 0
       return 0
@@ -1668,7 +1668,7 @@ function det_fflu(M::MatrixElem{T}) where {T <: RingElement}
       return base_ring(M)()
    end
    A = deepcopy(M)
-   P = PermGroup(n)()
+   P = SymmetricGroup(n)()
    r, d = fflu!(P, A)
    return r < n ? base_ring(M)() : (parity(P) == 0 ? d : -d)
 end
@@ -1815,7 +1815,7 @@ function rank(M::MatrixElem{T}) where {T <: RingElement}
       return 0
    end
    A = deepcopy(M)
-   P = PermGroup(n)()
+   P = SymmetricGroup(n)()
    r, d = fflu!(P, A)
    return r
 end
@@ -1830,7 +1830,7 @@ function rank(M::MatrixElem{T}) where {T <: FieldElement}
       return 0
    end
    A = deepcopy(M)
-   P = PermGroup(n)()
+   P = SymmetricGroup(n)()
    return lu!(P, A)
 end
 
@@ -1845,7 +1845,7 @@ function solve_fflu(A::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
    !issquare(A) && error("Non-square matrix in solve_fflu")
    nrows(A) != nrows(b) && error("Dimensions don't match in solve_fflu")
    FFLU = deepcopy(A)
-   p = PermGroup(nrows(A))()
+   p = SymmetricGroup(nrows(A))()
    r, d = fflu!(p, FFLU)
    r < nrows(A) && error("Singular matrix in solve_fflu")
    return solve_fflu_precomp(p, FFLU, b), d
@@ -1906,7 +1906,7 @@ function solve_lu(A::MatElem{T}, b::MatElem{T}) where {T <: FieldElement}
    end
 
    LU = deepcopy(A)
-   p = PermGroup(nrows(A))()
+   p = SymmetricGroup(nrows(A))()
    r = lu!(p, LU)
    r < nrows(A) && error("Singular matrix in solve_lu")
    return solve_lu_precomp(p, LU, b)
@@ -1974,7 +1974,7 @@ function solve_with_det(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatEle
    nrows(M) != ncols(M) && error("Non-square matrix")
    R = base_ring(M)
    FFLU = deepcopy(M)
-   p = PermGroup(nrows(M))()
+   p = SymmetricGroup(nrows(M))()
    r, d = fflu!(p, FFLU)
    if r < nrows(M)
       error("Singular matrix in solve_with_det")

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -8,27 +8,27 @@
     parent_type(::Type{<:Perm})
 > Return the type of the parent of a permutation.
 """
-parent_type(::Type{Perm{T}}) where T = PermGroup{T}
+parent_type(::Type{Perm{T}}) where T = SymmetricGroup{T}
 
 @doc Markdown.doc"""
-    elem_type(::Type{<:PermGroup})
+    elem_type(::Type{<:SymmetricGroup})
 > Return the type of elements of a permutation group.
 """
-elem_type(::Type{PermGroup{T}}) where T = Perm{T}
+elem_type(::Type{SymmetricGroup{T}}) where T = Perm{T}
 
 @doc Markdown.doc"""
     parent(g::Perm)
 > Return the parent of the permutation `g`.
 
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> G = PermutationGroup(5); g = Perm([3,4,5,2,1])
+julia> G = SymmetricGroup(5); g = Perm([3,4,5,2,1])
 (1,3,5)(2,4)
 
 julia> parent(g) == G
 true
 ```
 """
-parent(g::Perm{T}) where T = PermGroup(T(length(g.d)))
+parent(g::Perm{T}) where T = SymmetricGroup(T(length(g.d)))
 
 ###############################################################################
 #
@@ -259,7 +259,7 @@ julia> permtype(g)
  2
  1
 
-julia> G = PermGroup(5); e = parent(g)()
+julia> G = SymmetricGroup(5); e = parent(g)()
 ()
 
 julia> permtype(e)
@@ -280,8 +280,8 @@ permtype(g::Perm) = sort(diff(cycles(g).cptrs), rev=true)
 #
 ###############################################################################
 
-function show(io::IO, G::PermGroup)
-   print(io, "Permutation group over $(G.n) elements")
+function show(io::IO, G::SymmetricGroup)
+   print(io, "Full symmetric group over $(G.n) elements")
 end
 
 mutable struct PermDisplayStyle
@@ -367,7 +367,7 @@ true
 ==(g::Perm, h::Perm) = g.d == h.d
 
 @doc Markdown.doc"""
-    ==(G::PermGroup, H::PermGroup)
+    ==(G::SymmetricGroup, H::SymmetricGroup)
 > Return `true` if permutation groups are equal, otherwise return `false`.
 >
 > Permutation groups on the same number of letters, but parametrized
@@ -375,17 +375,17 @@ true
 
 # Examples:
 ```
-julia> G = PermGroup(UInt(5))
+julia> G = SymmetricGroup(UInt(5))
 Permutation group over 5 elements
 
-julia> H = PermGroup(5)
+julia> H = SymmetricGroup(5)
 Permutation group over 5 elements
 
 julia> G == H
 false
 ```
 """
-==(G::PermGroup, H::PermGroup) = typeof(G) == typeof(H) && G.n == H.n
+==(G::SymmetricGroup, H::SymmetricGroup) = typeof(G) == typeof(H) && G.n == H.n
 
 ###############################################################################
 #
@@ -570,7 +570,7 @@ Base.eltype(::Type{AllPerms{T}}) where T<:Integer = Perm{T}
 Base.length(A::AllPerms) = A.all
 
 @doc Markdown.doc"""
-    Generic.elements!(G::PermGroup)
+    Generic.elements!(G::SymmetricGroup)
 > Return an unsafe iterator over all permutations in `G`. Only one permutation
 > is allocated and then modified in-place using the non-recursive
 > [Heaps algorithm](https://en.wikipedia.org/wiki/Heap's_algorithm).
@@ -580,13 +580,13 @@ Base.length(A::AllPerms) = A.all
 
 # Examples:
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> elts = Generic.elements!(PermGroup(5));
+julia> elts = Generic.elements!(SymmetricGroup(5));
 
 
 julia> length(elts)
 120
 
-julia> for p in Generic.elements!(PermGroup(3))
+julia> for p in Generic.elements!(SymmetricGroup(3))
          println(p)
        end
 ()
@@ -596,7 +596,7 @@ julia> for p in Generic.elements!(PermGroup(3))
 (1,2,3)
 (1,3)
 
-julia> A = collect(Generic.elements!(PermGroup(3))); A
+julia> A = collect(Generic.elements!(SymmetricGroup(3))); A
 6-element Array{Perm{Int64},1}:
  (1,3)
  (1,3)
@@ -610,15 +610,15 @@ julia> unique(A)
  (1,3)
 ```
 """
-elements!(G::PermGroup)= (p for p in AllPerms(G.n))
+elements!(G::SymmetricGroup)= (p for p in AllPerms(G.n))
 
-function Base.iterate(G::PermGroup)
+function Base.iterate(G::SymmetricGroup)
   A = AllPerms(G.n)
   a, b = iterate(A)
   return deepcopy(A.elts), (A, b)
 end
 
-function Base.iterate(G::PermGroup, S)
+function Base.iterate(G::SymmetricGroup, S)
   A = S[1]
   c = S[2]
 
@@ -631,9 +631,9 @@ function Base.iterate(G::PermGroup, S)
   return deepcopy(s[1]), (A, s[2])
 end
 
-Base.eltype(::Type{PermGroup{T}}) where T = Perm{T}
+Base.eltype(::Type{SymmetricGroup{T}}) where T = Perm{T}
 
-Base.length(G::PermGroup) = order(G)
+Base.length(G::SymmetricGroup) = order(G)
 
 ###############################################################################
 #
@@ -642,11 +642,11 @@ Base.length(G::PermGroup) = order(G)
 ###############################################################################
 
 @doc Markdown.doc"""
-    order(G::PermGroup) -> BigInt
+    order(G::SymmetricGroup) -> BigInt
 > Return the order of the full permutation group as `BigInt`.
 """
-order(G::PermGroup) = order(BigInt, G)
-order(::Type{T}, G::PermGroup) where T = factorial(T(G.n))
+order(G::SymmetricGroup) = order(BigInt, G)
+order(::Type{T}, G::SymmetricGroup) where T = factorial(T(G.n))
 
 @doc Markdown.doc"""
     order(a::Perm) -> BigInt
@@ -709,7 +709,7 @@ function emb!(result::Perm, p::Perm, V)
 end
 
 @doc Markdown.doc"""
-    emb(G::PermGroup, V::Vector{Int}, check::Bool=true)
+    emb(G::SymmetricGroup, V::Vector{Int}, check::Bool=true)
 > Return the natural embedding of a permutation group into `G` as the
 > subgroup permuting points indexed by `V`.
 
@@ -718,14 +718,14 @@ end
 julia> p = Perm([2,3,1])
 (1,2,3)
 
-julia> f = Generic.emb(PermGroup(5), [3,2,5]);
+julia> f = Generic.emb(SymmetricGroup(5), [3,2,5]);
 
 
 julia> f(p)
 (2,5,3)
 ```
 """
-function emb(G::PermGroup, V::Vector{Int}, check::Bool=true)
+function emb(G::SymmetricGroup, V::Vector{Int}, check::Bool=true)
    if check
       @assert length(Base.Set(V)) == length(V)
       @assert all(V .<= G.n)
@@ -734,10 +734,11 @@ function emb(G::PermGroup, V::Vector{Int}, check::Bool=true)
 end
 
 @doc Markdown.doc"""
-    rand([rng=GLOBAL_RNG,] G::PermGroup)
+    rand([rng=GLOBAL_RNG,] G::SymmetricGroup)
 > Return a random permutation from `G`.
 """
-rand(rng::AbstractRNG, rs::Random.SamplerTrivial{PermGroup{T}}) where {T} = Perm(randperm!(rng, Vector{T}(undef, rs[].n)), false)
+rand(rng::AbstractRNG, rs::Random.SamplerTrivial{SymmetricGroup{T}}) where {T} =
+   Perm(randperm!(rng, Vector{T}(undef, rs[].n)), false)
 
 ###############################################################################
 #
@@ -745,35 +746,29 @@ rand(rng::AbstractRNG, rs::Random.SamplerTrivial{PermGroup{T}}) where {T} = Perm
 #
 ###############################################################################
 
-function perm(a::Vector{<: Integer}, check::Bool = true)
+function perm(a::AbstractVector{<:Integer}, check::Bool = true)
   return Perm(a, check)
 end
 
-(G::PermGroup)() = Perm(G.n)
+(G::SymmetricGroup)() = Perm(G.n)
 
-function (G::PermGroup{T})(a::Vector{T}, check::Bool=true) where T<:Integer
+function (G::SymmetricGroup{T})(a::AbstractVector{S}, check::Bool=true) where {S, T}
    if check
       G.n == length(a) || throw("Cannot coerce to $G: lengths differ")
    end
-   return Perm(a, check)
+   return Perm(convert(Vector{T}, a), check)
 end
 
-function (G::PermGroup{T})(a::Vector{S}, check::Bool=true) where {S<:Integer,T}
-   return G(convert(Vector{T}, a), check)
+function (G::SymmetricGroup{T})(p::Perm{S}, check::Bool=true) where {S, T}
+   parent(p) == G && return p
+   return Perm(convert(Vector{T}, p.d), check)
 end
 
-function (G::PermGroup{T})(p::Perm{S}, check::Bool=true) where {S<:Integer, T}
-   if parent(p) == G
-      return p
-   end
-   return G(convert(Vector{T}, p.d), check)
-end
-
-function (G::PermGroup)(str::String, check::Bool=true)
+function (G::SymmetricGroup)(str::String, check::Bool=true)
    return G(cycledec(parse_cycles(str)..., G.n), check)
 end
 
-function (G::PermGroup{T})(cdec::CycleDec{T}, check::Bool=true) where T
+function (G::SymmetricGroup{T})(cdec::CycleDec{T}, check::Bool=true) where T
    if check
       length(cdec.ccycles) == G.n || throw("Can not coerce to $G: lengths differ")
    end
@@ -858,13 +853,13 @@ julia> p = perm"(1,3)(2,4)"
 julia> typeof(p)
 Perm{Int64}
 
-julia> parent(p) == PermutationGroup(4)
+julia> parent(p) == SymmetricGroup(4)
 true
 
 julia> p = perm"(1,3)(2,4)(10)"
 (1,3)(2,4)
 
-julia> parent(p) == PermutationGroup(10)
+julia> parent(p) == SymmetricGroup(10)
 true
 ```
 """
@@ -876,12 +871,12 @@ macro perm_str(s)
       n = maximum(c)
    end
    cdec = cycledec(c, p, n)
-   return PermGroup(cdec.cptrs[end]-1)(cdec)
+   return SymmetricGroup(cdec.cptrs[end]-1)(cdec)
 end
 
 ###############################################################################
 #
-#   PermGroup constructor
+#   SymmetricGroup constructor
 #
 ###############################################################################
 
@@ -917,7 +912,7 @@ const _charvalsTableBig = Dict{Tuple{BitVector,Vector{Int}}, BigInt}()
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> G = PermutationGroup(4)
+julia> G = SymmetricGroup(4)
 Permutation group over 4 elements
 
 julia> chi = character(Partition([3,1])); # character of the regular representation

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -393,7 +393,7 @@ false
 #
 ###############################################################################
 function mul!(out::Perm, g::Perm, h::Perm)
-   out = (out === g || out === h ? similar(out) : out)
+   out = (out === h ? similar(out) : out)
    @inbounds for i in eachindex(out.d)
       out[i] = h[g[i]]
    end

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -948,7 +948,7 @@ end
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
-   T = PermutationGroup(3)
+   T = SymmetricGroup(3)
    P = T([2, 3, 1])
 
    @test A == inv(P)*(P*A)
@@ -956,7 +956,7 @@ end
    @testset "$name" for (name, (R, randparams)) in RINGS
       S = MatrixSpace(R, rand(1:9), rand(0:9))
       A = rand(S, randparams...)
-      T = PermutationGroup(nrows(A))
+      T = SymmetricGroup(nrows(A))
       P = rand(T)
       Q = inv(P)
 

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -249,7 +249,7 @@ end
 
    A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])
 
-   T = PermutationGroup(3)
+   T = SymmetricGroup(3)
    P = T([2, 3, 1])
 
    @test A == inv(P)*(P*A)

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -2,38 +2,40 @@ IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
 
 @testset "Perm.abstract_types..." begin
    @test Generic.Perm <: GroupElem
+   @test Generic.Perm <: AbstractAlgebra.AbstractPerm
 
-   @test Generic.PermGroup <: AbstractAlgebra.Group
+   @test Generic.SymmetricGroup <: AbstractAlgebra.Group
+   @test Generic.SymmetricGroup <: AbstractAlgebra.AbstractPermutationGroup
 end
 
 @testset "Perm.constructors ($T)..." for T in IntTypes
-   @test elem_type(Generic.PermGroup{T}) == Generic.Perm{T}
-   @test parent_type(Generic.Perm{T}) == Generic.PermGroup{T}
+   @test elem_type(Generic.SymmetricGroup{T}) == Generic.Perm{T}
+   @test parent_type(Generic.Perm{T}) == Generic.SymmetricGroup{T}
 
-   @test PermutationGroup(T(10)) isa Generic.PermGroup{T}
+   @test SymmetricGroup(T(10)) isa Generic.SymmetricGroup{T}
 
-   @test Generic.PermGroup(T(10)) isa Generic.PermGroup{T}
-   @test Generic.PermGroup{T}(0xa) isa Generic.PermGroup{T}
+   @test Generic.SymmetricGroup(T(10)) isa Generic.SymmetricGroup{T}
+   @test Generic.SymmetricGroup{T}(0xa) isa Generic.SymmetricGroup{T}
 
    if T <: Signed
-      @test_throws DomainError PermutationGroup(-rand(T(1):T(100)))
-      @test_throws DomainError Generic.PermGroup(-rand(T(1):T(100)))
+      @test_throws DomainError SymmetricGroup(-rand(T(1):T(100)))
+      @test_throws DomainError Generic.SymmetricGroup(-rand(T(1):T(100)))
    end
 
-   G0 = PermutationGroup(zero(T))
-   @test G0 isa Generic.PermGroup{T}
+   G0 = SymmetricGroup(zero(T))
+   @test G0 isa Generic.SymmetricGroup{T}
 
    p = Perm(T[])
    @test p == G0()
    @test parent(p) == G0
 
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
    @test elem_type(G) == Generic.Perm{T}
 
    @test G() isa GroupElem
    @test G() isa Generic.Perm{T}
    a = G()
-   @test parent_type(typeof(a)) == Generic.PermGroup{T}
+   @test parent_type(typeof(a)) == Generic.SymmetricGroup{T}
    @test parent(a) == G
 
    z = T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]
@@ -42,7 +44,7 @@ end
    @test G(z) isa Generic.Perm{T}
    b = G(z)
    @test typeof(b) == Generic.Perm{T}
-   @test parent_type(typeof(b)) == Generic.PermGroup{T}
+   @test parent_type(typeof(b)) == Generic.SymmetricGroup{T}
    @test parent(b) == G
 
    @test rand(G) isa Generic.Perm{T}
@@ -51,12 +53,12 @@ end
    @test rand(rng, G, 2, 3) isa Matrix{Generic.Perm{T}}
    g = rand(G)
    @test parent(g) == G
-   @test parent(g) == PermutationGroup(T(10))
+   @test parent(g) == SymmetricGroup(T(10))
 
    @test convert(Vector{T}, G(z)) == z
 
    if T != Int
-      @test parent(g) != PermutationGroup(10)
+      @test parent(g) != SymmetricGroup(10)
    end
 
    @test similar(g) isa Perm{T}
@@ -91,8 +93,8 @@ end
    @test perm"(1,2,3)(5)(10)" isa GroupElem
    @test perm"(1,2,3)(5)(10)" isa Generic.Perm
    @test perm"(1,2,3)(5)(10)" isa Generic.Perm{Int}
-   @test parent(perm"(1,2,3)(5)(10)") == PermGroup(10)
-   @test parent(perm"(1,2,3)(5)(6)") == PermGroup(6)
+   @test parent(perm"(1,2,3)(5)(10)") == SymmetricGroup(10)
+   @test parent(perm"(1,2,3)(5)(6)") == SymmetricGroup(6)
    @test perm"(1,2,3,4,5)" == Perm([2,3,4,5,1])
    @test perm"(3,2,1)(4,5)" == Perm([3,1,2,5,4])
 
@@ -101,10 +103,10 @@ end
 10,67,87,60,36,12)(2,57,34,88)(3,92,76,17,99,96,30,55,45,41,98)(4,56,59,97,49,
 21,15,9,26,86,83,29,27,66,6,58,28,5,68,40,72,7,84,93,39,79,23,46,63,32,61,100,
 11)(8,80,71,75,35,14,85,25,20,70,65,16,48,47,37,74,33,13,31,69)
-""" == PermGroup(100)(s2)
+""" == SymmetricGroup(100)(s2)
 
    for T in IntTypes
-      G = PermutationGroup(T(5))
+      G = SymmetricGroup(T(5))
       @test G("()") == G()
       @test G("()()") == G()
       @test G("(1)(2,3)") == Perm(T[1,3,2,4,5])
@@ -125,7 +127,7 @@ end
 end
 
 @testset "Perm.printing ($T)..." for T in IntTypes
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
 
    b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
@@ -142,7 +144,7 @@ end
 end
 
 @testset "Perm.basic_manipulation ($T)..." for T in IntTypes
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
 
    a = G()
    b = deepcopy(a)
@@ -163,7 +165,7 @@ end
 end
 
 @testset "Perm.iteration ($T)..." for T in IntTypes
-   G = PermutationGroup(T(6))
+   G = SymmetricGroup(T(6))
    @test length(AllPerms(T(6))) == 720
    @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
    @test order(G) isa BigInt
@@ -182,7 +184,7 @@ end
 end
 
 @testset "Perm.binary_ops ($T)..." for T in IntTypes
-   G = PermutationGroup(T(3))
+   G = SymmetricGroup(T(3))
 
    a = Perm(T[2,1,3]) # (1,2)
    b = Perm(T[2,3,1]) # (1,2,3)
@@ -212,7 +214,7 @@ end
    @test a_copy^2 == AbstractAlgebra.mul!(a,a,a)
    @test a_copy == a
 
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
    p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
    @test p^0 == G()
    @test p^1 == p
@@ -223,9 +225,9 @@ end
 end
 
 @testset "Perm.mixed_binary_ops..." begin
-   G = PermutationGroup(6)
+   G = SymmetricGroup(6)
    for T in IntTypes
-      H = PermutationGroup(T(6))
+      H = SymmetricGroup(T(6))
 
       @test G(H()) == G()
       @test H(G()) == H()
@@ -238,7 +240,7 @@ end
 end
 
 @testset "Perm.inversion ($T)..." for T in IntTypes
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
 
    a = G()
    b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
@@ -246,14 +248,14 @@ end
    @test a == inv(a)
    @test a == b*inv(b)
 
-   G = PermutationGroup(3)
+   G = SymmetricGroup(3)
    for a in G, b in G
       @test inv(a*b) == inv(b)*inv(a)
    end
 end
 
 @testset "Perm.misc ($T)..." for T in IntTypes
-   G = PermutationGroup(T(10))
+   G = SymmetricGroup(T(10))
    a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
    @test cycles(G()) isa Generic.CycleDec{T}
@@ -304,12 +306,12 @@ end
 @testset "Perm.characters..." begin
    for T in IntTypes
       N = T(7)
-      G = PermutationGroup(N)
+      G = SymmetricGroup(N)
 
       @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
 
       N = T(3)
-      G = PermutationGroup(N)
+      G = SymmetricGroup(N)
       ps = Partition.([[1,1,1], [2,1], [3]])
       l = Partition(T[1,1,1])
 
@@ -336,7 +338,7 @@ end
    @test character(Partition([2,2,2,2]), Partition([8])) == 0
 
    N = 4
-   G = PermutationGroup(N)
+   G = SymmetricGroup(N)
 
    ps = Partition.([[1,1,1,1], [2,1,1], [2,2], [3,1], [4]])
    @test Set(AllParts(N)) == Set(ps)
@@ -357,7 +359,7 @@ end
    # compatible with GAP numbering of conjugacy classes. This is NOT the order
    # of partitions given by AllParts.
    N = 5
-   G = PermutationGroup(N)
+   G = SymmetricGroup(N)
    ps = Partition.([[1,1,1,1,1], [2,1,1,1], [2,2,1], [3,1,1], [3,2], [4,1], [5]])
    @test Set(AllParts(N)) == Set(ps)
 
@@ -379,6 +381,6 @@ end
    # test for overflow
 
    p = Partition(collect(10:-1:1))
-   @test character(p, PermutationGroup(big(55))()) == 44261486084874072183645699204710400
+   @test character(p, SymmetricGroup(big(55))()) == 44261486084874072183645699204710400
    @test dim(YoungTableau(p)) == 44261486084874072183645699204710400
 end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -265,7 +265,7 @@ end
    @test order(G()) == 1
 
    @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
-   @test Generic.permtype(a) isa Vector{Int}
+   @test Generic.permtype(a) isa Vector{T}
    @test Generic.permtype(a) == [6,3,1]
    @test cycles(a)[1] isa Vector{T}
    @test cycles(a)[1] == T[1,2,3,5,6,7]

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -36,6 +36,8 @@ end
    @test Generic._numpart(100) == 190_569_292
    @test Generic._numpart(1000) == 24_061_467_864_032_622_473_692_149_727_991
 
+   @test collect(AllParts(5)) isa Vector{Generic.Partition{Int}}
+   @test collect(AllParts(Int8(5))) isa Vector{Generic.Partition{Int8}}
    @test collect(AllParts(2)) == [Partition([1,1]), Partition([2])]
    @test collect(AllParts(1)) == [Partition([1])]
    @test collect(AllParts(0)) == [Partition(Int[])]


### PR DESCRIPTION
* simple rename `PermGroup` → `SymmetricGroup` to a name which describes the type better and to free the generic name `PermutationGroup` which has a distinct meaning.
* a new abstract type `AbstractPermutationGroup` sandwiched  between `SymmetricGroup` and `Group` is introduced
* parametrize Partitions by the integer type (`Int8` yields 30-50% speedup over `Int`s when iterating).

Since we've just released `v0.8` and this is very much breaking feel free to merge whenever deemed appropriate.

Merry Christmas! ;-)