### PR TITLE
Improve test code for sqrt

### DIFF
--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -568,7 +568,8 @@ end
             @test q^2 == f^2
 
             if f != 0
-               @test_throws ErrorException sqrt(f^2*varlist[rand(1:num_vars)])
+               x = varlist[rand(1:num_vars)]
+               @test_throws ErrorException sqrt(f^2*(x^2 - x))
             end
          end
       end
@@ -599,7 +600,8 @@ end
             @test q^2 == f^2
 
             if f != 0
-               @test_throws ErrorException sqrt(f^2*varlist[rand(1:num_vars)])
+               x = varlist[rand(1:num_vars)]
+               @test_throws ErrorException sqrt(f^2*(x^2 - x))
             end
          end
       end


### PR DESCRIPTION
The original test code for MPoly sqrt was not testing very much in the non-square case.

This PR makes it work harder.

It also fixes a bug:

* Although the heap was being resized on demand, the list of exponents that could be used on the heap was of fixed size, causing an BoundsError in the worst case (the new test code hits this case).