### PR TITLE
docs: fix wrong spacing in docstrings, which breaks highlighting

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -700,7 +700,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   inv(a::AbstractAlgebra.AbsSeriesElem)
+    inv(a::AbstractAlgebra.AbsSeriesElem)
 > Return the inverse of the power series $a$, i.e. $1/a$.
 """
 function inv(a::AbstractAlgebra.AbsSeriesElem)
@@ -732,7 +732,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   sqrt(a::AbstractAlgebra.AbsSeriesElem)
+    sqrt(a::AbstractAlgebra.AbsSeriesElem)
 > Return the square root of the power series $a$.
 """
 function Base.sqrt(a::AbstractAlgebra.AbsSeriesElem)

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -140,7 +140,7 @@ max_precision(R::LaurentSeriesRing) = R.prec_max
 max_precision(R::LaurentSeriesField) = R.prec_max
 
 @doc Markdown.doc"""
-   exp_gcd(a::Generic.LaurentSeriesElem)
+    exp_gcd(a::Generic.LaurentSeriesElem)
 > Return the GCD of the exponents of the polynomial underlying the given Laurent series.
 """
 function exp_gcd(a::LaurentSeriesElem)
@@ -1170,7 +1170,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   inv(a::Generic.LaurentSeriesElem)
+    inv(a::Generic.LaurentSeriesElem)
 > Return the inverse of the power series $a$, i.e. $1/a$.
 """
 function inv(a::LaurentSeriesElem)
@@ -1207,7 +1207,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   sqrt(a::Generic.LaurentSeriesElem)
+    sqrt(a::Generic.LaurentSeriesElem)
 > Return the square root of the power series $a$.
 """
 function Base.sqrt(a::LaurentSeriesElem)
@@ -1639,7 +1639,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   LaurentSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true)
+    LaurentSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true)
 > Return a tuple $(S, x)$ consisting of the parent object `S` of a Laurent series
 > ring over the given base ring and a generator `x` for the Laurent series ring.
 > The maximum precision of the series in the ring is set to `prec`. This is taken as a

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -139,7 +139,7 @@ function vars(p::MPoly{T}) where {T <: RingElement}
 end
 
 @doc Markdown.doc"""
-   var_index(p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
+    var_index(p::AbstractAlgebra.MPolyElem{T}) where {T <: RingElement}
 > Return the index of the given variable $x$. If $x$ is not a variable
 > in a multivariate polynomial ring, an exception is raised.
 """
@@ -983,7 +983,7 @@ function degree(f::AbstractAlgebra.MPolyElem{T}, i::Int) where T <: RingElement
 end
 
 @doc Markdown.doc"""
-   degree(f::AbstractAlgebra.MPolyElem{T}, x::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+    degree(f::AbstractAlgebra.MPolyElem{T}, x::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
 > Return the degree of the polynomial $f$ in terms of the variable $x$.
 """
 function degree(f::AbstractAlgebra.MPolyElem{T}, x::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
@@ -991,7 +991,7 @@ function degree(f::AbstractAlgebra.MPolyElem{T}, x::AbstractAlgebra.MPolyElem{T}
 end
 
 @doc Markdown.doc"""
-   degrees(f::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+    degrees(f::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
 > Return an array of the degrees of the polynomial $f$ in terms of each variable.
 """
 function degrees(f::AbstractAlgebra.MPolyElem{T}) where T <: RingElement

--- a/src/generic/Module.jl
+++ b/src/generic/Module.jl
@@ -310,7 +310,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   isisomorphic(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T <: RingElement
+    isisomorphic(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T <: RingElement
 > Return `true` if the modules $M$ and $N$ are isomorphic.
 """
 function isisomorphic(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T <: RingElement

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -68,7 +68,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   inv(f::Map(ModuleIsomorphism))
+    inv(f::Map(ModuleIsomorphism))
 > Return the inverse map of the given module isomorphism. This is computed
 > cheaply.
 """

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1270,7 +1270,7 @@ end
 #CF TODO: use squaring for fast large valuation
 
 @doc Markdown.doc"""
-   remove(z::AbstractAlgebra.PolyElem{T}, p::AbstractAlgebra.PolyElem{T}) where T <: RingElement
+    remove(z::AbstractAlgebra.PolyElem{T}, p::AbstractAlgebra.PolyElem{T}) where T <: RingElement
 > Compute the valuation of $z$ at $p$, that is, the largest $k$ such that
 > $p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
 >

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -758,7 +758,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   PuiseuxSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true)
+    PuiseuxSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true)
 > Return a tuple $(S, x)$ consisting of the parent object `S` of a Puiseux series
 > ring over the given base ring and a generator `x` for the Puiseux series ring.
 > The maximum precision of the series in the ring is set to `prec`. This is taken as a

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -930,7 +930,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   inv(a::AbstractAlgebra.RelSeriesElem)
+    inv(a::AbstractAlgebra.RelSeriesElem)
 > Return the inverse of the power series $a$, i.e. $1/a$.
 """
 function inv(a::AbstractAlgebra.RelSeriesElem)
@@ -963,7 +963,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   sqrt(a::AbstractAlgebra.RelSeriesElem)
+    sqrt(a::AbstractAlgebra.RelSeriesElem)
 > Return the square root of the power series $a$.
 """
 function Base.sqrt(a::AbstractAlgebra.RelSeriesElem)
@@ -1320,7 +1320,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-   PowerSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true, model=:capped_relative)
+    PowerSeriesRing(R::AbstractAlgebra.Ring, prec::Int, s::AbstractString; cached=true, model=:capped_relative)
 > Return a tuple $(S, x)$ consisting of the parent object `S` of a power series
 > ring over the given base ring and a generator `x` for the power series ring.
 > The maximum precision of power series in the ring is set to `prec`. If the

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -37,7 +37,7 @@ zero(::Integers{T}) where T <: Integer = T(0)
 one(::Integers{T}) where T <: Integer = T(1)
 
 @doc Markdown.doc"""
-   isunit(a::Integer)
+    isunit(a::Integer)
 > Return `true` if $a$ is $1$ or $-1$.
 """
 isunit(a::Integer) = a == 1 || a == -1
@@ -202,7 +202,7 @@ function exp(a::T) where T <: Integer
 # This is used in various Euclidean domains for Chinese remaindering.
 
 @doc Markdown.doc"""
-   ppio(a::T, b::T)
+    ppio(a::T, b::T)
 
 > Split $a$ into $c*d$ where $c = gcd(a, b^\infty)$.
 """


### PR DESCRIPTION
For the record, perl command to make the replacement:
```
perl -i -p -e 'BEGIN{undef $/;}  s/"""\n   (\S)/"""\n    \1/smg' *jl
```