### PR TITLE
fix #274, at-PolynomialRing macro creates generic polynomials

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4756,7 +4756,8 @@ macro PolynomialRing(R, args...)
     end
     ring1 = gensym()
     ring2 = gensym()
-    push!(exprs, :($(Expr(:tuple, esc(ring1), esc(ring2))) = PolynomialRing($(esc(R)), $(esc(all_names)))))
+    push!(exprs, :($(Expr(:tuple, esc(ring1), esc(ring2))) =
+                   AbstractAlgebra.PolynomialRing($(esc(R)), $(esc(all_names)))))
     vars = Symbol[]
     k = gensym()
     push!(exprs, :($(esc(k)) = 0))


### PR DESCRIPTION
Before:
```julia
julia> using Nemo; R, x = @PolynomialRing(ZZ, x); typeof(R)
AbstractAlgebra.Generic.MPolyRing{fmpz}
```
Now:
```julia
julia> using Nemo; R, x = @PolynomialRing(ZZ, x); typeof(R)
FmpzMPolyRing
```
Ideas welcome on how to test that without depending on `Nemo`.

By the way, is the only purpose of the macro to not have to write quotes around `x` on the rhs?
