### PR TITLE
Fix add! and addeq! for GF

### DIFF
--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -324,6 +324,10 @@ function mul!(z::GFElem{BigInt}, x::GFElem{BigInt}, y::GFElem{BigInt})
 end
 
 function addeq!(z::GFElem{T}, x::GFElem{T}) where T <: Integer
+   return z + x
+end
+
+function addeq!(z::GFElem{BigInt}, x::GFElem{BigInt})
    R = parent(x)
    p = R.p::T
    d = addeq!(z.d, x.d)
@@ -335,6 +339,10 @@ function addeq!(z::GFElem{T}, x::GFElem{T}) where T <: Integer
 end
 
 function add!(z::GFElem{T}, x::GFElem{T}, y::GFElem{T}) where T <: Integer
+   return x + y
+end
+
+function add!(z::GFElem{BigInt}, x::GFElem{BigInt}, y::GFElem{BigInt})
    R = parent(x)
    p = R.p::T
    d = add!(z.d, x.d, y.d)

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -128,6 +128,18 @@ end
       @test b1*S(1) == b1
       @test S(1)*b1 == b1
    end
+
+   if Int == Int32
+      F = GF(2147483659)
+      a = F(2147483659 - 1)
+      @test addeq!(a, a) == F(2147483657)
+      @test add!(a, a, a) == F(2147483657)
+   else
+      F = GF(4611686018427388039)
+      a = F(4611686018427388039 - 1)
+      @test addeq!(a, a) == F(4611686018427388037)
+      @test add!(a, a, a) == F(4611686018427388037)
+   end
 end
 
 @testset "Julia.GFElem.adhoc_binary..." begin


### PR DESCRIPTION
We cannot call add! or addeq! on the underlying data, since this will
overflow for Int. So use the same as in the mul! and fall back to +.