### PR TITLE
Add AdditiveGroup, AdditiveGroupElem

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -88,7 +88,7 @@ using Random: Random, AbstractRNG
 
 export elem_type, parent_type
 
-export SetElem, GroupElem, NCRingElem, RingElem, ModuleElem, FieldElem, RingElement,
+export SetElem, GroupElem, AdditiveGroupElem, NCRingElem, RingElem, ModuleElem, FieldElem, RingElement,
        FieldElement, Map, AccessorNotSetError
 
 export SetMap, FunctionalMap, IdentityMap

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -9,7 +9,9 @@
 
 abstract type Set end
 
-abstract type Group <: Set end
+abstract type Group <: Set end # with * as operation
+
+abstract type AdditiveGroup <: Set end # with + as operation
 
 abstract type NCRing <: Set end
 
@@ -21,7 +23,9 @@ abstract type Field <: Ring end
 
 abstract type SetElem end
 
-abstract type GroupElem <: SetElem end
+abstract type GroupElem <: SetElem end # with * as operation
+
+abstract type AdditiveGroupElem <: SetElem end # with + as operation
 
 abstract type NCRingElem <: SetElem end
 
@@ -31,7 +35,7 @@ abstract type FieldElem <: RingElem end
 
 # parameterized domains
 
-abstract type Module{T} <: Group end
+abstract type Module{T} <: AdditiveGroup end
 
 abstract type FPModule{T} <: Module{T} end
 
@@ -39,7 +43,7 @@ abstract type Ideal{T} <: Set end
 
 # elements of parameterised domains
 
-abstract type ModuleElem{T} <: GroupElem end
+abstract type ModuleElem{T} <: AdditiveGroupElem end
 
 abstract type FPModuleElem{T} <: ModuleElem{T} end
 


### PR DESCRIPTION
Also change Module{T} to derive from AdditiveGroup instead of Group, and ModuleElem{T} to derive from AdditiveGroupElem instead of GroupElem.

Not sure if this is the best approach, but I believe we do need a way to distinguish between additive and multiplicative groups (in the GAPGroup code, basically all groups will be multiplicative, just as in GAP).

Happy to do it some of other way if you tell me which/how (of course I'd also like to understand why that other way is better).

I would imagine that one then could write relatively efficient "adapter types" which wrap an additive group (element) inside a multiple group (element) and vice versa. In GAP, I can't do this efficiently; in Julia, I am hoping one can compile away most of the conversion if all types are known ahead; but we'll have to see if that's right down the road. I am very intrigued by the possibility, though, as being forced to work with abelian groups in multiplicative notation is a frequent (and understandable) complaint.