### PR TITLE
Square root of all the things

### DIFF
--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -174,6 +174,35 @@ julia> h = gcd(f, g)
 
 ```
 
+### Square root
+
+```@docs
+issquare{T <: RingElem}(::FracElem{T})
+```
+
+```@docs
+sqrt{T <: RingElem}(::FracElem{T})
+```
+
+**Examples**
+
+```jldoctest
+julia> R, x = PolynomialRing(QQ, "x")
+(Univariate Polynomial Ring in x over Rationals, x)
+
+julia> S = FractionField(R)
+Fraction field of Univariate Polynomial Ring in x over Rationals
+
+julia> a = (21//4*x^6 - 15*x^5 + 27//14*x^4 + 9//20*x^3 + 3//7*x + 9//10)//(x + 3)
+(21//4*x^6 - 15*x^5 + 27//14*x^4 + 9//20*x^3 + 3//7*x + 9//10)//(x + 3)
+
+julia> sqrt(a^2)
+(21//4*x^6 - 15*x^5 + 27//14*x^4 + 9//20*x^3 + 3//7*x + 9//10)//(x + 3)
+
+julia> issquare(a^2)
+true
+```
+
 ### Remove and valuation
 
 When working over a Euclidean domain, it is convenient to extend valuations to the

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -148,6 +148,10 @@ AbstractAlgebra.sqrt(a::BigInt)
 ```
 
 ```@docs
+issquare(a::BigInt)
+```
+
+```@docs
 AbstractAlgebra.exp(a::BigInt)
 ```
 
@@ -157,9 +161,11 @@ AbstractAlgebra.exp(a::BigInt)
 julia> d = AbstractAlgebra.sqrt(ZZ(36))
 6
 
+julia> issquare(ZZ(9))
+true
+
 julia> m = AbstractAlgebra.exp(ZZ(0))
 1
-
 ```
 ### Coprime bases
 

--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -470,6 +470,40 @@ julia> d = gcd(f*g^2, f^2*g)
 
 ```
 
+### Square root
+
+Over rings for which an exact square root is available, it is possible to take
+the square root of a polynomial or test whether it is a square.
+
+```julia
+sqrt(f::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
+```
+
+Return the square root of the polynomial $f$ and raise an exception if it is
+not a square.
+
+```julia
+issquare(f::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
+```
+
+Return `true` if $f$ is a square.
+
+**Examples**
+
+```jldoctest
+julia> R, (x, y) = PolynomialRing(ZZ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y])
+
+julia> f = -4*x^5*y^4 + 5*x^5*y^3 + 4*x^4 - x^3*y^4
+-4*x^5*y^4 + 5*x^5*y^3 + 4*x^4 - x^3*y^4
+
+julia> sqrt(f^2)
+4*x^5*y^4 - 5*x^5*y^3 - 4*x^4 + x^3*y^4
+
+julia> issquare(f)
+false
+```
+
 ## Interface for sparse distributed, random access multivariates
 
 The following additional functions should be implemented by libraries that provide a

--- a/docs/src/mpolynomial_rings.md
+++ b/docs/src/mpolynomial_rings.md
@@ -476,14 +476,16 @@ Over rings for which an exact square root is available, it is possible to take
 the square root of a polynomial or test whether it is a square.
 
 ```julia
-sqrt(f::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
+sqrt(f::MyMPoly{T}, check::bool=true) where T <: AbstractAlgebra.RingElem
 ```
 
 Return the square root of the polynomial $f$ and raise an exception if it is
-not a square.
+not a square. If `check` is set to `false`, the input is assumed to be a
+perfect square and this assumption is not fully checked. This can be
+significantly faster.
 
 ```julia
-issquare(f::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
+issquare(::MyMPoly{T}) where T <: AbstractAlgebra.RingElem
 ```
 
 Return `true` if $f$ is a square.

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -270,6 +270,10 @@ isunit(::PolyElem)
 ```
 
 ```@docs
+issquare(::PolyElem)
+```
+
+```@docs
 degree(::Generic.PolynomialElem)
 ```
 
@@ -439,6 +443,20 @@ x*y^9 + (x + 1)*y^8 + 3*y^7
 julia> h = shift_right(f, 2)
 x
 
+```
+
+### Square root
+
+```@docs
+Base.sqrt(::PolyElem{T}) where T <: RingElement
+```
+
+**Examples**
+
+```julia
+R, x = PolynomialRing(ZZ, "x")
+g = x^2+6*x+1
+sqrt(g^2)
 ```
 
 ### Change of base ring

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -448,7 +448,7 @@ x
 ### Square root
 
 ```@docs
-Base.sqrt(::PolyElem{T}) where T <: RingElement
+Base.sqrt(::PolyElem{T}, ::Bool) where T <: RingElement
 ```
 
 **Examples**

--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -148,6 +148,10 @@ AbstractAlgebra.sqrt(a::Rational{BigInt})
 ```
 
 ```@docs
+issquare(a::Rational{BigInt})
+```
+
+```@docs
 AbstractAlgebra.exp(a::Rational{BigInt})
 ```
 
@@ -157,9 +161,11 @@ AbstractAlgebra.exp(a::Rational{BigInt})
 julia> d = AbstractAlgebra.sqrt(ZZ(36)//ZZ(25))
 6//5
 
+julia> issquare(ZZ(9)//ZZ(16))
+true
+
 julia> m = AbstractAlgebra.exp(ZZ(0)//ZZ(1))
 1//1
-
 ```
 
 

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -236,3 +236,29 @@ julia> h = gcd(f, g)
 
 ```
 
+### Square Root
+
+```@docs
+issquare{T <: Integer}(::ResElem{T})
+```
+
+```@docs
+sqrt{T <: Integer}(::ResElem{T})
+```
+
+**Examples**
+
+```jldoctest
+julia> R = ResidueField(ZZ, 733)
+Residue field of Integers modulo 733
+
+julia> a = R(86)
+86
+
+julia> issquare(a)
+true
+
+julia> sqrt(a)
+532
+```
+

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -239,11 +239,11 @@ julia> h = gcd(f, g)
 ### Square Root
 
 ```@docs
-issquare{T <: Integer}(::ResElem{T})
+issquare{T <: Integer}(::ResFieldElem{T})
 ```
 
 ```@docs
-sqrt{T <: Integer}(::ResElem{T})
+sqrt{T <: Integer}(::ResFieldElem{T})
 ```
 
 **Examples**

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -734,6 +734,29 @@ end
 
 ###############################################################################
 #
+#   Square root
+#
+###############################################################################
+
+@doc Markdown.doc"""
+    issquare(a::AbstractAlgebra.FracElem{T}) where T <: RingElem
+> Return `true` if $a$ is a square.
+"""
+function issquare(a::AbstractAlgebra.FracElem{T}) where T <: RingElem
+   return issquare(numerator(a)) && issquare(denominator(a))
+end
+
+@doc Markdown.doc"""
+    Base.sqrt(a::AbstractAlgebra.FracElem{T}) where T <: RingElem
+> Return the square root of $a$ if it is a square, otherwise raise an
+> exception.
+"""
+function Base.sqrt(a::AbstractAlgebra.FracElem{T}) where T <: RingElem
+   return parent(a)(sqrt(numerator(a)), sqrt(denominator(a)))
+end
+
+###############################################################################
+#
 #   GCD
 #
 ###############################################################################

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1453,7 +1453,7 @@ function sqrt_classical_char2(f::AbstractAlgebra.PolyElem{T}) where {T <: RingEl
    return true, q
 end
 
-function sqrt_classical(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
+function sqrt_classical(f::AbstractAlgebra.PolyElem{T}, check::Bool=true) where {T <: RingElement}
    S = parent(f)
    R = base_ring(f)
    if characteristic(R) == 2
@@ -1475,7 +1475,8 @@ function sqrt_classical(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    b = -2*d[lenq]
    k = 1
    c = R()
-   for i = m - 2:-1:0
+   last = check ? 0 : lenq - 1
+   for i = m - 2:-1:last
       qc = -coeff(f, i)
       for j = lenq - k + 1:lenq
          if i - j + 2 >= j && j > 0
@@ -1502,13 +1503,23 @@ function sqrt_classical(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    return true, q
 end
 
-function Base.sqrt(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-   flag, q = sqrt_classical(f)
+@doc Markdown.doc"""
+    Base.sqrt(f::AbstractAlgebra.PolyElem{T}, check::Bool=true) where T <: RingElement
+> Return the square root of $f$ if it is a perfect square, otherwise an
+> exception is raised. If `check` is set to `false` the function assumes
+> the input is square and may not fully check this.
+"""
+function Base.sqrt(f::AbstractAlgebra.PolyElem{T}, check::Bool=true) where T <: RingElement
+   flag, q = sqrt_classical(f, check)
    !flag && error("Not a square in sqrt")
    return q
 end
 
-function issquare(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
+@doc Markdown.doc"""
+    issquare(f::AbstractAlgebra.PolyElem{T}) where T <: RingElement
+> Return `true` if $f$ is a perfect square.
+"""
+function issquare(f::AbstractAlgebra.PolyElem{T}) where T <: RingElement
    flag, q = sqrt_classical(f)
    return flag
 end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1424,9 +1424,41 @@ end
 #
 ################################################################################
 
+function sqrt_classical_char2(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
+   S = parent(f)
+   R = base_ring(f)
+   if iszero(f)
+      return true, S()
+   end
+   m = length(f)
+   if iseven(m) # square polys have even degree
+      return false, S()
+   end
+   for i = 1:2:m # polynomial must have even exponents
+      if !iszero(coeff(f, i))
+         return false, S()
+      end
+   end
+   lenq = div(m + 1, 2)
+   d = Array{T}(undef, lenq)
+   for i = 1:lenq
+      c = coeff(f, 2*i - 2)
+      if !issquare(c)
+         return false, S()
+      end
+      d[i] = sqrt(c)
+   end
+   q = S(d)
+   q = set_length!(q, lenq)
+   return true, q
+end
+
 function sqrt_classical(f::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    S = parent(f)
    R = base_ring(f)
+   if characteristic(R) == 2
+      return sqrt_classical_char2(f)
+   end
    if iszero(f)
       return true, S()
    end

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -482,6 +482,9 @@ end
 function Base.sqrt(a::AbstractAlgebra.ResFieldElem{T}) where T <: Integer
    U = parent(a)
    p = modulus(a)
+   if p == 2 # special case, cannot find a quadratic nonresidue mod 2
+      return deepcopy(a)
+   end
    # Compute Q, S such that p - 1 = Q*2^S
    Q = p - 1
    S = 0 # power of 2 dividing p - 1

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -193,11 +193,12 @@ end
 @doc Markdown.doc"""
     sqrt(a::T) where T <: Integer
 > Return the integer square root of $a$. If $a$ is not a perfect square an
-> error is thrown.
+> exception is thrown. If `check` is set to `false` this check is not
+> performed.
 """
-function sqrt(a::T) where T <: Integer
+function sqrt(a::T, check::Bool=true) where T <: Integer
    s = isqrt(a)
-   s*s != a && error("Not a square in sqrt")
+   (check && s*s != a) && error("Not a square in sqrt")
    return s
 end
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -127,6 +127,29 @@ function powmod(a::T, b::Int, c::T) where T <: Integer
    end
 end
 
+function powmod(a::T, b::BigInt, c::T) where T <: Integer
+   b < 0 && throw(DomainError(b, "exponent must be >= 0"))
+   # special cases
+   if a == 0
+      return T(0)
+   elseif b == 0
+      return T(1)
+   else
+      n = ndigits(b; base = 2)
+      bit = BigInt(1) << (n - 1)
+      z = mod(a, c)
+      bit >>= 1
+      while bit != 0
+         z = mod(z*z, c)
+         if (bit & b) != 0
+            z = mod(z*a, c)
+         end
+         bit >>= 1
+      end
+      return z
+   end
+end
+
 ###############################################################################
 #
 #   Divides

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -180,7 +180,7 @@ end
 
 @doc Markdown.doc"""
     issquare(a::T) where T <: Integer
-> Return true if $a$ is a square..
+> Return true if $a$ is a square.
 """
 function issquare(a::T) where T <: Integer
    if a < 0

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -178,6 +178,18 @@ function sqrt(a::T) where T <: Integer
    return s
 end
 
+@doc Markdown.doc"""
+    issquare(a::T) where T <: Integer
+> Return true if $a$ is a square..
+"""
+function issquare(a::T) where T <: Integer
+   if a < 0
+      return false
+   end
+   s = isqrt(a)
+   return a == s*s
+end
+
 ###############################################################################
 #
 #   Exponential

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -181,6 +181,14 @@ function sqrt(a::Rational{T}) where T <: Integer
    return sqrt(numerator(a))//sqrt(denominator(a))
 end
 
+@doc Markdown.doc"""
+    issquare(a::Rational{T}) where T <: Integer
+> Return true if $a$ is the square of a rational..
+"""
+function issquare(a::Rational{T}) where T <: Integer
+   return issquare(numerator(a)) && issquare(denominator(a))
+end
+
 ###############################################################################
 #
 #   Exponential

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -177,8 +177,8 @@ end
 > Return the square root of $a$ if it is the square of a rational, otherwise
 > throw an error.
 """
-function sqrt(a::Rational{T}) where T <: Integer
-   return sqrt(numerator(a))//sqrt(denominator(a))
+function sqrt(a::Rational{T}, check::Bool=true) where T <: Integer
+   return sqrt(numerator(a, check))//sqrt(denominator(a, check))
 end
 
 @doc Markdown.doc"""

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -183,7 +183,7 @@ end
 
 @doc Markdown.doc"""
     issquare(a::Rational{T}) where T <: Integer
-> Return true if $a$ is the square of a rational..
+> Return true if $a$ is the square of a rational.
 """
 function issquare(a::Rational{T}) where T <: Integer
    return issquare(numerator(a)) && issquare(denominator(a))

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -198,7 +198,8 @@ end
 end
 
 @testset "Generic.Frac.divides..." begin
-   S, x = PolynomialRing(ZZ, "x")
+   R, x = PolynomialRing(ZZ, "x")
+   S = FractionField(R)
 
    for i in 1:10000
      a = rand(S, 1:5, -10:10)
@@ -209,6 +210,19 @@ end
      if d
        @test b * q == a
      end
+   end
+end
+
+@testset "Generic.Frac.square_root..." begin
+   R, x = PolynomialRing(QQ, "x")
+   S = FractionField(R)
+
+   for i = 1:100
+      a = rand(S, 1:5, -10:10)
+
+      @test issquare(a^2)
+
+      @test sqrt(a^2)^2 == a^2
    end
 end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -544,6 +544,33 @@ end
    end
 end
 
+@testset "Generic.MPoly.sqrt..." begin
+   for R in [ZZ, QQ]
+      for num_vars = 1:10
+         var_names = ["x$j" for j in 1:num_vars]
+         ord = rand_ordering()
+
+         S, varlist = PolynomialRing(ZZ, var_names, ordering = ord)
+
+         for iter = 1:10
+            f = rand(S, 0:5, 0:100, -100:100)
+
+            p = f^2
+
+            @test issquare(p)
+         
+            q = sqrt(f^2)
+
+            @test q^2 == f^2
+
+            if f != 0
+               @test_throws ErrorException sqrt(f^2*varlist[rand(1:num_vars)])
+            end
+         end
+      end
+   end
+end
+
 @testset "Generic.MPoly.euclidean_division..." begin
    R, x = QQ["y"]
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -563,6 +563,10 @@ end
 
             @test q^2 == f^2
 
+            q = sqrt(f^2, false)
+
+            @test q^2 == f^2
+
             if f != 0
                @test_throws ErrorException sqrt(f^2*varlist[rand(1:num_vars)])
             end
@@ -585,6 +589,10 @@ end
             s = f^2
 
             @test issquare(s)
+
+            q = sqrt(f^2)
+
+            @test q^2 == f^2
 
             q = sqrt(f^2)
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -544,7 +544,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.sqrt..." begin
+@testset "Generic.MPoly.square_root..." begin
    for R in [ZZ, QQ]
       for num_vars = 1:10
          var_names = ["x$j" for j in 1:num_vars]

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -569,6 +569,33 @@ end
          end
       end
    end
+
+   # Field of characteristic p
+   for p in [2, 7, 13, 65537, ZZ(2), ZZ(7), ZZ(37), ZZ(65537)]
+      R = ResidueField(ZZ, p)
+      for num_vars = 1:10
+         var_names = ["x$j" for j in 1:num_vars]
+         ord = rand_ordering()
+
+         S, varlist = PolynomialRing(R, var_names, ordering = ord)
+
+         for iter = 1:10
+            f = rand(S, 0:5, 0:100, 0:Int(p))
+
+            s = f^2
+
+            @test issquare(s)
+
+            q = sqrt(f^2)
+
+            @test q^2 == f^2
+
+            if f != 0
+               @test_throws ErrorException sqrt(f^2*varlist[rand(1:num_vars)])
+            end
+         end
+      end
+   end
 end
 
 @testset "Generic.MPoly.euclidean_division..." begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2600,6 +2600,10 @@ end
 
       @test q^2 == f^2
 
+      q = sqrt(f^2, false)
+
+      @test q^2 == f^2
+
       if f != 0
          @test_throws ErrorException sqrt(f^2*x)
       end
@@ -2615,6 +2619,10 @@ end
       @test issquare(p)
 
       q = sqrt(f^2)
+
+      @test q^2 == f^2
+
+      q = sqrt(f^2, false)
 
       @test q^2 == f^2
 
@@ -2637,6 +2645,10 @@ end
          @test issquare(s)
 
          q = sqrt(f^2)
+
+         @test q^2 == f^2
+
+         q = sqrt(f^2, false)
 
          @test q^2 == f^2
 

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2586,7 +2586,7 @@ end
    end
 end
 
-@testset "Generic.Poly.sqrt..." begin
+@testset "Generic.Poly.square_root..." begin
    for R in [ZZ, QQ]
       S, x = PolynomialRing(R, "x")
       for iter = 1:10

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2586,6 +2586,27 @@ end
    end
 end
 
+@testset "Generic.Poly.sqrt..." begin
+   for R in [ZZ, QQ]
+      S, x = PolynomialRing(R, "x")
+      for iter = 1:10
+         f = rand(S, 0:20, -20:20)
+
+         p = f^2
+
+         @test issquare(p)
+
+         q = sqrt(f^2)
+
+         @test q^2 == f^2
+
+         if f != 0
+            @test_throws ErrorException sqrt(f^2*x)
+         end
+      end
+   end
+end
+
 @testset "Generic.Poly.generic_eval..." begin
    R, x = PolynomialRing(ZZ, "x")
 

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2587,14 +2587,54 @@ end
 end
 
 @testset "Generic.Poly.square_root..." begin
-   for R in [ZZ, QQ]
+   # Exact ring
+   S, x = PolynomialRing(ZZ, "x")
+   for iter = 1:10
+      f = rand(S, 0:20, -20:20)
+
+      p = f^2
+
+      @test issquare(p)
+
+      q = sqrt(f^2)
+
+      @test q^2 == f^2
+
+      if f != 0
+         @test_throws ErrorException sqrt(f^2*x)
+      end
+   end
+
+   # Exact field
+   S, x = PolynomialRing(QQ, "x")
+   for iter = 1:10
+      f = rand(S, 0:20, -20:20)
+
+      p = f^2
+
+      @test issquare(p)
+
+      q = sqrt(f^2)
+
+      @test q^2 == f^2
+
+      if f != 0
+         @test_throws ErrorException sqrt(f^2*x)
+      end
+   end
+
+   # Characteristic p field
+   for p in [2, 7, 19, 65537, ZZ(2), ZZ(7), ZZ(19), ZZ(65537)]
+      R = ResidueField(ZZ, p)
+
       S, x = PolynomialRing(R, "x")
+      
       for iter = 1:10
-         f = rand(S, 0:20, -20:20)
-
-         p = f^2
-
-         @test issquare(p)
+         f = rand(S, 0:20, 0:Int(p))
+         
+         s = f^2
+         
+         @test issquare(s)
 
          q = sqrt(f^2)
 

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -254,3 +254,45 @@ end
 
    @test divexact(f, g) == T(7*x^2+25*x+26)
 end
+
+@testset "Generic.ResF.square_root..." begin
+   for p in [3, 47, 733, 13913, 168937, 3980299, 57586577]
+       R = Generic.ResidueField(ZZ, p)
+
+       for i = 1:10
+          a = rand(R, 0:p - 1)^2
+          b = sqrt(a)
+          @test b^2 == a
+
+          if !iszero(a)
+             z = rand(R, 1:p - 1)
+             while issquare(z)
+                z = rand(R, 1:p - 1)
+             end
+
+             @test !issquare(z*a)
+             @test_throws ErrorException sqrt(z*a)
+         end
+      end
+   end
+
+   for p in [ZZ(3), ZZ(53), ZZ(727), ZZ(8893), ZZ(191339), ZZ(2369093), ZZ(52694921)]
+       R = Generic.ResidueField(ZZ, p)                                                                                  
+       
+       for i = 1:10
+          a = rand(R, 0:Int(p - 1))^2
+          b = sqrt(a)
+          @test b^2 == a
+
+          if !iszero(a)
+             z = rand(R, 1:Int(p - 1))
+             while issquare(z)
+                z = rand(R, 1:Int(p - 1))
+             end
+
+             @test !issquare(z*a)
+             @test_throws ErrorException sqrt(z*a)
+         end
+      end
+   end
+end

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -76,8 +76,6 @@ end
 
      @test dim(N) == rank(matrix(QQ, [s[ix] for s in S, ix in 1:dim(M)]))
    end
-
-   println("PASS")
 end
 
 @testset "Generic.Submodule.unary_ops..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -151,6 +151,8 @@ end
 
       @test AbstractAlgebra.sqrt(f)^2 == f
       @test AbstractAlgebra.sqrt(g)^2 == g
+      @test issquare(f)
+      @test issquare(g)
    end
 end
 

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -70,6 +70,8 @@ end
       for n = 0:20
          @test r == 0 || a == powmod(r, n, modR)
          @test s == 0 || b == powmod(s, n, modS)
+         @test powmod(r, n, modR) == powmod(r, BigInt(n), modR)
+         @test powmod(s, n, modS) == powmod(s, BigInt(n), modS)
 
          a = mod(a*r, modR)
          b = mod(b*s, modS)

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -126,6 +126,8 @@ end
 
       @test AbstractAlgebra.sqrt(f)^2 == f
       @test AbstractAlgebra.sqrt(g)^2 == g
+      @test issquare(f)
+      @test issquare(g)
    end
 end
 


### PR DESCRIPTION
This main purpose of this PR is to provide:

* generic sparse multivariate square root [1] (new algorithm)
* generic univariate square root [1]

There are two functions: sqrt and issquare.

It also adds:

* issquare for integers and rationals
* issquare and sqrt for Z/pZ
* issquare and sqrt for fraction fields

Exact multivariate sqrt (check=false) is about twice as fast as checked mode (at 4000 terms in output). Exact univariate sqrt is only about 20% faster (at 10000 terms in output).

Note this does not provide sqrt for multivariates in Nemo, as this has to be implemented in Flint (which @tthsqe12 and I have agreed to do soon).

The PR makes no systematic attempt to implement the new sqrt interface being discussed.

[1] over an (exact) integral domain in which a sqrt is available