### PR TITLE
remove docstring for inv(M::Generic.MatrixElem{<:FieldElement})

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -758,8 +758,7 @@ julia> B = T([BigInt(4), 5, 7])
 ### Inverse
 
 ```@docs
-inv{T <: RingElem}(::MatElem{T})
-inv{T <: FieldElem}(::MatElem{T})
+inv(::MatrixElem{<:RingElement})
 ```
 
 **Examples**

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2339,12 +2339,6 @@ function pseudo_inv(M::MatrixElem{T}) where {T <: RingElement}
    return X, d
 end
 
-@doc Markdown.doc"""
-    inv(M::Generic.MatrixElem{T}) where {T <: FieldElement}
-> Given a non-singular $n\times n$ matrix over a field, return an
-> $n\times n$ matrix $X$ such that $MX = I_n$ where $I_n$ is the $n\times n$
-> identity matrix. If $M$ is singular an exception is raised.
-"""
 function inv(M::MatrixElem{T}) where {T <: FieldElement}
    issquare(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
    A = solve_lu(M, identity_matrix(M))


### PR DESCRIPTION
It's basically the same as that for RingElement, and as
`FieldElement <: RingElement`, trying to show docs for
`inv(M::Generic.MatrixElem{<:FieldElement})` resulted in
showing both docstrings.