### PR TITLE
follow the Random API for Poly and Integers via RandomExtensions.make

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-RandomExtensions = "0.4.1"
+RandomExtensions = "0.4.2"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,10 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+RandomExtensions = "0.4.1"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -100,6 +100,7 @@ import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh, bin,
              +, -, *, ==, ^, &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
 
 using Random: Random, AbstractRNG
+using RandomExtensions: RandomExtensions, make
 
 export elem_type, parent_type
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -99,8 +99,8 @@ import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh, bin,
              typed_hcat, typed_vcat, vcat, xor, zero, zeros,
              +, -, *, ==, ^, &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
 
-using Random: Random, AbstractRNG
-using RandomExtensions: RandomExtensions, make
+using Random: Random, AbstractRNG, SamplerTrivial
+using RandomExtensions: RandomExtensions, make, Make2
 
 export elem_type, parent_type
 

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -6,7 +6,9 @@ import LinearAlgebra: det, issymmetric, norm,
 import LinearAlgebra: lu, lu!, tr
 
 using Markdown, Random, InteractiveUtils
-using RandomExtensions: RandomExtensions, make
+
+using Random: SamplerTrivial, GLOBAL_RNG
+using RandomExtensions: RandomExtensions, make, Make, Make2, Make3, Make4
 
 import Base: Array, abs, asin, asinh, atan, atanh, axes, bin, checkbounds, cmp, conj,
              convert, copy, cos, cosh, dec, deepcopy, deepcopy_internal,

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -6,6 +6,7 @@ import LinearAlgebra: det, issymmetric, norm,
 import LinearAlgebra: lu, lu!, tr
 
 using Markdown, Random, InteractiveUtils
+using RandomExtensions: RandomExtensions, make
 
 import Base: Array, abs, asin, asinh, atan, atanh, axes, bin, checkbounds, cmp, conj,
              convert, copy, cos, cosh, dec, deepcopy, deepcopy_internal,

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -980,8 +980,7 @@ function RandomExtensions.make(S::AbstractAlgebra.FracField, vs...)
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{
-                 <:RandomExtensions.Make2{<:RingElement, <:AbstractAlgebra.FracField}})
+              sp::SamplerTrivial{<:Make2{<:RingElement, <:AbstractAlgebra.FracField}})
    S, v = sp[][1:end]
    R = base_ring(S)
    n = rand(rng, v)
@@ -995,7 +994,7 @@ end
 rand(rng::AbstractRNG, S::AbstractAlgebra.FracField, v...) =
    rand(rng, make(S, v...))
 
-rand(S::AbstractAlgebra.FracField, v...) = rand(Random.GLOBAL_RNG, S, v...)
+rand(S::AbstractAlgebra.FracField, v...) = rand(GLOBAL_RNG, S, v...)
 
 ###############################################################################
 #

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -246,7 +246,7 @@ RandomExtensions.maketype(S::LaurentPolyWrapRing, _, _) = elem_type(S)
 function RandomExtensions.make(S::LaurentPolyWrapRing, v1, vs...)
    R = S.polyring
    if length(vs) == 1 && vs[1] isa Integer && elem_type(R) == Random.gentype(v1)
-      RandomExtensions.Make(S, v1, vs[1]) # forward to default Make constructor
+     Make(S, v1, vs[1]) # forward to default Make constructor
    else
       degrees_range = v1
       m = minimum(degrees_range)
@@ -256,8 +256,7 @@ function RandomExtensions.make(S::LaurentPolyWrapRing, v1, vs...)
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:LaurentPolyWrap,
-                                                                 <:LaurentPolyWrapRing}})
+              sp::SamplerTrivial{<:Make3{<:LaurentPolyWrap, <:LaurentPolyWrapRing}})
    v, m = sp[][2:end]
    LaurentPolyWrap(rand(rng, v), m)
 end
@@ -266,7 +265,7 @@ rand(rng::AbstractRNG, S::LaurentPolyWrapRing, degrees_range, v...) =
    rand(rng, make(S, degrees_range, v...))
 
 rand(S::LaurentPolyWrapRing, degrees_range, v...) =
-   rand(Random.GLOBAL_RNG, S, degrees_range, v...)
+   rand(GLOBAL_RNG, S, degrees_range, v...)
 
 
 ###############################################################################

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1491,16 +1491,16 @@ RandomExtensions.maketype(S::LaurentSeriesRingOrField, ::UnitRange{Int}, _) = el
 function RandomExtensions.make(S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, val_range, vs[1]) # forward to default Make constructor
+     Make(S, val_range, vs[1]) # forward to default Make constructor
    else
       make(S, val_range, make(R, vs...))
    end
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
-                                                                 <:LaurentSeriesRingOrField,
-                                                                 UnitRange{Int}}})
+              sp::SamplerTrivial{<:Make3{<:RingElement,
+                                         <:LaurentSeriesRingOrField,
+                                         UnitRange{Int}}})
    S, val_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
@@ -1515,7 +1515,7 @@ rand(rng::AbstractRNG, S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, v
    rand(rng, make(S, val_range, v...))
 
 rand(S::LaurentSeriesRingOrField, val_range, v...) =
-   rand(Random.GLOBAL_RNG, S, val_range, v...)
+   rand(GLOBAL_RNG, S, val_range, v...)
 
 
 ###############################################################################

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1484,29 +1484,39 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::LaurentSeriesRing, val_range::UnitRange{Int}, v...)
+const LaurentSeriesRingOrField = Union{LaurentSeriesRing,LaurentSeriesField}
+
+RandomExtensions.maketype(S::LaurentSeriesRingOrField, ::UnitRange{Int}, _) = elem_type(S)
+
+function RandomExtensions.make(S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, val_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, val_range, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
+                                                                 <:LaurentSeriesRingOrField,
+                                                                 UnitRange{Int}}})
+   S, val_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:S.prec_max - 1
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return shift_left(f, rand(rng, val_range))
 end
 
-function rand(rng::AbstractRNG, S::LaurentSeriesField, val_range::UnitRange{Int}, v...)
-   R = base_ring(S)
-   f = S()
-   x = gen(S)
-   for i = 0:S.prec_max - 1
-      f += rand(rng, R, v...)*x^i
-   end
-   return shift_left(f, rand(rng, val_range))
-end
+rand(rng::AbstractRNG, S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, val_range, v...))
 
-function rand(S::Union{LaurentSeriesRing,LaurentSeriesField}, val_range, v...)
+rand(S::LaurentSeriesRingOrField, val_range, v...) =
    rand(Random.GLOBAL_RNG, S, val_range, v...)
-end
+
 
 ###############################################################################
 #

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4688,13 +4688,13 @@ function RandomExtensions.make(S::AbstractAlgebra.MPolyRing, term_range::UnitRan
                                exp_bound::UnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, term_range, exp_bound, vs[1])
+      Make(S, term_range, exp_bound, vs[1])
    else
       make(S, term_range, exp_bound, make(R, vs...))
    end
 end
 
-function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make4{
+function rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make4{
                  <:RingElement,<:AbstractAlgebra.MPolyRing,UnitRange{Int},UnitRange{Int}}})
    S, term_range, exp_bound, v = sp[][1:end]
    f = S()
@@ -4717,7 +4717,7 @@ function rand(rng::AbstractRNG, S::AbstractAlgebra.MPolyRing,
 end
 
 function rand(S::AbstractAlgebra.MPolyRing, term_range, exp_bound, v...)
-   rand(Random.GLOBAL_RNG, S, term_range, exp_bound, v...)
+   rand(GLOBAL_RNG, S, term_range, exp_bound, v...)
 end
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5070,16 +5070,33 @@ Base.map(f, a::MatrixElem) = map_entries(f, a)
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.MatSpace, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.MatSpace, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+   else
+      make(S, make(R, vs...))
+   end
+end
+
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:MatSpaceElem,
+                                                                 <:AbstractAlgebra.MatSpace}})
+   S, v = sp[][1:end]
    M = S()
    R = base_ring(S)
    for i = 1:nrows(M)
       for j = 1:ncols(M)
-         M[i, j] = rand(rng, R, v...)
+         M[i, j] = rand(rng, v)
       end
    end
    return M
 end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.MatSpace, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5075,7 +5075,7 @@ RandomExtensions.maketype(S::AbstractAlgebra.MatSpace, _) = elem_type(S)
 function RandomExtensions.make(S::AbstractAlgebra.MatSpace, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+      Make(S, vs[1]) # forward to default Make constructor
    else
       make(S, make(R, vs...))
    end
@@ -5083,8 +5083,8 @@ end
 
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:MatSpaceElem,
-                                                                 <:AbstractAlgebra.MatSpace}})
+              sp::SamplerTrivial{<:Make2{<:MatSpaceElem,
+                                         <:AbstractAlgebra.MatSpace}})
    S, v = sp[][1:end]
    M = S()
    R = base_ring(S)

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -350,15 +350,15 @@ RandomExtensions.maketype(S::AbstractAlgebra.MatAlgebra, _) = elem_type(S)
 function RandomExtensions.make(S::AbstractAlgebra.MatAlgebra, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+      Make(S, vs[1]) # forward to default Make constructor
    else
       make(S, make(R, vs...))
    end
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:AbstractAlgebra.MatAlgElem,
-                                                                 <:AbstractAlgebra.MatAlgebra}})
+              sp::SamplerTrivial{<:Make2{<:AbstractAlgebra.MatAlgElem,
+                                         <:AbstractAlgebra.MatAlgebra}})
    S, v = sp[][1:end]
    M = S()
    n = degree(M)

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -344,17 +344,34 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...)
+
+RandomExtensions.maketype(S::AbstractAlgebra.MatAlgebra, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.MatAlgebra, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+   else
+      make(S, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:AbstractAlgebra.MatAlgElem,
+                                                                 <:AbstractAlgebra.MatAlgebra}})
+   S, v = sp[][1:end]
    M = S()
    n = degree(M)
    R = base_ring(S)
    for i = 1:n
       for j = 1:n
-         M[i, j] = rand(rng, R, v...)
+         M[i, j] = rand(rng, v)
       end
    end
    return M
 end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.MatAlgebra, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/Module.jl
+++ b/src/generic/Module.jl
@@ -342,14 +342,14 @@ RandomExtensions.maketype(M::AbstractAlgebra.FPModule, _) = elem_type(M)
 function RandomExtensions.make(M::AbstractAlgebra.FPModule, vs...)
    R = base_ring(M)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(M, vs[1]) # forward to default Make constructor
+      Make(M, vs[1]) # forward to default Make constructor
    else
       make(M, make(R, vs...))
    end
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{
+              sp::SamplerTrivial{<:Make2{
                  <:AbstractAlgebra.FPModuleElem, <:AbstractAlgebra.FPModule}})
    M, vals = sp[][1:end]
    M(rand(rng, vals, ngens(M)))

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -699,16 +699,16 @@ RandomExtensions.maketype(S::AbstractAlgebra.NCPolyRing, dr::UnitRange{Int}, _) 
 function RandomExtensions.make(S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+      Make(S, deg_range, vs[1]) # forward to default Make constructor
    else
       make(S, deg_range, make(R, vs...))
    end
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:AbstractAlgebra.NCPolyElem,
-                                                                 <:AbstractAlgebra.NCPolyRing,
-                                                                 UnitRange{Int}}})
+              sp::SamplerTrivial{<:Make3{<:AbstractAlgebra.NCPolyElem,
+                                         <:AbstractAlgebra.NCPolyRing,
+                                         UnitRange{Int}}})
    S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -694,19 +694,35 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.NCPolyRing, dr::UnitRange{Int}, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:AbstractAlgebra.NCPolyElem,
+                                                                 <:AbstractAlgebra.NCPolyRing,
+                                                                 UnitRange{Int}}})
+   S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:rand(rng, deg_range)
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return f
 end
 
-function rand(S::AbstractAlgebra.NCPolyRing, deg_range, v...)
-   rand(Random.GLOBAL_RNG, S, deg_range, v...)
-end
+rand(rng::AbstractRNG, S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, deg_range, v...))
+
+rand(S::AbstractAlgebra.NCPolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v...)
 
 ###############################################################################
 #

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2748,14 +2748,14 @@ RandomExtensions.maketype(S::AbstractAlgebra.PolyRing, dr::UnitRange{Int}, _) = 
 function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+      Make(S, deg_range, vs[1]) # forward to default Make constructor
    else
       make(S, deg_range, make(R, vs...))
    end
 end
 
 # define rand for make(S, deg_range, v)
-function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
+function rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
    S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2745,6 +2745,15 @@ end
 
 RandomExtensions.maketype(S::AbstractAlgebra.PolyRing, dr::UnitRange{Int}, _) = elem_type(S)
 
+function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
 # define rand for make(S, deg_range, v)
 function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
    S, deg_range, v = sp[][1:end]
@@ -2755,15 +2764,6 @@ function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Mak
       f += rand(rng, v)*x^i
    end
    return f
-end
-
-function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
-   R = base_ring(S)
-   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
-   else
-      make(S, deg_range, make(R, vs...))
-   end
 end
 
 rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...) =

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1281,7 +1281,7 @@ function pseudodivrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyEle
    s = b^k
    return q*s, f*s
 end
-   
+
 ################################################################################
 #
 #   Remove and valuation
@@ -2743,15 +2743,31 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.PolyRing, dr::UnitRange{Int}, _) = elem_type(S)
+
+# define rand for make(S, deg_range, v)
+function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
+   S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:rand(rng, deg_range)
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return f
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, deg_range, v...))
 
 rand(S::AbstractAlgebra.PolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v...)
 

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -609,9 +609,9 @@ RandomExtensions.make(S::PuiseuxSeriesRingOrField, val_range::UnitRange{Int},
      make(S, scale_range, make(laurent_ring(S), val_range, vs...))
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
-                                                                 <:PuiseuxSeriesRingOrField,
-                                                                 UnitRange{Int}}})
+              sp::SamplerTrivial{<:Make3{<:RingElement,
+                                         <:PuiseuxSeriesRingOrField,
+                                         UnitRange{Int}}})
    S, scale_range, v = sp[][1:end]
    (first(scale_range) <= 0 || last(scale_range) <= 0) && error("Scale must be positive")
    return S(rand(rng, v), rand(rng, scale_range))

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -600,19 +600,30 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::PuiseuxSeriesRing, val_range::UnitRange{Int}, scale_range::UnitRange{Int}, v...)
+const PuiseuxSeriesRingOrField = Union{PuiseuxSeriesRing,PuiseuxSeriesField}
+
+RandomExtensions.maketype(S::PuiseuxSeriesRingOrField, ::UnitRange{Int}, _) = elem_type(S)
+
+RandomExtensions.make(S::PuiseuxSeriesRingOrField, val_range::UnitRange{Int},
+                      scale_range::UnitRange{Int}, vs...) =
+     make(S, scale_range, make(laurent_ring(S), val_range, vs...))
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
+                                                                 <:PuiseuxSeriesRingOrField,
+                                                                 UnitRange{Int}}})
+   S, scale_range, v = sp[][1:end]
    (first(scale_range) <= 0 || last(scale_range) <= 0) && error("Scale must be positive")
-   return S(rand(rng, laurent_ring(S), val_range, v...), rand(rng, scale_range))
+   return S(rand(rng, v), rand(rng, scale_range))
 end
 
-function rand(rng::AbstractRNG, S::PuiseuxSeriesField, val_range::UnitRange{Int}, scale_range::UnitRange{Int}, v...)
-   (first(scale_range) <= 0 || last(scale_range) <= 0) && error("Scale must be positive")
-   return S(rand(rng, laurent_ring(S), val_range, v...), rand(rng, scale_range))
-end
+rand(rng::AbstractRNG, S::PuiseuxSeriesRingOrField, val_range::UnitRange{Int},
+     scale_range::UnitRange{Int}, v...) =
+        rand(rng, make(S, val_range, scale_range, v...))
 
-function rand(S::Union{PuiseuxSeriesRing,PuiseuxSeriesField}, val_range, scale_range, v...)
+rand(S::PuiseuxSeriesRingOrField, val_range, scale_range, v...) =
    rand(Random.GLOBAL_RNG, S, val_range, scale_range, v...)
-end
+
 
 ###############################################################################
 #

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1236,16 +1236,14 @@ RandomExtensions.maketype(S::SeriesRing, ::UnitRange{Int}, _) = elem_type(S)
 function RandomExtensions.make(S::SeriesRing, val_range::UnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, val_range, vs[1]) # forward to default Make constructor
+      Make(S, val_range, vs[1]) # forward to default Make constructor
    else
       make(S, val_range, make(R, vs...))
    end
 end
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
-                                                                 <:SeriesRing,
-                                                                 UnitRange{Int}}})
+              sp::SamplerTrivial{<:Make3{<:RingElement, <:SeriesRing, UnitRange{Int}}})
    S, val_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -504,10 +504,28 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.ResRing{T}, v...) where {T <: RingElement}
-   R = base_ring(S)
-   return S(rand(rng, R, v...))
+RandomExtensions.maketype(R::AbstractAlgebra.ResRing, _) = elem_type(R)
+
+# define rand(make(S, v))
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResElem{T},
+                                          <:AbstractAlgebra.ResRing{T}}}
+              ) where {T}
+   S, v = sp[][1:end]
+   S(rand(rng, v))
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.ResRing, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1])
+   else
+      make(S, make(base_ring(S), vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.ResRing, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.ResRing, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -508,9 +508,8 @@ RandomExtensions.maketype(R::AbstractAlgebra.ResRing, _) = elem_type(R)
 
 # define rand(make(S, v))
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{
-                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResElem{T},
-                                          <:AbstractAlgebra.ResRing{T}}}
+              sp::SamplerTrivial{<:Make2{<:AbstractAlgebra.ResElem{T},
+                                         <:AbstractAlgebra.ResRing{T}}}
               ) where {T}
    S, v = sp[][1:end]
    S(rand(rng, v))
@@ -519,7 +518,7 @@ end
 function RandomExtensions.make(S::AbstractAlgebra.ResRing, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1])
+      Make(S, vs[1])
    else
       make(S, make(base_ring(S), vs...))
    end

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -563,10 +563,27 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.ResField{T}, v...) where {T <: RingElement}
-   R = base_ring(S)
-   return S(rand(rng, R, v...))
+RandomExtensions.maketype(R::AbstractAlgebra.ResField, _) = elem_type(R)
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResFieldElem{T},
+                                          <:AbstractAlgebra.ResField{T}}}
+              ) where {T}
+   S, v = sp[][1:end]
+   S(rand(rng, v))
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.ResField, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1])
+   else
+      make(S, make(base_ring(S), vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.ResField, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.ResField, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -566,9 +566,8 @@ end
 RandomExtensions.maketype(R::AbstractAlgebra.ResField, _) = elem_type(R)
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{
-                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResFieldElem{T},
-                                          <:AbstractAlgebra.ResField{T}}}
+              sp::SamplerTrivial{<:Make2{<:AbstractAlgebra.ResFieldElem{T},
+                                         <:AbstractAlgebra.ResField{T}}}
               ) where {T}
    S, v = sp[][1:end]
    S(rand(rng, v))
@@ -577,7 +576,7 @@ end
 function RandomExtensions.make(S::AbstractAlgebra.ResField, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1])
+      Make(S, vs[1])
    else
       make(S, make(base_ring(S), vs...))
    end

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -185,13 +185,17 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Floats, n::UnitRange{<:AbstractFloat})
-   return R(n.start + rand(rng, Float64)*(n.stop - n.start))
+RandomExtensions.maketype(R::Floats{T}, _) where {T} = T
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{
+                 T, Floats{T}, <:UnitRange{<:Union{AbstractFloat, Int}}}}) where {T}
+   R, n = sp[][1:end]
+   R(n.start + rand(rng, Float64)*(n.stop - n.start))
 end
 
-function rand(rng::AbstractRNG, R::Floats, n::UnitRange{Int})
-   return R(n.start + rand(rng, Float64)*(n.stop - n.start))
-end
+
+rand(rng::AbstractRNG, R::Floats, n::UnitRange) = rand(rng, make(R, n))
 
 rand(R::Floats, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -188,8 +188,9 @@ end
 RandomExtensions.maketype(R::Floats{T}, _) where {T} = T
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{
-                 T, Floats{T}, <:UnitRange{<:Union{AbstractFloat, Int}}}}) where {T}
+              sp::SamplerTrivial{<:Make2{T, Floats{T},
+                                         <:UnitRange{<:Union{AbstractFloat, Int}}}}
+              ) where {T}
    R, n = sp[][1:end]
    R(n.start + rand(rng, Float64)*(n.stop - n.start))
 end

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -355,7 +355,7 @@ RandomExtensions.maketype(R::AbstractAlgebra.Integers{T}, _) where {T} = T
 
 # define rand(make(ZZ, n:m))
 rand(rng::AbstractRNG,
-     sp::Random.SamplerTrivial{<:RandomExtensions.Make2{T, Integers{T}, UnitRange{Int}}}
+     sp::SamplerTrivial{<:Make2{T, Integers{T}, UnitRange{Int}}}
      ) where {T} =
         sp[][1](rand(rng, sp[][2]))
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -351,9 +351,16 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Integers, n::UnitRange{Int})
-   return R(rand(rng, n))
-end
+RandomExtensions.maketype(R::AbstractAlgebra.Integers{T}, _) where {T} = T
+
+# define rand(make(ZZ, n:m))
+rand(rng::AbstractRNG,
+     sp::Random.SamplerTrivial{<:RandomExtensions.Make2{T, Integers{T}, UnitRange{Int}}}
+     ) where {T} =
+        sp[][1](rand(rng, sp[][2]))
+
+
+rand(rng::AbstractRNG, R::Integers, n) = R(rand(rng, n))
 
 rand(R::Integers, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -302,8 +302,7 @@ end
 RandomExtensions.maketype(R::Rationals{T}, _) where {T} = Rational{T}
 
 function rand(rng::AbstractRNG,
-              sp::Random.SamplerTrivial{
-                 <:RandomExtensions.Make2{Rational{T}, Rationals{T}, UnitRange{Int}}}
+              sp::SamplerTrivial{<:Make2{Rational{T}, Rationals{T}, UnitRange{Int}}}
               ) where {T}
    R, n = sp[][1:end]
    d = T(0)

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -299,7 +299,13 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Rationals{T}, n::UnitRange{Int}) where T <: Integer
+RandomExtensions.maketype(R::Rationals{T}, _) where {T} = Rational{T}
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{Rational{T}, Rationals{T}, UnitRange{Int}}}
+              ) where {T}
+   R, n = sp[][1:end]
    d = T(0)
    while d == 0
       d = T(rand(rng, n))
@@ -307,6 +313,9 @@ function rand(rng::AbstractRNG, R::Rationals{T}, n::UnitRange{Int}) where T <: I
    n = T(rand(rng, n))
    return R(n, d)
 end
+
+
+rand(rng::AbstractRNG, R::Rationals, n) = rand(rng, make(R, n))
 
 rand(R::Rationals, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -52,10 +52,12 @@ end
 @testset "Generic.Frac.rand..." begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
-   f = rand(K, 0:3, -3:3)
-   @test f isa Generic.Frac
-   f = rand(rng, K, 0:3, -3:3)
-   @test f isa Generic.Frac
+   m = make(K, 0:3, -3:3)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(K, 0:3, -3:3),
+                rand(rng, K, 0:3, -3:3)]
+      @test f isa Generic.Frac
+   end
 end
 
 @testset "Generic.Frac.manipulation..." begin

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -375,18 +375,16 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
    @testset "rand" begin
       L, y = LaurentPolynomialRing(ZZ, "y")
 
-      f = rand(L, -5:5, -10:10)
-      @test f isa LaurentPolyElem{BigInt}
-      @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
-      for i = -5:5
-         @test coeff(f, i) ∈ -10:10
-      end
+      m = make(L, -5:5, -10:10)
+      for f in (rand(m), rand(rng, m),
+                rand(L, -5:5, -10:10),
+                rand(rng, L, -5:5, -10:10))
 
-      f = rand(rng, L, -5:5, -10:10)
-      @test f isa LaurentPolyElem{BigInt}
-      @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
-      for i = -5:5
-         @test coeff(f, i) ∈ -10:10
+         @test f isa LaurentPolyElem{BigInt}
+         @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
+         for i = -5:5
+            @test coeff(f, i) ∈ -10:10
+         end
       end
    end
 

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -106,11 +106,25 @@ end
    f = rand(rng, R, -12:12, -10:10)
    @test f isa Generic.LaurentSeriesRingElem
 
+   for m in (make(R, -12:12, -10:10),
+            make(R, -12:12, make(ZZ, -10:10)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.LaurentSeriesRingElem{BigInt}
+      end
+   end
+
    R, x = LaurentSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, -1:1)
    @test f isa Generic.LaurentSeriesFieldElem
    f = rand(rng, R, -12:12, -1:1)
    @test f isa Generic.LaurentSeriesFieldElem
+
+   for m in (make(R, -12:12, -1:1),
+             make(R, -12:12, make(RealField, -1:1)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.LaurentSeriesFieldElem{BigFloat}
+      end
+   end
 end
 
 @testset "Generic.LaurentSeries.manipulation..." begin

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -108,10 +108,12 @@ end
    @test ord in [:lex, :deglex, :degrevlex]
 
    S, varlist = PolynomialRing(R, var_names, ordering = ord)
-   f = rand(S, 0:5, 0:100, 0:0, -100:100)
-   @test f isa Generic.MPoly
-   f = rand(rng, S, 0:5, 0:100, 0:0, -100:100)
-   @test f isa Generic.MPoly
+   m = make(S, 0:5, 0:100, 0:0, -100:100)
+   for f in (rand(m), rand(rng, m),
+             rand(S, 0:5, 0:100, 0:0, -100:100),
+             rand(rng, S, 0:5, 0:100, 0:0, -100:100))
+      @test f isa Generic.MPoly
+   end
 end
 
 @testset "Generic.MPoly.manipulation..." begin

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -519,7 +519,7 @@ end
    end
 
    M0 = MatrixAlgebra(R, 0)
-   m0 = rand(M0, 0:9, -9, 9)
+   m0 = rand(M0, 0:9, -9:9)
    @test length(m0) == 0
    @test isempty(m0)
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -2902,3 +2902,19 @@ end
    @test Matrix(F) == B
    @test eltype(B) == F2Elem
 end
+
+@testset "Generic.Mat.rand" begin
+   M = MatrixSpace(ZZ, 2, 3)
+   m = make(M, 1:9)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M, 1:9), rand(rng, M, 1:9)]
+      @test A isa elem_type(M)
+   end
+
+   M = MatrixSpace(GF(7), 3, 2)
+   m = make(M)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M), rand(rng, M)]
+      @test A isa elem_type(M)
+   end
+end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1250,3 +1250,19 @@ end
       end
    end
 end
+
+@testset "Generic.MatAlg.rand" begin
+   M = MatrixAlgebra(ZZ, 3)
+   m = make(M, 1:9)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M, 1:9), rand(rng, M, 1:9)]
+      @test A isa elem_type(M)
+   end
+
+   M = MatrixAlgebra(GF(7), 2)
+   m = make(M)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M), rand(rng, M)]
+      @test A isa elem_type(M)
+   end
+end

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -15,10 +15,11 @@ end
 
 @testset "Generic.Module.rand..." begin
    F = FreeModule(ZZ, 3)
-   f = rand(F, 1:9)
-   @test f isa Generic.FreeModuleElem
-   f = rand(rng, F, 1:9)
-   @test f isa Generic.FreeModuleElem
+   m = make(F, 1:9)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(F, 1:9), rand(rng, F, 1:9)]
+      @test f isa Generic.FreeModuleElem
+   end
 end
 
 @testset "Generic.Module.manipulation..." begin

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -103,10 +103,12 @@ end
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
-   f = rand(S, 0:10, -10:10)
-   @test f isa Generic.NCPoly
-   f = rand(rng, S, 0:10, -10:10)
-   @test f isa Generic.NCPoly
+   m = make(S, 0:10, -10:10)
+   for f in (rand(m), rand(rng, m),
+             rand(S, 0:10, -10:10),
+             rand(rng, S, 0:10, -10:10))
+      @test f isa Generic.NCPoly
+   end
 end
 
 @testset "Generic.NCPoly.binary_ops..." begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -86,11 +86,41 @@
 end
 
 @testset "Generic.Poly.rand..." begin
+   # TODO: test more than just the result type
    R, x = PolynomialRing(ZZ, "x")
    f = rand(R, 0:10, -10:10)
    @test f isa Generic.Poly
    f = rand(rng, R, 0:10, -10:10)
    @test f isa Generic.Poly
+
+   # make API
+   for m in (make(R, 0:10, make(ZZ, -10:10)),
+             make(R, 0:10, -10:10)) # convenience only
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.Poly
+      end
+      @test rand(m, 3) isa Vector{Generic.Poly{BigInt}}
+      @test size(rand(rng, m, 2, 3)) == (2, 3)
+   end
+
+   S, y = PolynomialRing(R, "y")
+   for m in (make(S, 0:5, make(R, 0:10, make(ZZ, -10:10))),
+             make(S, 0:5, make(R, 0:10, -10:10)),
+             make(S, 0:5, 0:10, -10:10))
+
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.Poly{Generic.Poly{BigInt}}
+      end
+      a = rand(m, 3)
+      @test length(a) == 3
+      @test a isa Vector{Generic.Poly{Generic.Poly{BigInt}}}
+   end
+
+   T, z = PolynomialRing(GF(7), "z")
+   m = make(T, 0:4)
+   for f in (rand(m), rand(rng, m))
+      @test f isa Generic.Poly{AbstractAlgebra.GFElem{Int64}}
+   end
 end
 
 @testset "Generic.Poly.manipulation..." begin

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -98,11 +98,25 @@ end
    f = rand(rng, R, -12:12, 1:6, -10:10)
    @test f isa Generic.PuiseuxSeriesRingElem
 
+   for m in (make(R, -12:12, 1:6, -10:10),
+             make(R, -12:12, 1:6, make(ZZ, -10:10)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.PuiseuxSeriesRingElem{BigInt}
+      end
+   end
+
    R, x = PuiseuxSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, 1:6, -1:1)
    @test f isa Generic.PuiseuxSeriesFieldElem
    f = rand(rng, R, -12:12, 1:6, -1:1)
    @test f isa Generic.PuiseuxSeriesFieldElem
+
+   for m in (make(R, -12:12, 1:6, -1:1),
+             make(R, -12:12, 1:6, make(RealField, -1:1)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.PuiseuxSeriesFieldElem{BigFloat}
+      end
+   end
 end
 
 @testset "Generic.PuiseuxSeries.manipulation..." begin

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -84,10 +84,12 @@ end
 
 @testset "Generic.RelSeries.rand..." begin
    R, x = PowerSeriesRing(ZZ, 10, "x")
-   f = rand(R, 0:12, -10:10)
-   @test f isa Generic.RelSeries
-   f = rand(rng, R, 0:12, -10:10)
-   @test f isa Generic.RelSeries
+   m = make(R, 0:12, -10:10)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(R, 0:12, -10:10),
+                rand(rng, R, 0:12, -10:10)]
+      @test f isa Generic.RelSeries
+   end
 end
 
 @testset "Generic.RelSeries.manipulation..." begin

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -57,6 +57,17 @@ end
    @test f isa Generic.Res
    f = rand(rng, R, 1:9)
    @test f isa Generic.Res
+   m = make(R, 1:9)
+   for f = (rand(m), rand(rng, m))
+      @test f isa Generic.Res
+      @test 1 <= f.data <= 9
+   end
+
+   # make with 3 arguments
+   P, x = PolynomialRing(RealField, "x")
+   R = Generic.ResidueRing(P, x^3)
+   m = make(R, 1:9, -3:3)
+   @test rand(m) isa Generic.Res{AbstractAlgebra.Generic.Poly{BigFloat}}
 end
 
 @testset "Generic.Res.manipulation..." begin

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -55,6 +55,12 @@ end
    @test f isa Generic.ResF
    f = rand(rng, R, 1:9)
    @test f isa Generic.ResF
+
+   m = make(R, 1:9)
+   for f in (rand(m), rand(rng, m))
+      @test f isa Generic.ResF
+      @test 1 <= f.data <= 9
+   end
 end
 
 @testset "Generic.ResF.manipulation..." begin

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -46,6 +46,15 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, UnitRange(big(1.0), big(9.0)))
    @test f isa elem_type(R)
+
+   # make
+   for r in (1:9, UnitRange(1.0, 9.0), UnitRange(big(1.0), big(9.0)))
+      m = make(R, r)
+      @test rand(m) isa elem_type(R)
+      @test 1.0 <= rand(m) <= 9.0
+      @test rand(rng, m) isa elem_type(R)
+      @test rand(m, 2, 3) isa Matrix{elem_type(R)}
+   end
 end
 
 @testset "Julia.Floats.manipulation..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -52,6 +52,9 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, 0:22)
    @test f isa elem_type(R)
+   f = rand(make(R, 0:22))
+   @test f isa elem_type(R)
+   @test f in 0:22
 end
 
 @testset "Julia.Integers.modular_arithmetic..." begin

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -41,6 +41,14 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, 1:9)
    @test f isa elem_type(R)
+
+   # make
+   m = make(R, 1:9)
+   for f = (rand(m), rand(rng, m))
+      @test f isa elem_type(R)
+      @test 1 <= numerator(f) <= 9
+      @test 1 <= denominator(f) <= 9
+   end
 end
 
 @testset "Julia.Rationals.manipulation..." begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using AbstractAlgebra
 
 using SparseArrays, LinearAlgebra
 using AbstractAlgebra: mul! # disambiguate from LinearAlgebra.mul!
+using RandomExtensions: make
 
 if VERSION < v"0.7.0-DEV.2004"
    using Base.Test


### PR DESCRIPTION
As discussed in the Jitsi meeting last Friday. I made an implementation instead of just proposing an API because it's very difficult to know whether the idea of an API will work in practice, and the amount of implementation work was reasonable here.

In this case, "Following the Random API" means that one object is enough to encode all the necessary information for the various `rand` methods to know how to draw random objects (numbers, polynomials...) together with an RNG.

For example `1:3` or `Bool` are such objects (they mean draw numbers from the `{1, 2, 3}` set or from the `{false, true}` set respectively).
One counter-example is how we draw integers in AA: our API is e.g. `rand(ZZ, 1:3)` : two objects (`ZZ` and `1:3`) are necessary in order to convey to `rand` all the information.

One advantage of following the "Random API" is composability. For example, you can create arrays (`rand(1:3, 2, 3)`) or randomize already existing arrays (`rand!([0, 0, 0], 1:3)`).

The obvious solution when more than one object are necessary is to pack them into one `struct` (not into a `Tuple`, as `rand(::Tuple)` already has a meaning). This is for example what distributions from the `Distributions` package do, e.g. with `Normal(0.0, 1.0)`.
But it can be very tedious to define custom `struct`s for all the various `rand` methods you want to define (both for the implementer, and for the user who has to remember all the ad-hoc names). For example, we would have `rand(RandIntegers(ZZ, 1:3))` where `RandIntegers` is such a custom struct with two fields.

One solution to this problem is to use a custom generic `struct` which behaves like `Tuple`, call it `Make`: `Make(a, b, c)` contains as its unique field the tuple `(a, b, c)`, and represents a "distribution" (in an extended meaning), containing all the information needed by `rand`. Then, the implementer doesn't have to define new `struct`s for each `rand` method, and the user just has to remember one name: `Make`. For example we would have:
```julia
julia>  rand(Make(ZZ, 1:3), 3)
3-element Array{BigInt,1}:
 1
 3
 2

julia> R, x = PolynomialRing(ZZ, "x");

julia> m = Make(R, 0:5, Make(ZZ, -10:10)); 

julia> rand(RandomDevice(), m) # equivalent to our current `rand(RandomDevice(), R, 0:5, -10:10)`
x^4 + 5*x^3 + 7*x^2 - 3*x + 9

julia>  rand(m, 2)
2-element Array{AbstractAlgebra.Generic.Poly{BigInt},1}:
 -9*x + 2
 -3*x^3 - 10*x^2 - 6*x - 8

julia> rand!(ans,  m)
2-element Array{AbstractAlgebra.Generic.Poly{BigInt},1}:
 9*x^5 - 6*x^4 + 5*x^3 - 6*x^2 - x + 10
 2*x^5 - 9*x^3 - x^2 + 8*x + 7
```
Now, when elements of a tuple `t` are types, then `t`'s type doesn't know which type it contains (e.g. `typeof(1, Bool) == Tuple{Int,DataType}`), so this leads to type instabilities. Working around this makes the implementation of `Make` slightly less straight-forward; one such implementation is in the [`RandomExtensions.jl`](https://github.com/rfourquet/RandomExtensions.jl) package, which exports the `make` function (instead of `Make`) as the interface for creating "distributions" (such that the example above works with this PR just by replacing `Make` by `make`).

As seen in the above example, recursivity is handled via nested `Make/make` calls. To mirror the current "flattened" API (e.g. `rand(R, 0:5, -10:10)`), this PR also defines for convenience a flattened `make` API (e.g. `make(R, 0:5, -10:10)`).

`RandomExtensions` also defines an experimental convenience API using pairs, such that `rand(a => b)` is interpreted as `rand(make(a, b))` and `rand(a => (b, c...))` is interpreted as `rand(make(a, b, c...))`. So you can do
```julia
julia> rand(ZZ => 1:3, 3)
3-element Array{BigInt,1}:
 3
 3
 2

julia> rand(R => (0:5, -10:10))
-3*x^2 - 7*x + 7

julia> S, y = PolynomialRing(R, "y");

julia> rand(make(S, 0:5, 5:10, -10:10))
-8*x^8 - x^7 - 8*x^6 + 8*x^5 - 4*x^4 + 4*x^3 + 9*x^2 + 6*x - 8

julia>  rand(S => (0:5, 5:10, -10:10)) # equivalent to rand(S => (0:5, R => (5:10, ZZ => -10:10)))
(3*x^9 - 10*x^8 + 5*x^7 + 6*x^6 - 9*x^5 + 7*x^4 + 2*x^3 + 10*x^2 - 9*x - 9)*y + 7*x^7 - 2*x^6 - 7*x^5 + 6*x^4 + 3*x^2 + 9*x + 4
```

I have thought a lot about this problem in general (independently of AA/Oscar), and didn't find better than the `make` framework (started about 3 years ago) from `RandomExtensions`, which I consider to be quite solid at this point (allowing a non-type object as the first argument of `make` is a new feature though, and was not yet extensively tested).

cc @fieker @wbhart