### PR TITLE
add pretty printing infrastructure

### DIFF
--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -63,6 +63,9 @@ basis(N::FreeModule) = gens(N)
 ###############################################################################
 
 function show(io::IO, M::FreeModule{T}) where T <: Union{RingElement, NCRingElem}
+   AbstractAlgebra.@show_name(io, M)
+   AbstractAlgebra.@show_special(io, M)
+
    print(io, "Free module of rank ")
    print(io, rank(M))
    print(io, " over ")
@@ -70,6 +73,9 @@ function show(io::IO, M::FreeModule{T}) where T <: Union{RingElement, NCRingElem
 end
 
 function show(io::IO, M::FreeModule{T}) where T <: FieldElement
+   AbstractAlgebra.@show_name(io, M)
+   AbstractAlgebra.@show_special(io, M)
+
    print(io, "Vector space of dimension ")
    print(io, dim(M))
    print(io, " over ")

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1070,6 +1070,7 @@ end
 mutable struct FreeModule{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModule{T}
    rank::Int
    base_ring::NCRing
+   AbstractAlgebra.@declare_other
 
    function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true) where T <: Union{RingElement, NCRingElem}
       if cached && haskey(FreeModuleDict, (R, rank))


### PR DESCRIPTION
  used currently for FreeModule (in Oscar: to print homogenous
  components "properly")
  and AnticNumberField (Nemo: to print cyclotomic and quadratic fields)
  and GrpAbFinGen (Hecke: many things)

Key features for "nice" jupyter printing

Completely invisible to the user, purely developer toys