### PR TITLE
Perm multiplication: check that they have compatible parents

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -30,6 +30,10 @@ true
 """
 parent(g::Perm{T}) where T = SymmetricGroup(T(length(g.d)))
 
+check_parent(g::Perm, h::Perm) = length(g.d) == length(h.d) ||
+   throw(ArgumentError("incompatible permutation groups"))
+
+
 ###############################################################################
 #
 #   Low-level manipulation
@@ -396,6 +400,8 @@ false
 ###############################################################################
 function mul!(out::Perm, g::Perm, h::Perm)
    out = (out === h ? similar(out) : out)
+   check_parent(out, g)
+   check_parent(g, h)
    @inbounds for i in eachindex(out.d)
       out[i] = h[g[i]]
    end

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -214,6 +214,11 @@ end
    @test a_copy^2 == AbstractAlgebra.mul!(a,a,a)
    @test a_copy == a
 
+   G2 = SymmetricGroup(T(2))
+   c = Perm(T[2, 1])
+   @test_throws ArgumentError a*c
+   @test_throws ArgumentError c*a
+
    G = SymmetricGroup(T(10))
    p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
    @test p^0 == G()


### PR DESCRIPTION
It's currently possible to construct an invalid permutation by multiplying two incomptible ones, e.g.:
```julia
julia> p = perm"(1, 2)" * perm"(1, 2, 3)";

julia> p # invalid state
Error showing value of type Perm{Int64}:
ERROR: BoundsError: attempt to access 2-element BitArray{1} at index [3]
[...]

julia> p = perm"(1, 2, 3)" * perm"(1, 2)"; # multiplication fails
ERROR: BoundsError: attempt to access 2-element Array{Int64,1} at index [3]
[...]
```
With this PR, in both of the above cases, we get a more explicit message:
```julia
julia> p = perm"(1, 2, 3)" * perm"(1, 2)";
ERROR: ArgumentError: incompatible permutation groups
Stacktrace:
[...]
```