### PR TITLE
Set val prec length

### DIFF
--- a/docs/src/polynomial_rings.md
+++ b/docs/src/polynomial_rings.md
@@ -178,8 +178,7 @@ the length of the polynomial to $n$. This function does not need to normalise th
 polynomial and is not useful to the user, but is used extensively by the AbstractAlgebra
 generic functionality.
 
-This function mutates the existing polynomial in-place, but does not return the
-polynomial.
+This function returns the resulting polynomial.
 
 ```julia
 coeff(f::MyPoly{T}, n::Int) where T <: AbstractAlgebra.RingElem
@@ -241,8 +240,8 @@ julia> n = length(f)
 julia> c = coeff(f, 1)
 3
 
-julia> set_length!(g, normalise(g, 7))
-4
+julia> g = set_length!(g, normalise(g, 7))
+x^3+2*x+1
 
 julia> g = setcoeff!(g, 2, BigInt(11))
 x^3+11*x^2+2*x+1

--- a/docs/src/series_rings.md
+++ b/docs/src/series_rings.md
@@ -195,7 +195,7 @@ set_prec!(f::MySeries{T}, prec::Int)
 
 Set the absolute precision of the given series to the given value.
 
-This function mutates the series in-place but does not return the mutated series.
+This return the updated series.
 
 ```julia
 valuation(f::MySeries{T})
@@ -210,7 +210,7 @@ set_val!(f::MySeries{T}, val::Int)
 For relative series and Laurent series only, this function alters the valuation of the
 given series to the given value.
 
-The series is mutated in-place but does not return the mutated series.
+This function returns the updated series.
 
 ```julia
 polcoeff(f::MySeries{T}, n::Int)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -194,7 +194,7 @@ end
 function -(a::AbstractAlgebra.AbsSeriesElem)
    len = length(a)
    z = parent(a)()
-   set_prec!(z, precision(a))
+   z = set_prec!(z, precision(a))
    fit!(z, len)
    for i = 1:len
       z = setcoeff!(z, i - 1, -coeff(a, i - 1))
@@ -222,7 +222,7 @@ function +(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
    lenz = max(lena, lenb)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
+   z = set_prec!(z, prec)
    i = 1
    while i <= min(lena, lenb)
       z = setcoeff!(z, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
@@ -254,7 +254,7 @@ function -(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
    lenz = max(lena, lenb)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
+   z = set_prec!(z, prec)
    i = 1
    while i <= min(lena, lenb)
       z = setcoeff!(z, i - 1, coeff(a, i - 1) - coeff(b, i - 1))
@@ -332,7 +332,7 @@ function *(a::T, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElem}
    len = length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
+   z = set_prec!(z, precision(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
@@ -348,7 +348,7 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.AbsSer
    len = length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
+   z = set_prec!(z, precision(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
@@ -386,13 +386,13 @@ function shift_left(x::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: Rin
    prec = min(prec, max_precision(parent(x)))
    if xlen == 0
       z = zero(parent(x))
-      set_prec!(z, prec)
+      z = set_prec!(z, prec)
       return z
    end
    zlen = min(prec, xlen + n)
    z = parent(x)()
    fit!(z, zlen)
-   set_prec!(z, prec)
+   z = set_prec!(z, prec)
    for i = 1:n
       z = setcoeff!(z, i - 1, zero(base_ring(x)))
    end
@@ -413,12 +413,12 @@ function shift_right(x::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: Ri
    xlen = length(x)
    if n >= xlen
       z = zero(parent(x))
-      set_prec!(z, max(0, precision(x) - n))
+      z = set_prec!(z, max(0, precision(x) - n))
       return z
    end
    z = parent(x)()
    fit!(z, xlen - n)
-   set_prec!(z, precision(x) - n)
+   z = set_prec!(z, precision(x) - n)
    for i = 1:xlen - n
       z = setcoeff!(z, i - 1, coeff(x, i + n - 1))
    end
@@ -443,7 +443,7 @@ function truncate(a::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: RingE
    end
    z = parent(a)()
    fit!(z, n)
-   set_prec!(z, n)
+   z = set_prec!(z, n)
    for i = 1:min(n, len)
       z = setcoeff!(z, i - 1, coeff(a, i - 1))
    end
@@ -469,14 +469,14 @@ function ^(a::AbstractAlgebra.AbsSeriesElem{T}, b::Int) where {T <: RingElement}
    # special case powers of x for constructing power series efficiently
    if b == 0
       z = one(parent(a))
-      set_prec!(z, precision(a))
+      z = set_prec!(z, precision(a))
       return z
    elseif precision(a) > 0 && isgen(a) && b > 0
       # arithmetic operators must not introduce new aliasing
       return deepcopy(shift_left(a, b - 1))
    elseif length(a) == 1
       z = parent(a)(coeff(a, 0)^b)
-      set_prec!(z, precision(a))
+      z = set_prec!(z, precision(a))
       return z
    elseif b == 1
       return deepcopy(a)
@@ -639,7 +639,7 @@ function divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::AbstractAlgebra.AbsSer
    end
    y = truncate(y, precision(x))
    res = parent(x)()
-   set_prec!(res, min(precision(x), precision(y) + valuation(x)))
+   res = set_prec!(res, min(precision(x), precision(y) + valuation(x)))
    lc = coeff(y, 0)
    lc == 0 && error("Not an exact division")
    lenr = precision(x)
@@ -670,7 +670,7 @@ function divexact(x::AbstractAlgebra.AbsSeriesElem, y::Union{Integer, Rational, 
    lenx = length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
+   z = set_prec!(z, precision(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
    end
@@ -686,7 +686,7 @@ function divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::T) where {T <: RingEle
    lenx = length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
+   z = set_prec!(z, precision(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
    end
@@ -709,7 +709,7 @@ function inv(a::AbstractAlgebra.AbsSeriesElem)
    a1 = coeff(a, 0)
    ainv = parent(a)()
    fit!(ainv, precision(a))
-   set_prec!(ainv, precision(a))
+   ainv = set_prec!(ainv, precision(a))
    if precision(a) != 0
       ainv = setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
    end
@@ -752,7 +752,7 @@ function Base.sqrt(a::AbstractAlgebra.AbsSeriesElem)
    prec = precision(a) - aval2
    asqrt = parent(a)()
    fit!(asqrt, prec)
-   set_prec!(asqrt, prec)
+   asqrt = set_prec!(asqrt, prec)
    for n = 1:aval2
       asqrt = setcoeff!(asqrt, n - 1, R())
    end
@@ -796,12 +796,12 @@ end
 function Base.exp(a::AbstractAlgebra.AbsSeriesElem)
    if iszero(a)
       z = one(parent(a))
-      set_prec!(z, precision(a))
+      z = set_prec!(z, precision(a))
       return z
    end
    z = parent(a)()
    fit!(z, precision(a))
-   set_prec!(z, precision(a))
+   z = set_prec!(z, precision(a))
    z = setcoeff!(z, 0, exp(coeff(a, 0)))
    len = length(a)
    for k = 1 : precision(a) - 1

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -236,7 +236,7 @@ function +(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
       z = setcoeff!(z, i - 1, deepcopy(coeff(b, i - 1)))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -268,7 +268,7 @@ function -(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
       z = setcoeff!(z, i - 1, -coeff(b, i - 1))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -314,7 +314,7 @@ function *(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
       end
    end
    z = parent(a)(d, lenz, prec)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -336,7 +336,7 @@ function *(a::T, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -352,7 +352,7 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.AbsSer
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -399,7 +399,7 @@ function shift_left(x::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: Rin
    for i = 1:xlen
       z = setcoeff!(z, i + n - 1, coeff(x, i - 1))
    end
-   set_length!(z, normalise(z, zlen))
+   z = set_length!(z, normalise(z, zlen))
    return z
 end
 
@@ -450,7 +450,7 @@ function truncate(a::AbstractAlgebra.AbsSeriesElem{T}, n::Int) where {T <: RingE
    for i = len + 1:n
       z = setcoeff!(z, i - 1, zero(base_ring(a)))
    end
-   set_length!(z, normalise(z, n))
+   z = set_length!(z, normalise(z, n))
    return z
 end
 
@@ -651,7 +651,7 @@ function divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::AbstractAlgebra.AbsSer
          x = setcoeff!(x, i + j, coeff(x, i + j) - coeff(y, j)*q)
       end
    end
-   set_length!(res, normalise(res, length(res)))
+   res = set_length!(res, normalise(res, length(res)))
    return res
 end
 
@@ -721,7 +721,7 @@ function inv(a::AbstractAlgebra.AbsSeriesElem)
       end
       ainv = setcoeff!(ainv, n - 1, divexact(s, a1))
    end
-   set_length!(ainv, normalise(ainv, precision(a)))
+   ainv = set_length!(ainv, normalise(ainv, precision(a)))
    return ainv
 end
 
@@ -779,7 +779,7 @@ function Base.sqrt(a::AbstractAlgebra.AbsSeriesElem)
       c = divexact(c, g2)
       asqrt = setcoeff!(asqrt, aval2 + n, c)
    end
-   set_length!(asqrt, normalise(asqrt, prec))
+   asqrt = set_length!(asqrt, normalise(asqrt, prec))
    return asqrt
 end
 
@@ -812,7 +812,7 @@ function Base.exp(a::AbstractAlgebra.AbsSeriesElem)
       !isunit(base_ring(a)(k)) && error("Unable to divide in exp")
       z = setcoeff!(z, k, divexact(s, k))
    end
-   set_length!(z, normalise(z, precision(a)))
+   z = set_length!(z, normalise(z, precision(a)))
    return z
 end
 

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -166,6 +166,7 @@ end
 
 function set_length!(a::LaurentSeriesElem, len::Int)
    a.length = len
+   return a
 end
 
 function set_prec!(a::LaurentSeriesElem, prec::Int)
@@ -218,7 +219,7 @@ function rescale!(a::LaurentSeriesElem)
          a = setcoeff!(a, i*s, t)
       end
       set_scale!(a, s*scale(a))
-      set_length!(a, zlen)
+      a = set_length!(a, zlen)
    elseif pol_length(a) <= 1
       set_scale!(a, 1)
    end
@@ -387,7 +388,7 @@ function renormalize!(z::LaurentSeriesElem)
    end
    set_prec!(z, zprec)
    if i == zlen
-      set_length!(z, 0)
+      z = set_length!(z, 0)
       set_val!(z, zprec)
       set_scale!(z, 1)
    elseif i != 0
@@ -395,7 +396,7 @@ function renormalize!(z::LaurentSeriesElem)
       for j = 1:zlen - i
          z = setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
       end
-      set_length!(z, zlen - i)
+      z = set_length!(z, zlen - i)
    end
    return nothing
 end
@@ -554,7 +555,7 @@ function +(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
          z = setcoeff!(z, i, R())
       end
    end
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    z = rescale!(z)
    return z
@@ -614,7 +615,7 @@ function -(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
          z = setcoeff!(z, i, R())
       end
    end
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    z = rescale!(z)
    return z
@@ -677,7 +678,7 @@ function *(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
       end
    end
    z = parent(a)(d, lenz, prec + zval, zval, sz)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    z = rescale!(z)
    return z
@@ -703,7 +704,7 @@ function *(a::T, b::LaurentSeriesElem{T}) where {T <: RingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    renormalize!(z)
    z = rescale!(z)
    return z
@@ -723,7 +724,7 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::LaurentSeriesElem)
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    renormalize!(z)
    z = rescale!(z)
    return z
@@ -791,7 +792,7 @@ function truncate(a::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
    z = parent(a)()
    set_prec!(z, n)
    if n <= aval
-      set_length!(z, 0)
+      z = set_length!(z, 0)
       set_val!(z, n)
       set_scale!(z, 1)
    else
@@ -803,7 +804,7 @@ function truncate(a::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
       for i = 0:zlen - 1
          z = setcoeff!(z, i, polcoeff(a, i))
       end
-      set_length!(z, normalise(z, zlen))
+      z = set_length!(z, normalise(z, zlen))
       set_scale!(z, sa)
       z = rescale!(z)
    end
@@ -845,7 +846,7 @@ function mullow(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}, n::Int) where 
       end
    end
    z = parent(a)(d, lenz, prec, 0, s, false)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -892,7 +893,7 @@ function ^(a::LaurentSeriesElem{T}, b::Int) where {T <: RingElement}
       set_val!(z, b)
       z = setcoeff!(z, 0, deepcopy(polcoeff(a, 0)))
       set_scale!(z, 1)
-      set_length!(z, 1)
+      z = set_length!(z, 1)
       return z
    elseif pol_length(a) == 1
       z = parent(a)(polcoeff(a, 0)^b)
@@ -1116,7 +1117,7 @@ function divexact(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: 
          x = setcoeff!(x, i + j, polcoeff(x, i + j) - polcoeff(y, j)*q)
       end
    end
-   set_length!(res, normalise(res, pol_length(res)))
+   res = set_length!(res, normalise(res, pol_length(res)))
    res = rescale!(res)
    return res
 end
@@ -1195,7 +1196,7 @@ function inv(a::LaurentSeriesElem)
       end
       ainv = setcoeff!(ainv, n - 1, divexact(s, a1))
    end
-   set_length!(ainv, normalise(ainv, lenz))
+   ainv = set_length!(ainv, normalise(ainv, lenz))
    ainv = rescale!(ainv)
    return ainv
 end
@@ -1254,7 +1255,7 @@ function Base.sqrt(a::LaurentSeriesElem)
       asqrt = setcoeff!(asqrt, n, c)
     end
     set_scale!(asqrt, s)
-    set_length!(asqrt, normalise(asqrt, zlen))
+    asqrt = set_length!(asqrt, normalise(asqrt, zlen))
     asqrt = rescale!(asqrt)
     return asqrt
 end
@@ -1307,7 +1308,7 @@ function Base.exp(a::LaurentSeriesElem{T}) where {T <: RingElement}
       !flag && error("Unable to divide in exp")
       z = setcoeff!(z, k, q)
    end
-   set_length!(z, normalise(z, preca))
+   z = set_length!(z, normalise(z, preca))
    z = inflate(z, sc)
    z = rescale!(z)
    return z
@@ -1476,7 +1477,7 @@ function add!(c::LaurentSeriesElem{T}, a::LaurentSeriesElem{T}, b::LaurentSeries
          c.coeffs[i + 1] = R()
       end
    end
-   set_length!(c, normalise(c, lenr))
+   c = set_length!(c, normalise(c, lenr))
    renormalize!(c)
    c = rescale!(c)
    return c

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -171,10 +171,12 @@ end
 
 function set_prec!(a::LaurentSeriesElem, prec::Int)
    a.prec = prec
+   return a
 end
 
 function set_val!(a::LaurentSeriesElem, val::Int)
    a.val = val
+   return a
 end
 
 @doc Markdown.doc"""
@@ -183,6 +185,7 @@ end
 """
 function set_scale!(a::LaurentSeriesElem, scale::Int)
    a.scale = scale
+   return a
 end
 
 function polcoeff(a::LaurentSeriesElem, n::Int)
@@ -218,10 +221,10 @@ function rescale!(a::LaurentSeriesElem)
          a = setcoeff!(a, i, polcoeff(a, i*s))
          a = setcoeff!(a, i*s, t)
       end
-      set_scale!(a, s*scale(a))
+      a = set_scale!(a, s*scale(a))
       a = set_length!(a, zlen)
    elseif pol_length(a) <= 1
-      set_scale!(a, 1)
+      a = set_scale!(a, 1)
    end
    return a
 end
@@ -386,13 +389,13 @@ function renormalize!(z::LaurentSeriesElem)
    while i < zlen && iszero(polcoeff(z, i))
       i += 1
    end
-   set_prec!(z, zprec)
+   z = set_prec!(z, zprec)
    if i == zlen
       z = set_length!(z, 0)
-      set_val!(z, zprec)
-      set_scale!(z, 1)
+      z = set_val!(z, zprec)
+      z = set_scale!(z, 1)
    elseif i != 0
-      set_val!(z, zval + i*scale(z))
+      z = set_val!(z, zval + i*scale(z))
       for j = 1:zlen - i
          z = setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
       end
@@ -485,9 +488,9 @@ show_minus_one(::Type{LaurentSeriesElem{T}}) where {T <: RingElement} = show_min
 function -(a::LaurentSeriesElem)
    len = pol_length(a)
    z = parent(a)()
-   set_prec!(z, precision(a))
-   set_val!(z, valuation(a))
-   set_scale!(z, scale(a))
+   z = set_prec!(z, precision(a))
+   z = set_val!(z, valuation(a))
+   z = set_scale!(z, scale(a))
    fit!(z, len)
    for i = 1:len
       z = setcoeff!(z, i - 1, -polcoeff(a, i - 1))
@@ -528,9 +531,9 @@ function +(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
    R = base_ring(a)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
-   set_val!(z, valz)
-   set_scale!(z, sz)
+   z = set_prec!(z, prec)
+   z = set_val!(z, valz)
+   z = set_scale!(z, sz)
    pa = vala
    pb = valb
    j = 0
@@ -588,9 +591,9 @@ function -(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
    R = base_ring(a)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
-   set_val!(z, valz)
-   set_scale!(z, sz)
+   z = set_prec!(z, prec)
+   z = set_val!(z, valz)
+   z = set_scale!(z, sz)
    pa = vala
    pb = valb
    j = 0
@@ -698,9 +701,9 @@ function *(a::T, b::LaurentSeriesElem{T}) where {T <: RingElem}
    len = pol_length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
-   set_val!(z, valuation(b))
-   set_scale!(z, scale(b))
+   z = set_prec!(z, precision(b))
+   z = set_val!(z, valuation(b))
+   z = set_scale!(z, scale(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
@@ -718,9 +721,9 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::LaurentSeriesElem)
    len = pol_length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
-   set_val!(z, valuation(b))
-   set_scale!(z, scale(b))
+   z = set_prec!(z, precision(b))
+   z = set_val!(z, valuation(b))
+   z = set_scale!(z, scale(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
@@ -755,8 +758,8 @@ end
 """
 function shift_left(x::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
    z = deepcopy(x)
-   set_prec!(z, precision(x) + n)
-   set_val!(z, valuation(x) + n)
+   z = set_prec!(z, precision(x) + n)
+   z = set_val!(z, valuation(x) + n)
    return z
 end
 
@@ -767,8 +770,8 @@ end
 """
 function shift_right(x::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
    z = deepcopy(x)
-   set_prec!(z, precision(x) - n)
-   set_val!(z, valuation(x) - n)
+   z = set_prec!(z, precision(x) - n)
+   z = set_val!(z, valuation(x) - n)
    return z
 end
 
@@ -790,22 +793,22 @@ function truncate(a::LaurentSeriesElem{T}, n::Int) where {T <: RingElement}
       return a
    end
    z = parent(a)()
-   set_prec!(z, n)
+   z = set_prec!(z, n)
    if n <= aval
       z = set_length!(z, 0)
-      set_val!(z, n)
-      set_scale!(z, 1)
+      z = set_val!(z, n)
+      z = set_scale!(z, 1)
    else
       sa = scale(a)
       zlen = div(n - aval + sa - 1, sa)
       zlen = min(zlen, alen)
       fit!(z, zlen)
-      set_val!(z, aval)
+      z = set_val!(z, aval)
       for i = 0:zlen - 1
          z = setcoeff!(z, i, polcoeff(a, i))
       end
       z = set_length!(z, normalise(z, zlen))
-      set_scale!(z, sa)
+      z = set_scale!(z, sa)
       z = rescale!(z)
    end
    return z
@@ -819,9 +822,9 @@ function mullow(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}, n::Int) where 
    if lena == 0 || lenb == 0
       z = zero(parent(a))
       zprec = valuation(a) + valuation(b)
-      set_val!(z, zprec)
-      set_prec!(z, zprec)
-      set_scale!(z, scale(a))
+      z = set_val!(z, zprec)
+      z = set_prec!(z, zprec)
+      z = set_scale!(z, scale(a))
       return z
    end
    s = scale(a)
@@ -878,9 +881,9 @@ function ^(a::LaurentSeriesElem{T}, b::Int) where {T <: RingElement}
    # special case powers of x for constructing power series efficiently
    if pol_length(a) == 0
       z = parent(a)()
-      set_prec!(z, b*valuation(a))
-      set_val!(z, b*valuation(a))
-      set_scale!(z, 1)
+      z = set_prec!(z, b*valuation(a))
+      z = set_val!(z, b*valuation(a))
+      z = set_scale!(z, 1)
       return z
    elseif b == 0
       # in fact, the result would be exact 1 if we had exact series
@@ -889,17 +892,17 @@ function ^(a::LaurentSeriesElem{T}, b::Int) where {T <: RingElement}
    elseif isgen(a)
       z = parent(a)()
       fit!(z, 1)
-      set_prec!(z, b + precision(a) - 1)
-      set_val!(z, b)
+      z = set_prec!(z, b + precision(a) - 1)
+      z = set_val!(z, b)
       z = setcoeff!(z, 0, deepcopy(polcoeff(a, 0)))
-      set_scale!(z, 1)
+      z = set_scale!(z, 1)
       z = set_length!(z, 1)
       return z
    elseif pol_length(a) == 1
       z = parent(a)(polcoeff(a, 0)^b)
-      set_prec!(z, (b - 1)*valuation(a) + precision(a))
-      set_val!(z, b*valuation(a))
-      set_scale!(z, 1)
+      z = set_prec!(z, (b - 1)*valuation(a) + precision(a))
+      z = set_val!(z, b*valuation(a))
+      z = set_scale!(z, 1)
       return z
    elseif b == 1
       return deepcopy(a)
@@ -928,10 +931,10 @@ function ^(a::LaurentSeriesElem{T}, b::Int) where {T <: RingElement}
       end
       bit >>= 1
    end
-   set_val!(z, b*val)
-   set_prec!(z, b*val + prec)
+   z = set_val!(z, b*val)
+   z = set_prec!(z, b*val + prec)
    if pol_length(z) <= 1
-      set_scale!(z, 1)
+      z = set_scale!(z, 1)
    end
    renormalize!(z)
    z = rescale!(z)
@@ -1096,8 +1099,8 @@ function divexact(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: 
    end
    res = parent(x)()
    y = truncate(y, precision(x) - valuation(x))
-   set_prec!(res, min(precision(x), valuation(x) + precision(y)))
-   set_val!(res, valuation(x))
+   res = set_prec!(res, min(precision(x), valuation(x) + precision(y)))
+   res = set_val!(res, valuation(x))
    sx = scale(x)
    sy = scale(y)
    sr = gcd(sx, sy)
@@ -1105,7 +1108,7 @@ function divexact(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: 
    dy = div(sy, sr)
    x = downscale(x, dx)
    y = downscale(y, dy)
-   set_scale!(res, sr)
+   res = set_scale!(res, sr)
    lc = coeff(y, 0)
    lenr = div(precision(res) - valuation(res) + sr - 1, sr)
    leny = div(precision(y) + sr - 1, sr)
@@ -1137,9 +1140,9 @@ function divexact(x::LaurentSeriesElem, y::Union{Integer, Rational, AbstractFloa
    lenx = pol_length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
-   set_val!(z, valuation(x))
-   set_scale!(z, scale(x))
+   z = set_prec!(z, precision(x))
+   z = set_val!(z, valuation(x))
+   z = set_scale!(z, scale(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
@@ -1155,9 +1158,9 @@ function divexact(x::LaurentSeriesElem{T}, y::T) where {T <: RingElem}
    lenx = pol_length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
-   set_val!(z, valuation(x))
-   set_scale!(z, scale(x))
+   z = set_prec!(z, precision(x))
+   z = set_val!(z, valuation(x))
+   z = set_scale!(z, scale(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
@@ -1181,9 +1184,9 @@ function inv(a::LaurentSeriesElem)
    sa = scale(a)
    lenz = div(precision(a) - valuation(a) + sa - 1, sa)
    fit!(ainv, lenz)
-   set_prec!(ainv, precision(a) - 2*valuation(a))
-   set_val!(ainv, -valuation(a))
-   set_scale!(ainv, sa)
+   ainv = set_prec!(ainv, precision(a) - 2*valuation(a))
+   ainv = set_val!(ainv, -valuation(a))
+   ainv = set_scale!(ainv, sa)
    !isunit(a1) && error("Unable to invert power series")
    if lenz != 0
       ainv = setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
@@ -1220,17 +1223,17 @@ function Base.sqrt(a::LaurentSeriesElem)
    prec = precision(a) - aval
    if prec == 0
       asqrt = parent(a)()
-      set_prec!(asqrt, aval2)
-      set_val!(asqrt, aval2)
-      set_scale!(asqrt, 1)
+      asqrt = set_prec!(asqrt, aval2)
+      asqrt = set_val!(asqrt, aval2)
+      asqrt = set_scale!(asqrt, 1)
       return asqrt
    end
    asqrt = parent(a)()
    s = scale(a)
    zlen = div(prec + s - 1, s)
    fit!(asqrt, prec)
-   set_prec!(asqrt, prec + aval2)
-   set_val!(asqrt, aval2)
+   asqrt = set_prec!(asqrt, prec + aval2)
+   asqrt = set_val!(asqrt, aval2)
    if prec > 0
       g = sqrt(polcoeff(a, 0))
       asqrt = setcoeff!(asqrt, 0, g)
@@ -1254,7 +1257,7 @@ function Base.sqrt(a::LaurentSeriesElem)
       c = divexact(c, g2)
       asqrt = setcoeff!(asqrt, n, c)
     end
-    set_scale!(asqrt, s)
+    asqrt = set_scale!(asqrt, s)
     asqrt = set_length!(asqrt, normalise(asqrt, zlen))
     asqrt = rescale!(asqrt)
     return asqrt
@@ -1273,7 +1276,7 @@ end
 function Base.exp(a::LaurentSeriesElem{T}) where {T <: RingElement}
    if iszero(a)
       z = one(parent(a))
-      set_prec!(z, precision(a))
+      z = set_prec!(z, precision(a))
       return z
    end
    vala = valuation(a)
@@ -1293,8 +1296,8 @@ function Base.exp(a::LaurentSeriesElem{T}) where {T <: RingElement}
    z = parent(a)()
    R = base_ring(a)
    fit!(z, preca)
-   set_prec!(z, preca)
-   set_val!(z, 0)
+   z = set_prec!(z, preca)
+   z = set_val!(z, 0)
    c = vala == 0 ? polcoeff(a, 0) : R()
    z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -149,7 +149,7 @@ function +(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) w
       z = setcoeff!(z, i - 1, deepcopy(coeff(b, i - 1)))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -177,7 +177,7 @@ function -(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) w
       z = setcoeff!(z, i - 1, -coeff(b, i - 1))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -203,7 +203,7 @@ function *(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) w
       end
    end
    z = parent(a)(d)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -220,7 +220,7 @@ function *(a::T, b::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -231,7 +231,7 @@ function *(a::AbstractAlgebra.NCPolyElem{T}, b::T) where {T <: NCRingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, coeff(a, i - 1)*b)
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -256,7 +256,7 @@ function ^(a::AbstractAlgebra.NCPolyElem{T}, b::Int) where {T <: NCRingElem}
       for i = 1:b
          z = setcoeff!(z, i - 1, deepcopy(coeff(a, 0)))
       end
-      set_length!(z, b + 1)
+      z = set_length!(z, b + 1)
       return z
    elseif length(a) == 0
       return zero(R)
@@ -398,7 +398,7 @@ function mullow(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{
       end
    end
    z = parent(a)(d)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -430,11 +430,11 @@ function divexact_right(f::AbstractAlgebra.NCPolyElem{T}, g::AbstractAlgebra.NCP
       q1 = d[lenf - leng + 1] = divexact_right(coeff(f, lenf - 1), coeff(g, leng - 1))
       f = f - shift_left(q1*g, lenf - leng)
       if length(f) == lenf # inexact case
-         set_length!(f, normalise(f, lenf - 1))
+         f = set_length!(f, normalise(f, lenf - 1))
       end
    end
    q = parent(f)(d)
-   set_length!(q, lenq)
+   q = set_length!(q, lenq)
    return q
 end
 
@@ -460,11 +460,11 @@ function divexact_left(f::AbstractAlgebra.NCPolyElem{T}, g::AbstractAlgebra.NCPo
       q1 = d[lenf - leng + 1] = divexact_left(coeff(f, lenf - 1), coeff(g, leng - 1))
       f = f - shift_left(g*q1, lenf - leng)
       if length(f) == lenf # inexact case
-         set_length!(f, normalise(f, lenf - 1))
+         f = set_length!(f, normalise(f, lenf - 1))
       end
    end
    q = parent(f)(d)
-   set_length!(q, lenq)
+   q = set_length!(q, lenq)
    return q
 end
 
@@ -485,7 +485,7 @@ function divexact_right(a::AbstractAlgebra.NCPolyElem{T}, b::T) where {T <: NCRi
    for i = 1:length(a)
       z = setcoeff!(z, i - 1, divexact_right(coeff(a, i - 1), b))
    end
-   set_length!(z, length(a))
+   z = set_length!(z, length(a))
    return z
 end
 
@@ -500,7 +500,7 @@ function divexact_left(a::AbstractAlgebra.NCPolyElem{T}, b::T) where {T <: NCRin
    for i = 1:length(a)
       z = setcoeff!(z, i - 1, divexact_left(coeff(a, i - 1), b))
    end
-   set_length!(z, length(a))
+   z = set_length!(z, length(a))
    return z
 end
 
@@ -515,7 +515,7 @@ function divexact_right(a::AbstractAlgebra.NCPolyElem, b::Union{Integer, Rationa
    for i = 1:length(a)
       z = setcoeff!(z, i - 1, divexact_right(coeff(a, i - 1), b))
    end
-   set_length!(z, length(a))
+   z = set_length!(z, length(a))
    return z
 end
 
@@ -585,6 +585,7 @@ function set_length!(c::NCPoly{T}, n::Int) where T <: NCRingElem
       end
    end
    c.length = n
+   return c
 end
 
 function fit!(c::NCPoly{T}, n::Int) where {T <: NCRingElem}
@@ -602,7 +603,7 @@ function fit!(c::NCPoly{T}, n::Int) where {T <: NCRingElem}
 end
 
 function zero!(c::NCPoly{T}) where {T <: NCRingElem}
-   set_length!(c, 0)
+   c = set_length!(c, 0)
    return c
 end
 
@@ -611,7 +612,7 @@ function mul!(c::AbstractAlgebra.NCPolyElem{T}, a::AbstractAlgebra.NCPolyElem{T}
    lenb = length(b)
 
    if lena == 0 || lenb == 0
-      set_length!(c, 0)
+      c = set_length!(c, 0)
    else
       if a === c
          a = deepcopy(a)
@@ -640,7 +641,7 @@ function mul!(c::AbstractAlgebra.NCPolyElem{T}, a::AbstractAlgebra.NCPolyElem{T}
          end
       end
 
-      set_length!(c, normalise(c, lenc))
+      c = set_length!(c, normalise(c, lenc))
    end
    return c
 end
@@ -653,7 +654,7 @@ function addeq!(c::AbstractAlgebra.NCPolyElem{T}, a::AbstractAlgebra.NCPolyElem{
    for i = 1:lena
       c.coeffs[i] = addeq!(c.coeffs[i], coeff(a, i - 1))
    end
-   set_length!(c, normalise(c, len))
+   c = set_length!(c, normalise(c, len))
    return c
 end
 
@@ -677,7 +678,7 @@ function add!(c::AbstractAlgebra.NCPolyElem{T}, a::AbstractAlgebra.NCPolyElem{T}
       c = setcoeff!(c, i - 1, deepcopy(coeff(b, i - 1)))
       i += 1
    end
-   set_length!(c, normalise(c, len))
+   c = set_length!(c, normalise(c, len))
    return c
 end
 

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -350,7 +350,7 @@ function -(a::PolynomialElem)
    for i = 1:len
       z = setcoeff!(z, i - 1, -coeff(a, i - 1))
    end
-   set_length!(z, len)
+   z = set_length!(z, len)
    return z
 end
 
@@ -384,7 +384,7 @@ function +(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where
       z = setcoeff!(z, i - 1, deepcopy(coeff(b, i - 1)))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -412,7 +412,7 @@ function -(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where
       z = setcoeff!(z, i - 1, -coeff(b, i - 1))
       i += 1
    end
-   set_length!(z, normalise(z, i - 1))
+   z = set_length!(z, normalise(z, i - 1))
    return z
 end
 
@@ -533,7 +533,7 @@ function mul_ks(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) 
       end
       setcoeff!(r, i - 1, u)
    end
-   set_length!(r, normalise(r, lenr))
+   r = set_length!(r, normalise(r, lenr))
    return r
 end
 
@@ -563,7 +563,7 @@ function mul_classical(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyEl
       d[i] = reduce!(d[i])
    end
    z = parent(a)(d)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -593,7 +593,7 @@ function *(a::T, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -608,7 +608,7 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::PolynomialElem)
    for i = 1:len
       z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    return z
 end
 
@@ -652,7 +652,7 @@ function pow_multinomial(a::AbstractAlgebra.PolyElem{T}, e::Int) where {T <: Rin
       res[k + 1] = divexact(res[k + 1], d)
    end
    z = parent(a)(res)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -671,7 +671,7 @@ function ^(a::AbstractAlgebra.PolyElem{T}, b::Int) where {T <: RingElement}
       for i = 1:b
          z = setcoeff!(z, i - 1, deepcopy(coeff(a, 0)))
       end
-      set_length!(z, b + 1)
+      z = set_length!(z, b + 1)
       return z
    elseif b == 0
       return one(R)
@@ -850,7 +850,7 @@ function truncate(a::PolynomialElem, n::Int)
    for i = 1:lenz
       z = setcoeff!(z, i - 1, coeff(a, i - 1))
    end
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -892,7 +892,7 @@ function mullow(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}, 
       d[i] = reduce!(d[i])
    end
    z = parent(a)(d)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -917,7 +917,7 @@ function reverse(x::PolynomialElem, len::Int)
    for i = 1:len
       z = setcoeff!(r, i - 1, coeff(x, len - i))
    end
-   set_length!(r, normalise(r, len))
+   r = set_length!(r, normalise(r, len))
    return r
 end
 
@@ -1075,11 +1075,11 @@ function divexact(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}
       q1 = d[lenf - leng + 1] = divexact(coeff(f, lenf - 1), coeff(g, leng - 1))
       f = f - shift_left(q1*g, lenf - leng)
       if length(f) == lenf # inexact case
-         set_length!(f, normalise(f, lenf - 1))
+         f = set_length!(f, normalise(f, lenf - 1))
       end
    end
    q = parent(f)(d)
-   set_length!(q, lenq)
+   q = set_length!(q, lenq)
    return q
 end
 
@@ -1100,7 +1100,7 @@ function divexact(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem}
    for i = 1:length(a)
       z = setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
    end
-   set_length!(z, length(a))
+   z = set_length!(z, length(a))
    return z
 end
 
@@ -1115,7 +1115,7 @@ function divexact(a::AbstractAlgebra.PolyElem, b::Union{Integer, Rational, Abstr
    for i = 1:length(a)
       z = setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
    end
-   set_length!(z, length(a))
+   z = set_length!(z, length(a))
    return z
 end
 
@@ -1147,7 +1147,7 @@ function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) whe
             u = addeq!(u, c)
             f = setcoeff!(f, i + length(f) - length(g) - 1, u)
          end
-         set_length!(f, normalise(f, length(f) - 1))
+         f = set_length!(f, normalise(f, length(f) - 1))
       end
    end
    return f
@@ -1187,7 +1187,7 @@ function Base.divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem
          u = addeq!(u, c)
          f = setcoeff!(f, i + length(f) - length(g) - 1, u)
       end
-      set_length!(f, normalise(f, length(f) - 1))
+      f = set_length!(f, normalise(f, length(f) - 1))
    end
    return q, f
 end
@@ -1256,7 +1256,7 @@ function pseudodivrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyEle
    while lenq > 0 && iszero(coeff(q, lenq - 1))
       lenq -= 1
    end
-   set_length!(q, lenq)
+   q = set_length!(q, lenq)
    s = b^k
    return q*s, f*s
 end
@@ -1369,7 +1369,7 @@ function divides(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T})
          u = addeq!(u, c)
          f = setcoeff!(f, i + length(f) - length(g) - 1, u)
       end
-      set_length!(f, normalise(f, length(f)))
+      f = set_length!(f, normalise(f, length(f)))
    end
    return iszero(f), q
 end
@@ -1392,7 +1392,7 @@ function divides(z::AbstractAlgebra.PolyElem{T}, x::T) where {T <: RingElement}
       end
       q = setcoeff!(q, i - 1, c)
    end
-   set_length!(q, flag ? length(z) : 0)
+   q = set_length!(q, flag ? length(z) : 0)
    return flag, q
 end
 
@@ -1644,7 +1644,7 @@ function derivative(a::PolynomialElem)
    for i = 1:len - 1
       z = setcoeff!(z, i - 1, i*coeff(a, i))
    end
-   set_length!(z, normalise(z, len - 1))
+   z = set_length!(z, normalise(z, len - 1))
    return z
 end
 
@@ -1670,7 +1670,7 @@ function integral(x::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlge
    while len > 0 && iszero(coeff(p, len - 1)) # FIXME: cannot use normalise here
       len -= 1
    end
-   set_length!(p, len)
+   p = set_length!(p, len)
    return p
 end
 
@@ -1716,7 +1716,7 @@ function subresultant_ducos(A::AbstractAlgebra.PolyElem{T}, Sd1::AbstractAlgebra
    for j = 0:e1 - 2
       setcoeff!(D, j, se*coeff(A, j))
    end
-   set_length!(D, normalise(D, e1 - 1))
+   D = set_length!(D, normalise(D, e1 - 1))
    Hj = parent(A)()
    fit!(Hj, e1)
    setcoeff!(Hj, e1 - 1, se)
@@ -2317,7 +2317,7 @@ function interpolate(S::AbstractAlgebra.PolyRing, x::Array{T, 1}, y::Array{T, 1}
    end
    newton_to_monomial!(P, x)
    r = S(P)
-   set_length!(r, normalise(r, n))
+   r = set_length!(r, normalise(r, n))
    return r
 end
 
@@ -2346,7 +2346,7 @@ function interpolate(S::AbstractAlgebra.PolyRing, x::Array{T, 1}, y::Array{T, 1}
    end
    newton_to_monomial!(P, x)
    r = S(P)
-   set_length!(r, normalise(r, n))
+   r = set_length!(r, normalise(r, n))
    return r
 end
 
@@ -2505,6 +2505,7 @@ function set_length!(c::Poly{T}, n::Int) where T <: RingElement
       end
    end
    c.length = n
+   return c
 end
 
 function fit!(c::Poly{T}, n::Int) where {T <: RingElement}
@@ -2522,7 +2523,7 @@ function fit!(c::Poly{T}, n::Int) where {T <: RingElement}
 end
 
 function zero!(c::Poly{T}) where {T <: RingElement}
-   set_length!(c, 0)
+   c = set_length!(c, 0)
    return c
 end
 
@@ -2531,7 +2532,7 @@ function mul!(c::AbstractAlgebra.PolyElem{T}, a::AbstractAlgebra.PolyElem{T}, b:
    lenb = length(b)
 
    if lena == 0 || lenb == 0
-      set_length!(c, 0)
+      c = set_length!(c, 0)
    else
       if a === c
          a = deepcopy(a)
@@ -2560,7 +2561,7 @@ function mul!(c::AbstractAlgebra.PolyElem{T}, a::AbstractAlgebra.PolyElem{T}, b:
          end
       end
 
-      set_length!(c, normalise(c, lenc))
+      c = set_length!(c, normalise(c, lenc))
    end
    return c
 end
@@ -2573,7 +2574,7 @@ function addeq!(c::AbstractAlgebra.PolyElem{T}, a::AbstractAlgebra.PolyElem{T}) 
    for i = 1:lena
       c.coeffs[i] = addeq!(c.coeffs[i], coeff(a, i - 1))
    end
-   set_length!(c, normalise(c, len))
+   c = set_length!(c, normalise(c, len))
    return c
 end
 
@@ -2597,7 +2598,7 @@ function add!(c::AbstractAlgebra.PolyElem{T}, a::AbstractAlgebra.PolyElem{T}, b:
       c = setcoeff!(c, i - 1, deepcopy(coeff(b, i - 1)))
       i += 1
    end
-   set_length!(c, normalise(c, len))
+   c = set_length!(c, normalise(c, len))
    return c
 end
 

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -255,16 +255,16 @@ function rescale!(a::PuiseuxSeriesElem)
    if !iszero(a)
       d = gcd(a.scale, gcd(scale(a.data), gcd(valuation(a.data), precision(a.data))))
       if d != 1
-         set_scale!(a.data, div(scale(a.data), d))
-         set_prec!(a.data, AbstractAlgebra.div(precision(a.data), d))
-         set_val!(a.data, AbstractAlgebra.div(valuation(a.data), d))
+         a.data = set_scale!(a.data, div(scale(a.data), d))
+         a.data = set_prec!(a.data, AbstractAlgebra.div(precision(a.data), d))
+         a.data = set_val!(a.data, AbstractAlgebra.div(valuation(a.data), d))
          a.scale = div(a.scale, d)
       end
    else
       d = gcd(precision(a.data), a.scale)
       if d != 1
-         set_prec!(a.data, AbstractAlgebra.div(precision(a.data), d))
-         set_val!(a.data, AbstractAlgebra.div(valuation(a.data), d))
+         a.data = set_prec!(a.data, AbstractAlgebra.div(precision(a.data), d))
+         a.data = set_val!(a.data, AbstractAlgebra.div(valuation(a.data), d))
          a.scale = div(a.scale, d)
       end
    end
@@ -619,7 +619,7 @@ end
 
 function zero!(a::PuiseuxSeriesElem{T}) where T <: RingElement
    zero!(a.data)
-   set_scale(a, 1)
+   a = set_scale(a, 1)
    return a
 end
 

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -123,10 +123,12 @@ end
 
 function set_prec!(a::AbstractAlgebra.SeriesElem, prec::Int)
    a.prec = prec
+   return a
 end
 
 function set_val!(a::AbstractAlgebra.RelSeriesElem, val::Int)
    a.val = val
+   return a
 end
 
 function polcoeff(a::RelSeries, n::Int)
@@ -221,12 +223,12 @@ function renormalize!(z::AbstractAlgebra.RelSeriesElem)
    while i < zlen && iszero(polcoeff(z, i))
       i += 1
    end
-   set_prec!(z, zprec)
+   z = set_prec!(z, zprec)
    if i == zlen
       z = set_length!(z, 0)
-      set_val!(z, zprec)
+      z = set_val!(z, zprec)
    else
-      set_val!(z, zval + i)
+      z = set_val!(z, zval + i)
       for j = 1:zlen - i
          z = setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
       end
@@ -313,8 +315,8 @@ show_minus_one(::Type{<:AbstractAlgebra.SeriesElem{T}}) where {T <: RingElement}
 function -(a::AbstractAlgebra.RelSeriesElem)
    len = pol_length(a)
    z = parent(a)()
-   set_prec!(z, precision(a))
-   set_val!(z, valuation(a))
+   z = set_prec!(z, precision(a))
+   z = set_val!(z, valuation(a))
    fit!(z, len)
    for i = 1:len
       z = setcoeff!(z, i - 1, -polcoeff(a, i - 1))
@@ -346,8 +348,8 @@ function +(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
    R = base_ring(a)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
-   set_val!(z, valz)
+   z = set_prec!(z, prec)
+   z = set_val!(z, valz)
    if vala >= valb
       for i = 1:min(lenb, vala - valb)
          z = setcoeff!(z, i - 1, deepcopy(polcoeff(b, i - 1)))
@@ -404,8 +406,8 @@ function -(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
    R = base_ring(a)
    z = parent(a)()
    fit!(z, lenz)
-   set_prec!(z, prec)
-   set_val!(z, valz)
+   z = set_prec!(z, prec)
+   z = set_val!(z, valz)
    if vala >= valb
       for i = 1:min(lenb, vala - valb)
          z = setcoeff!(z, i - 1, -polcoeff(b, i - 1))
@@ -500,8 +502,8 @@ function *(a::T, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElem}
    len = pol_length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
-   set_val!(z, valuation(b))
+   z = set_prec!(z, precision(b))
+   z = set_val!(z, valuation(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
@@ -518,8 +520,8 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.RelSer
    len = pol_length(b)
    z = parent(b)()
    fit!(z, len)
-   set_prec!(z, precision(b))
-   set_val!(z, valuation(b))
+   z = set_prec!(z, precision(b))
+   z = set_val!(z, valuation(b))
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
@@ -556,14 +558,14 @@ function shift_left(x::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: Rin
    xlen = pol_length(x)
    if xlen == 0
       z = zero(parent(x))
-      set_prec!(z, precision(x) + n)
-      set_val!(z, valuation(x) + n)
+      z = set_prec!(z, precision(x) + n)
+      z = set_val!(z, valuation(x) + n)
       return z
    end
    z = parent(x)()
    fit!(z, xlen)
-   set_prec!(z, precision(x) + n)
-   set_val!(z, valuation(x) + n)
+   z = set_prec!(z, precision(x) + n)
+   z = set_val!(z, valuation(x) + n)
    for i = 1:xlen
       z = setcoeff!(z, i - 1, polcoeff(x, i - 1))
    end
@@ -582,13 +584,13 @@ function shift_right(x::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: Ri
    xprec = precision(x)
    z = parent(x)()
    if n >= xlen + xval
-      set_prec!(z, max(0, xprec - n))
-      set_val!(z, max(0, xprec - n))
+      z = set_prec!(z, max(0, xprec - n))
+      z = set_val!(z, max(0, xprec - n))
    else
       zlen = min(xlen + xval - n, xlen)
       fit!(z, zlen)
-      set_prec!(z, max(0, xprec - n))
-      set_val!(z, max(0, xval - n))
+      z = set_prec!(z, max(0, xprec - n))
+      z = set_val!(z, max(0, xval - n))
       for i = 1:zlen
          z = setcoeff!(z, i - 1, polcoeff(x, i + xlen  - zlen - 1))
       end
@@ -616,13 +618,13 @@ function truncate(a::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingE
       return a
    end
    z = parent(a)()
-   set_prec!(z, n)
+   z = set_prec!(z, n)
    if n <= aval
       z = set_length!(z, 0)
-      set_val!(z, n)
+      z = set_val!(z, n)
    else
       fit!(z, n - aval)
-      set_val!(z, aval)
+      z = set_val!(z, aval)
       for i = 1:min(n - aval, alen)
          z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
@@ -679,8 +681,8 @@ function ^(a::AbstractAlgebra.RelSeriesElem{T}, b::Int) where {T <: RingElement}
    # special case powers of x for constructing power series efficiently
    if pol_length(a) == 0
       z = parent(a)()
-      set_prec!(z, b*valuation(a))
-      set_val!(z, b*valuation(a))
+      z = set_prec!(z, b*valuation(a))
+      z = set_val!(z, b*valuation(a))
       return z
    elseif b == 0
       # in fact, the result would be exact 1 if we had exact series
@@ -689,15 +691,15 @@ function ^(a::AbstractAlgebra.RelSeriesElem{T}, b::Int) where {T <: RingElement}
    elseif isgen(a)
       z = parent(a)()
       fit!(z, 1)
-      set_prec!(z, b + precision(a) - 1)
-      set_val!(z, b)
+      z = set_prec!(z, b + precision(a) - 1)
+      z = set_val!(z, b)
       z = setcoeff!(z, 0, deepcopy(polcoeff(a, 0)))
       z = set_length!(z, 1)
       return z
    elseif pol_length(a) == 1
       z = parent(a)(polcoeff(a, 0)^b)
-      set_prec!(z, (b - 1)*valuation(a) + precision(a))
-      set_val!(z, b*valuation(a))
+      z = set_prec!(z, (b - 1)*valuation(a) + precision(a))
+      z = set_val!(z, b*valuation(a))
       return z
    elseif b == 1
       return deepcopy(a)
@@ -718,8 +720,8 @@ function ^(a::AbstractAlgebra.RelSeriesElem{T}, b::Int) where {T <: RingElement}
          end
          bit >>= 1
       end
-      set_val!(z, b*val)
-      set_prec!(z, b*val + prec)
+      z = set_val!(z, b*val)
+      z = set_prec!(z, b*val + prec)
       renormalize!(z)
       return z
    end
@@ -867,8 +869,8 @@ function divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::AbstractAlgebra.RelSer
    end
    y = truncate(y, precision(x))
    res = parent(x)()
-   set_prec!(res, min(precision(x), valuation(x) + precision(y)))
-   set_val!(res, valuation(x))
+   res = set_prec!(res, min(precision(x), valuation(x) + precision(y)))
+   res = set_val!(res, valuation(x))
    lc = coeff(y, 0)
    lc == 0 && error("Not an exact division")
    lenr = precision(x) - valuation(x)
@@ -899,8 +901,8 @@ function divexact(x::AbstractAlgebra.RelSeriesElem, y::Union{Integer, Rational, 
    lenx = pol_length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
-   set_val!(z, valuation(x))
+   z = set_prec!(z, precision(x))
+   z = set_val!(z, valuation(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
@@ -916,8 +918,8 @@ function divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::T) where {T <: RingEle
    lenx = pol_length(x)
    z = parent(x)()
    fit!(z, lenx)
-   set_prec!(z, precision(x))
-   set_val!(z, valuation(x))
+   z = set_prec!(z, precision(x))
+   z = set_val!(z, valuation(x))
    for i = 1:lenx
       z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
@@ -940,8 +942,8 @@ function inv(a::AbstractAlgebra.RelSeriesElem)
    a1 = polcoeff(a, 0)
    ainv = parent(a)()
    fit!(ainv, precision(a))
-   set_prec!(ainv, precision(a))
-   set_val!(ainv, 0)
+   ainv = set_prec!(ainv, precision(a))
+   ainv = set_val!(ainv, 0)
    if precision(a) != 0
       ainv = setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
    end
@@ -976,14 +978,14 @@ function Base.sqrt(a::AbstractAlgebra.RelSeriesElem)
    prec = precision(a) - aval
    if prec == 0
       asqrt = parent(a)()
-      set_prec!(asqrt, aval2)
-      set_val!(asqrt, aval2)
+      asqrt = set_prec!(asqrt, aval2)
+      asqrt = set_val!(asqrt, aval2)
       return asqrt
    end
    asqrt = parent(a)()
    fit!(asqrt, prec)
-   set_prec!(asqrt, prec + aval2)
-   set_val!(asqrt, aval2)
+   asqrt = set_prec!(asqrt, prec + aval2)
+   asqrt = set_val!(asqrt, aval2)
    if prec > 0
       g = sqrt(polcoeff(a, 0))
       asqrt = setcoeff!(asqrt, 0, g)
@@ -1024,7 +1026,7 @@ end
 function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    if iszero(a)
       z = one(parent(a))
-      set_prec!(z, precision(a))
+      z = set_prec!(z, precision(a))
       return z
    end
    vala = valuation(a)
@@ -1032,8 +1034,8 @@ function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    z = parent(a)()
    R = base_ring(a)
    fit!(z, preca)
-   set_prec!(z, preca)
-   set_val!(z, 0)
+   z = set_prec!(z, preca)
+   z = set_val!(z, 0)
    c = vala == 0 ? polcoeff(a, 0) : R()
    z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -118,6 +118,7 @@ end
 
 function set_length!(a::AbstractAlgebra.SeriesElem, len::Int)
    a.length = len
+   return a
 end
 
 function set_prec!(a::AbstractAlgebra.SeriesElem, prec::Int)
@@ -222,14 +223,14 @@ function renormalize!(z::AbstractAlgebra.RelSeriesElem)
    end
    set_prec!(z, zprec)
    if i == zlen
-      set_length!(z, 0)
+      z = set_length!(z, 0)
       set_val!(z, zprec)
    else
       set_val!(z, zval + i)
       for j = 1:zlen - i
          z = setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
       end
-      set_length!(z, zlen - i)
+      z = set_length!(z, zlen - i)
    end
    return nothing
 end
@@ -380,7 +381,7 @@ function +(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
          z = setcoeff!(z, i - 1, deepcopy(polcoeff(a, i - 1)))
       end
    end
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    return z
 end
@@ -438,7 +439,7 @@ function -(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
          z = setcoeff!(z, i - 1, deepcopy(polcoeff(a, i - 1)))
       end
    end
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    return z
 end
@@ -480,7 +481,7 @@ function *(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
       end
    end
    z = parent(a)(d, lenz, prec + zval, zval)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    renormalize!(z)
    return z
 end
@@ -504,7 +505,7 @@ function *(a::T, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElem}
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    renormalize!(z)
    return z
 end
@@ -522,7 +523,7 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.RelSer
    for i = 1:len
       z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
-   set_length!(z, normalise(z, len))
+   z = set_length!(z, normalise(z, len))
    renormalize!(z)
    return z
 end
@@ -617,7 +618,7 @@ function truncate(a::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingE
    z = parent(a)()
    set_prec!(z, n)
    if n <= aval
-      set_length!(z, 0)
+      z = set_length!(z, 0)
       set_val!(z, n)
    else
       fit!(z, n - aval)
@@ -625,7 +626,7 @@ function truncate(a::AbstractAlgebra.RelSeriesElem{T}, n::Int) where {T <: RingE
       for i = 1:min(n - aval, alen)
          z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
-      set_length!(z, normalise(z, n - aval))
+      z = set_length!(z, normalise(z, n - aval))
    end
    return z
 end
@@ -659,7 +660,7 @@ function mullow(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSerie
       end
    end
    z = parent(a)(d, lenz, prec, 0)
-   set_length!(z, normalise(z, lenz))
+   z = set_length!(z, normalise(z, lenz))
    return z
 end
 
@@ -691,7 +692,7 @@ function ^(a::AbstractAlgebra.RelSeriesElem{T}, b::Int) where {T <: RingElement}
       set_prec!(z, b + precision(a) - 1)
       set_val!(z, b)
       z = setcoeff!(z, 0, deepcopy(polcoeff(a, 0)))
-      set_length!(z, 1)
+      z = set_length!(z, 1)
       return z
    elseif pol_length(a) == 1
       z = parent(a)(polcoeff(a, 0)^b)
@@ -879,7 +880,7 @@ function divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::AbstractAlgebra.RelSer
          x = setcoeff!(x, i + j, polcoeff(x, i + j) - polcoeff(y, j)*q)
       end
    end
-   set_length!(res, normalise(res, pol_length(res)))
+   res = set_length!(res, normalise(res, pol_length(res)))
    return res
 end
 
@@ -952,7 +953,7 @@ function inv(a::AbstractAlgebra.RelSeriesElem)
       end
       ainv = setcoeff!(ainv, n - 1, divexact(s, a1))
    end
-   set_length!(ainv, normalise(ainv, precision(a)))
+   ainv = set_length!(ainv, normalise(ainv, precision(a)))
    return ainv
 end
 
@@ -1006,7 +1007,7 @@ function Base.sqrt(a::AbstractAlgebra.RelSeriesElem)
       c = divexact(c, g2)
       asqrt = setcoeff!(asqrt, n, c)
    end
-   set_length!(asqrt, normalise(asqrt, prec))
+   asqrt = set_length!(asqrt, normalise(asqrt, prec))
    return asqrt
 end
 
@@ -1045,7 +1046,7 @@ function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
       !isunit(R(k)) && error("Unable to divide in exp")
       z = setcoeff!(z, k, divexact(s, k))
    end
-   set_length!(z, normalise(z, preca))
+   z = set_length!(z, normalise(z, preca))
    return z
 end
 
@@ -1227,7 +1228,7 @@ function add!(c::RelSeries{T}, a::RelSeries{T}, b::RelSeries{T}) where {T <: Rin
          c.coeffs[i] = deepcopy(a.coeffs[i])
       end
    end
-   set_length!(c, normalise(c, lenr))
+   c = set_length!(c, normalise(c, lenr))
    renormalize!(c)
    return c
 end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -500,7 +500,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, -10:10) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test shift_right(shift_left(f, s) + g, s) == f
       @test isequal(shift_left(f, s), x^s*f)
@@ -520,7 +520,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, -1:1) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test isapprox(shift_right(shift_left(f, s) + g, s), f)
       @test isapprox(shift_left(f, s), x^s*f)
@@ -541,7 +541,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, 0:5) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test shift_right(shift_left(f, s) + g, s) == f
       @test isequal(shift_left(f, s), x^s*f)

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -525,7 +525,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, -10:10) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test isequal(shift_right(shift_left(f, s) + g, s), f)
       @test isequal(shift_left(f, s), x^s*f)
@@ -545,7 +545,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, -1:1) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test isapprox(shift_right(shift_left(f, s) + g, s), f)
       @test isapprox(shift_left(f, s), x^s*f)
@@ -566,7 +566,7 @@ end
       s = rand(0:12)
       g = rand(R, 0:0, 0:5) + O(x^s)
 
-      set_prec!(g, max(precision(g), precision(f) + s))
+      g = set_prec!(g, max(precision(g), precision(f) + s))
 
       @test isequal(shift_right(shift_left(f, s) + g, s), f)
       @test isequal(shift_left(f, s), x^s*f)


### PR DESCRIPTION
Updates set_length!, set_val!, set_prec! and set_scale! to return their argument to support polynomials and series with immutable types.

Fixes #13.
Fixes #16.

Immediately after this is applied, the corresponding Nemo patch should be applied. There is also a Hecke patch but this can be delayed if needed.

Note this is breaking.