### PR TITLE
[WIP] use RandomTest to define random distributions for tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-RandomExtensions = "0.4.1"
+RandomExtensions = "0.4.2"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
+RandomTest = "b75900cc-ad60-4ba3-b7dc-d2abb275d94a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,10 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+RandomExtensions = "0.4.1"
 julia = "1"

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -101,6 +101,7 @@ import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh, bin,
 
 using Random: Random, AbstractRNG
 using RandomExtensions: RandomExtensions, make
+using RandomTest
 
 export elem_type, parent_type
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -100,6 +100,7 @@ import Base: Array, abs, acos, acosh, adjoint, asin, asinh, atan, atanh, bin,
              +, -, *, ==, ^, &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
 
 using Random: Random, AbstractRNG
+using RandomExtensions: RandomExtensions, make
 
 export elem_type, parent_type
 

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -7,6 +7,7 @@ import LinearAlgebra: lu, lu!, tr
 
 using Markdown, Random, InteractiveUtils
 using RandomExtensions: RandomExtensions, make
+using RandomTest: RandomTest, Sized, Nat, test
 
 import Base: Array, abs, asin, asinh, atan, atanh, axes, bin, checkbounds, cmp, conj,
              convert, copy, cos, cosh, dec, deepcopy, deepcopy_internal,

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -6,6 +6,7 @@ import LinearAlgebra: det, issymmetric, norm,
 import LinearAlgebra: lu, lu!, tr
 
 using Markdown, Random, InteractiveUtils
+using RandomExtensions: RandomExtensions, make
 
 import Base: Array, abs, asin, asinh, atan, atanh, axes, bin, checkbounds, cmp, conj,
              convert, copy, cos, cosh, dec, deepcopy, deepcopy_internal,

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1484,29 +1484,39 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::LaurentSeriesRing, val_range::UnitRange{Int}, v...)
+const LaurentSeriesRingOrField = Union{LaurentSeriesRing,LaurentSeriesField}
+
+RandomExtensions.maketype(S::LaurentSeriesRingOrField, ::UnitRange{Int}, _) = elem_type(S)
+
+function RandomExtensions.make(S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, val_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, val_range, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
+                                                                 <:LaurentSeriesRingOrField,
+                                                                 UnitRange{Int}}})
+   S, val_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:S.prec_max - 1
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return shift_left(f, rand(rng, val_range))
 end
 
-function rand(rng::AbstractRNG, S::LaurentSeriesField, val_range::UnitRange{Int}, v...)
-   R = base_ring(S)
-   f = S()
-   x = gen(S)
-   for i = 0:S.prec_max - 1
-      f += rand(rng, R, v...)*x^i
-   end
-   return shift_left(f, rand(rng, val_range))
-end
+rand(rng::AbstractRNG, S::LaurentSeriesRingOrField, val_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, val_range, v...))
 
-function rand(S::Union{LaurentSeriesRing,LaurentSeriesField}, val_range, v...)
+rand(S::LaurentSeriesRingOrField, val_range, v...) =
    rand(Random.GLOBAL_RNG, S, val_range, v...)
-end
+
 
 ###############################################################################
 #

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5070,16 +5070,33 @@ Base.map(f, a::MatrixElem) = map_entries(f, a)
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.MatSpace, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.MatSpace, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+   else
+      make(S, make(R, vs...))
+   end
+end
+
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:MatSpaceElem,
+                                                                 <:AbstractAlgebra.MatSpace}})
+   S, v = sp[][1:end]
    M = S()
    R = base_ring(S)
    for i = 1:nrows(M)
       for j = 1:ncols(M)
-         M[i, j] = rand(rng, R, v...)
+         M[i, j] = rand(rng, v)
       end
    end
    return M
 end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.MatSpace, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -344,17 +344,34 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...)
+
+RandomExtensions.maketype(S::AbstractAlgebra.MatAlgebra, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.MatAlgebra, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+   else
+      make(S, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{<:AbstractAlgebra.MatAlgElem,
+                                                                 <:AbstractAlgebra.MatAlgebra}})
+   S, v = sp[][1:end]
    M = S()
    n = degree(M)
    R = base_ring(S)
    for i = 1:n
       for j = 1:n
-         M[i, j] = rand(rng, R, v...)
+         M[i, j] = rand(rng, v)
       end
    end
    return M
 end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.MatAlgebra, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -694,19 +694,35 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.NCPolyRing, dr::UnitRange{Int}, _) = elem_type(S)
+
+function RandomExtensions.make(S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:AbstractAlgebra.NCPolyElem,
+                                                                 <:AbstractAlgebra.NCPolyRing,
+                                                                 UnitRange{Int}}})
+   S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:rand(rng, deg_range)
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return f
 end
 
-function rand(S::AbstractAlgebra.NCPolyRing, deg_range, v...)
-   rand(Random.GLOBAL_RNG, S, deg_range, v...)
-end
+rand(rng::AbstractRNG, S::AbstractAlgebra.NCPolyRing, deg_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, deg_range, v...))
+
+rand(S::AbstractAlgebra.NCPolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v...)
 
 ###############################################################################
 #

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2745,6 +2745,15 @@ end
 
 RandomExtensions.maketype(S::AbstractAlgebra.PolyRing, dr::UnitRange{Int}, _) = elem_type(S)
 
+function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
 # define rand for make(S, deg_range, v)
 function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
    S, deg_range, v = sp[][1:end]
@@ -2755,15 +2764,6 @@ function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Mak
       f += rand(rng, v)*x^i
    end
    return f
-end
-
-function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
-   R = base_ring(S)
-   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
-   else
-      make(S, deg_range, make(R, vs...))
-   end
 end
 
 rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...) =

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1281,7 +1281,7 @@ function pseudodivrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyEle
    s = b^k
    return q*s, f*s
 end
-   
+
 ################################################################################
 #
 #   Remove and valuation
@@ -2743,15 +2743,31 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...)
+RandomExtensions.maketype(S::AbstractAlgebra.PolyRing, dr::UnitRange{Int}, _) = elem_type(S)
+
+# define rand for make(S, deg_range, v)
+function rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,<:AbstractAlgebra.PolyRing,UnitRange{Int}}})
+   S, deg_range, v = sp[][1:end]
    R = base_ring(S)
    f = S()
    x = gen(S)
    for i = 0:rand(rng, deg_range)
-      f += rand(rng, R, v...)*x^i
+      f += rand(rng, v)*x^i
    end
    return f
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, deg_range, vs[1]) # forward to default Make constructor
+   else
+      make(S, deg_range, make(R, vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.PolyRing, deg_range::UnitRange{Int}, v...) =
+   rand(rng, make(S, deg_range, v...))
 
 rand(S::AbstractAlgebra.PolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v...)
 

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -600,19 +600,30 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::PuiseuxSeriesRing, val_range::UnitRange{Int}, scale_range::UnitRange{Int}, v...)
+const PuiseuxSeriesRingOrField = Union{PuiseuxSeriesRing,PuiseuxSeriesField}
+
+RandomExtensions.maketype(S::PuiseuxSeriesRingOrField, ::UnitRange{Int}, _) = elem_type(S)
+
+RandomExtensions.make(S::PuiseuxSeriesRingOrField, val_range::UnitRange{Int},
+                      scale_range::UnitRange{Int}, vs...) =
+     make(S, scale_range, make(laurent_ring(S), val_range, vs...))
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make3{<:RingElement,
+                                                                 <:PuiseuxSeriesRingOrField,
+                                                                 UnitRange{Int}}})
+   S, scale_range, v = sp[][1:end]
    (first(scale_range) <= 0 || last(scale_range) <= 0) && error("Scale must be positive")
-   return S(rand(rng, laurent_ring(S), val_range, v...), rand(rng, scale_range))
+   return S(rand(rng, v), rand(rng, scale_range))
 end
 
-function rand(rng::AbstractRNG, S::PuiseuxSeriesField, val_range::UnitRange{Int}, scale_range::UnitRange{Int}, v...)
-   (first(scale_range) <= 0 || last(scale_range) <= 0) && error("Scale must be positive")
-   return S(rand(rng, laurent_ring(S), val_range, v...), rand(rng, scale_range))
-end
+rand(rng::AbstractRNG, S::PuiseuxSeriesRingOrField, val_range::UnitRange{Int},
+     scale_range::UnitRange{Int}, v...) =
+        rand(rng, make(S, val_range, scale_range, v...))
 
-function rand(S::Union{PuiseuxSeriesRing,PuiseuxSeriesField}, val_range, scale_range, v...)
+rand(S::PuiseuxSeriesRingOrField, val_range, scale_range, v...) =
    rand(Random.GLOBAL_RNG, S, val_range, scale_range, v...)
-end
+
 
 ###############################################################################
 #

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -504,10 +504,28 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.ResRing{T}, v...) where {T <: RingElement}
-   R = base_ring(S)
-   return S(rand(rng, R, v...))
+RandomExtensions.maketype(R::AbstractAlgebra.ResRing, _) = elem_type(R)
+
+# define rand(make(S, v))
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResElem{T},
+                                          <:AbstractAlgebra.ResRing{T}}}
+              ) where {T}
+   S, v = sp[][1:end]
+   S(rand(rng, v))
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.ResRing, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1])
+   else
+      make(S, make(base_ring(S), vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.ResRing, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.ResRing, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -563,10 +563,27 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, S::AbstractAlgebra.ResField{T}, v...) where {T <: RingElement}
-   R = base_ring(S)
-   return S(rand(rng, R, v...))
+RandomExtensions.maketype(R::AbstractAlgebra.ResField, _) = elem_type(R)
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{<:AbstractAlgebra.ResFieldElem{T},
+                                          <:AbstractAlgebra.ResField{T}}}
+              ) where {T}
+   S, v = sp[][1:end]
+   S(rand(rng, v))
 end
+
+function RandomExtensions.make(S::AbstractAlgebra.ResField, vs...)
+   R = base_ring(S)
+   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
+      RandomExtensions.Make(S, vs[1])
+   else
+      make(S, make(base_ring(S), vs...))
+   end
+end
+
+rand(rng::AbstractRNG, S::AbstractAlgebra.ResField, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.ResField, v...) = rand(Random.GLOBAL_RNG, S, v...)
 

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -185,13 +185,17 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Floats, n::UnitRange{<:AbstractFloat})
-   return R(n.start + rand(rng, Float64)*(n.stop - n.start))
+RandomExtensions.maketype(R::Floats{T}, _) where {T} = T
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{<:RandomExtensions.Make2{
+                 T, Floats{T}, <:UnitRange{<:Union{AbstractFloat, Int}}}}) where {T}
+   R, n = sp[][1:end]
+   R(n.start + rand(rng, Float64)*(n.stop - n.start))
 end
 
-function rand(rng::AbstractRNG, R::Floats, n::UnitRange{Int})
-   return R(n.start + rand(rng, Float64)*(n.stop - n.start))
-end
+
+rand(rng::AbstractRNG, R::Floats, n::UnitRange) = rand(rng, make(R, n))
 
 rand(R::Floats, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -364,6 +364,12 @@ rand(rng::AbstractRNG, R::Integers, n) = R(rand(rng, n))
 
 rand(R::Integers, n) = rand(Random.GLOBAL_RNG, R, n)
 
+## testing
+
+# we re-use the test(T) method implemented in RandomTest,
+# and scale it down as an example here, to get smaller numbers
+RandomTest.test(::Integers{T}) where {T} = RandomTest.scale(0.4, test(T))
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -351,9 +351,16 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Integers, n::UnitRange{Int})
-   return R(rand(rng, n))
-end
+RandomExtensions.maketype(R::AbstractAlgebra.Integers{T}, _) where {T} = T
+
+# define rand(make(ZZ, n:m))
+rand(rng::AbstractRNG,
+     sp::Random.SamplerTrivial{<:RandomExtensions.Make2{T, Integers{T}, UnitRange{Int}}}
+     ) where {T} =
+        sp[][1](rand(rng, sp[][2]))
+
+
+rand(rng::AbstractRNG, R::Integers, n) = R(rand(rng, n))
 
 rand(R::Integers, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -299,7 +299,13 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::Rationals{T}, n::UnitRange{Int}) where T <: Integer
+RandomExtensions.maketype(R::Rationals{T}, _) where {T} = Rational{T}
+
+function rand(rng::AbstractRNG,
+              sp::Random.SamplerTrivial{
+                 <:RandomExtensions.Make2{Rational{T}, Rationals{T}, UnitRange{Int}}}
+              ) where {T}
+   R, n = sp[][1:end]
    d = T(0)
    while d == 0
       d = T(rand(rng, n))
@@ -307,6 +313,9 @@ function rand(rng::AbstractRNG, R::Rationals{T}, n::UnitRange{Int}) where T <: I
    n = T(rand(rng, n))
    return R(n, d)
 end
+
+
+rand(rng::AbstractRNG, R::Rationals, n) = rand(rng, make(R, n))
 
 rand(R::Rationals, n) = rand(Random.GLOBAL_RNG, R, n)
 

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -52,10 +52,12 @@ end
 @testset "Generic.Frac.rand..." begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
-   f = rand(K, 0:3, -3:3)
-   @test f isa Generic.Frac
-   f = rand(rng, K, 0:3, -3:3)
-   @test f isa Generic.Frac
+   m = make(K, 0:3, -3:3)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(K, 0:3, -3:3),
+                rand(rng, K, 0:3, -3:3)]
+      @test f isa Generic.Frac
+   end
 end
 
 @testset "Generic.Frac.manipulation..." begin

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -375,18 +375,16 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
    @testset "rand" begin
       L, y = LaurentPolynomialRing(ZZ, "y")
 
-      f = rand(L, -5:5, -10:10)
-      @test f isa LaurentPolyElem{BigInt}
-      @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
-      for i = -5:5
-         @test coeff(f, i) ∈ -10:10
-      end
+      m = make(L, -5:5, -10:10)
+      for f in (rand(m), rand(rng, m),
+                rand(L, -5:5, -10:10),
+                rand(rng, L, -5:5, -10:10))
 
-      f = rand(rng, L, -5:5, -10:10)
-      @test f isa LaurentPolyElem{BigInt}
-      @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
-      for i = -5:5
-         @test coeff(f, i) ∈ -10:10
+         @test f isa LaurentPolyElem{BigInt}
+         @test AbstractAlgebra.degrees_range(f) ⊆ -5:5
+         for i = -5:5
+            @test coeff(f, i) ∈ -10:10
+         end
       end
    end
 

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -106,11 +106,25 @@ end
    f = rand(rng, R, -12:12, -10:10)
    @test f isa Generic.LaurentSeriesRingElem
 
+   for m in (make(R, -12:12, -10:10),
+            make(R, -12:12, make(ZZ, -10:10)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.LaurentSeriesRingElem{BigInt}
+      end
+   end
+
    R, x = LaurentSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, -1:1)
    @test f isa Generic.LaurentSeriesFieldElem
    f = rand(rng, R, -12:12, -1:1)
    @test f isa Generic.LaurentSeriesFieldElem
+
+   for m in (make(R, -12:12, -1:1),
+             make(R, -12:12, make(RealField, -1:1)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.LaurentSeriesFieldElem{BigFloat}
+      end
+   end
 end
 
 @testset "Generic.LaurentSeries.manipulation..." begin

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -108,10 +108,12 @@ end
    @test ord in [:lex, :deglex, :degrevlex]
 
    S, varlist = PolynomialRing(R, var_names, ordering = ord)
-   f = rand(S, 0:5, 0:100, 0:0, -100:100)
-   @test f isa Generic.MPoly
-   f = rand(rng, S, 0:5, 0:100, 0:0, -100:100)
-   @test f isa Generic.MPoly
+   m = make(S, 0:5, 0:100, 0:0, -100:100)
+   for f in (rand(m), rand(rng, m),
+             rand(S, 0:5, 0:100, 0:0, -100:100),
+             rand(rng, S, 0:5, 0:100, 0:0, -100:100))
+      @test f isa Generic.MPoly
+   end
 end
 
 @testset "Generic.MPoly.manipulation..." begin

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -519,7 +519,7 @@ end
    end
 
    M0 = MatrixAlgebra(R, 0)
-   m0 = rand(M0, 0:9, -9, 9)
+   m0 = rand(M0, 0:9, -9:9)
    @test length(m0) == 0
    @test isempty(m0)
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -2902,3 +2902,19 @@ end
    @test Matrix(F) == B
    @test eltype(B) == F2Elem
 end
+
+@testset "Generic.Mat.rand" begin
+   M = MatrixSpace(ZZ, 2, 3)
+   m = make(M, 1:9)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M, 1:9), rand(rng, M, 1:9)]
+      @test A isa elem_type(M)
+   end
+
+   M = MatrixSpace(GF(7), 3, 2)
+   m = make(M)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M), rand(rng, M)]
+      @test A isa elem_type(M)
+   end
+end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1250,3 +1250,19 @@ end
       end
    end
 end
+
+@testset "Generic.MatAlg.rand" begin
+   M = MatrixAlgebra(ZZ, 3)
+   m = make(M, 1:9)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M, 1:9), rand(rng, M, 1:9)]
+      @test A isa elem_type(M)
+   end
+
+   M = MatrixAlgebra(GF(7), 2)
+   m = make(M)
+   for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(M), rand(rng, M)]
+      @test A isa elem_type(M)
+   end
+end

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -15,10 +15,11 @@ end
 
 @testset "Generic.Module.rand..." begin
    F = FreeModule(ZZ, 3)
-   f = rand(F, 1:9)
-   @test f isa Generic.FreeModuleElem
-   f = rand(rng, F, 1:9)
-   @test f isa Generic.FreeModuleElem
+   m = make(F, 1:9)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(F, 1:9), rand(rng, F, 1:9)]
+      @test f isa Generic.FreeModuleElem
+   end
 end
 
 @testset "Generic.Module.manipulation..." begin

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -103,10 +103,12 @@ end
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
-   f = rand(S, 0:10, -10:10)
-   @test f isa Generic.NCPoly
-   f = rand(rng, S, 0:10, -10:10)
-   @test f isa Generic.NCPoly
+   m = make(S, 0:10, -10:10)
+   for f in (rand(m), rand(rng, m),
+             rand(S, 0:10, -10:10),
+             rand(rng, S, 0:10, -10:10))
+      @test f isa Generic.NCPoly
+   end
 end
 
 @testset "Generic.NCPoly.binary_ops..." begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -86,11 +86,41 @@
 end
 
 @testset "Generic.Poly.rand..." begin
+   # TODO: test more than just the result type
    R, x = PolynomialRing(ZZ, "x")
    f = rand(R, 0:10, -10:10)
    @test f isa Generic.Poly
    f = rand(rng, R, 0:10, -10:10)
    @test f isa Generic.Poly
+
+   # make API
+   for m in (make(R, 0:10, make(ZZ, -10:10)),
+             make(R, 0:10, -10:10)) # convenience only
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.Poly
+      end
+      @test rand(m, 3) isa Vector{Generic.Poly{BigInt}}
+      @test size(rand(rng, m, 2, 3)) == (2, 3)
+   end
+
+   S, y = PolynomialRing(R, "y")
+   for m in (make(S, 0:5, make(R, 0:10, make(ZZ, -10:10))),
+             make(S, 0:5, make(R, 0:10, -10:10)),
+             make(S, 0:5, 0:10, -10:10))
+
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.Poly{Generic.Poly{BigInt}}
+      end
+      a = rand(m, 3)
+      @test length(a) == 3
+      @test a isa Vector{Generic.Poly{Generic.Poly{BigInt}}}
+   end
+
+   T, z = PolynomialRing(GF(7), "z")
+   m = make(T, 0:4)
+   for f in (rand(m), rand(rng, m))
+      @test f isa Generic.Poly{AbstractAlgebra.GFElem{Int64}}
+   end
 end
 
 @testset "Generic.Poly.manipulation..." begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -350,11 +350,13 @@ end
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
-      f = rand(R, 0:10, -10:10)
+      # f = rand(R, 0:10, -10:10) # Here, 0:10 and -10:10 are not really meaningful
+                                  # and were specified only because rand required it
+      f = randt(R)
       g = deepcopy(f)
       h = R()
       while iszero(h)
-         h = rand(R, 0:10, -10:10)
+         h = randt(R)
       end
 
       @test f == g
@@ -432,6 +434,23 @@ end
       @test c1 != R(c1) + f
       @test R(d1) != d1 + f
       @test d1 != R(d1) + f
+   end
+   # possible alternative with quickcheck-like testing:
+   # @quickcheck runs the specified "function" a certain number of times (100 by default),
+   # with random inputs;
+   # the function syntax is modified such that the "types" are replaced with
+   # "distributions" to pick from (`test` is applied to get a distribution if not already
+   # a distribution, like ZZ)
+   @quickcheck function (f::NonZero(test(R)), c1::ZZ, d1::ZZ)
+      @test R(c1) == c1
+      @test c1 == R(c1)
+      # etc...
+   end
+   # or non-macro:
+   quickcheck(NonZero(test(R)), ZZ, ZZ) do (f, c1, d1)
+      @test R(c1) == c1
+      @test c1 == R(c1)
+      # etc...
    end
 
    # Fake finite field of char 7, degree 2

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -98,11 +98,25 @@ end
    f = rand(rng, R, -12:12, 1:6, -10:10)
    @test f isa Generic.PuiseuxSeriesRingElem
 
+   for m in (make(R, -12:12, 1:6, -10:10),
+             make(R, -12:12, 1:6, make(ZZ, -10:10)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.PuiseuxSeriesRingElem{BigInt}
+      end
+   end
+
    R, x = PuiseuxSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, 1:6, -1:1)
    @test f isa Generic.PuiseuxSeriesFieldElem
    f = rand(rng, R, -12:12, 1:6, -1:1)
    @test f isa Generic.PuiseuxSeriesFieldElem
+
+   for m in (make(R, -12:12, 1:6, -1:1),
+             make(R, -12:12, 1:6, make(RealField, -1:1)))
+      for f in (rand(m), rand(rng, m))
+         @test f isa Generic.PuiseuxSeriesFieldElem{BigFloat}
+      end
+   end
 end
 
 @testset "Generic.PuiseuxSeries.manipulation..." begin

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -84,10 +84,12 @@ end
 
 @testset "Generic.RelSeries.rand..." begin
    R, x = PowerSeriesRing(ZZ, 10, "x")
-   f = rand(R, 0:12, -10:10)
-   @test f isa Generic.RelSeries
-   f = rand(rng, R, 0:12, -10:10)
-   @test f isa Generic.RelSeries
+   m = make(R, 0:12, -10:10)
+   for f in Any[rand(m), rand(rng, m), rand(m, 3)...,
+                rand(R, 0:12, -10:10),
+                rand(rng, R, 0:12, -10:10)]
+      @test f isa Generic.RelSeries
+   end
 end
 
 @testset "Generic.RelSeries.manipulation..." begin

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -57,6 +57,17 @@ end
    @test f isa Generic.Res
    f = rand(rng, R, 1:9)
    @test f isa Generic.Res
+   m = make(R, 1:9)
+   for f = (rand(m), rand(rng, m))
+      @test f isa Generic.Res
+      @test 1 <= f.data <= 9
+   end
+
+   # make with 3 arguments
+   P, x = PolynomialRing(RealField, "x")
+   R = Generic.ResidueRing(P, x^3)
+   m = make(R, 1:9, -3:3)
+   @test rand(m) isa Generic.Res{AbstractAlgebra.Generic.Poly{BigFloat}}
 end
 
 @testset "Generic.Res.manipulation..." begin

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -55,6 +55,12 @@ end
    @test f isa Generic.ResF
    f = rand(rng, R, 1:9)
    @test f isa Generic.ResF
+
+   m = make(R, 1:9)
+   for f in (rand(m), rand(rng, m))
+      @test f isa Generic.ResF
+      @test 1 <= f.data <= 9
+   end
 end
 
 @testset "Generic.ResF.manipulation..." begin

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -46,6 +46,15 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, UnitRange(big(1.0), big(9.0)))
    @test f isa elem_type(R)
+
+   # make
+   for r in (1:9, UnitRange(1.0, 9.0), UnitRange(big(1.0), big(9.0)))
+      m = make(R, r)
+      @test rand(m) isa elem_type(R)
+      @test 1.0 <= rand(m) <= 9.0
+      @test rand(rng, m) isa elem_type(R)
+      @test rand(m, 2, 3) isa Matrix{elem_type(R)}
+   end
 end
 
 @testset "Julia.Floats.manipulation..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -52,6 +52,9 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, 0:22)
    @test f isa elem_type(R)
+   f = rand(make(R, 0:22))
+   @test f isa elem_type(R)
+   @test f in 0:22
 end
 
 @testset "Julia.Integers.modular_arithmetic..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -92,7 +92,8 @@ end
    S = ZZ
 
    for iter = 1:1000
-      a1 = rand(R, -100:100)
+      a1 = rand(R, Small(Int)) # Small(Int) generates most numer in [-100, 100], with
+                               # mean of their absolute value approx. 33
       a2 = rand(R, -100:100)
       b1 = rand(S, -100:100)
       b2 = rand(S, -100:100)
@@ -158,8 +159,8 @@ end
    S = ZZ
 
    for iter = 1:1000
-      r = rand(R, 0:1000)
-      s = rand(S, 0:1000)
+      r = rand(test(R))
+      s = randt(S) # equivalent to rand(test(S))
 
       f = r^2
       g = s^2

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -41,6 +41,14 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, 1:9)
    @test f isa elem_type(R)
+
+   # make
+   m = make(R, 1:9)
+   for f = (rand(m), rand(rng, m))
+      @test f isa elem_type(R)
+      @test 1 <= numerator(f) <= 9
+      @test 1 <= denominator(f) <= 9
+   end
 end
 
 @testset "Julia.Rationals.manipulation..." begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using AbstractAlgebra
 
 using SparseArrays, LinearAlgebra
 using AbstractAlgebra: mul! # disambiguate from LinearAlgebra.mul!
+using RandomExtensions: make
 
 if VERSION < v"0.7.0-DEV.2004"
    using Base.Test


### PR DESCRIPTION
This is based off #648, so only [the last commit](https://github.com/Nemocas/AbstractAlgebra.jl/commit/7aea317db7f92b5395a2bbc8058ad5e5cc350452) is new here.

This uses the [RandomTest.jl](https://github.com/JuliaRandom/RandomTest.jl) package to define easily new distributions which can be used for testing.
Starting with an example:
```julia
julia> using AbstractAlgebra, RandomTest

julia> randt(ZZ, 10)
10-element Array{BigInt,1}:
 -56650976381335138235754141204422689
                               106353
                                  -20
                                    7
                                    7
                                   -1
                                   31
                                  -56
                                    0
                      -18191886763417
```
`randt(x)` is equivalent to `rand(test(x))`, where `test(x)` creates a distribution, which ideally generates different "kinds" of values (whatever that means), including corner cases. 
Another example:
```julia
julia> R, x = ZZ["x"];

julia> randt(R, 5)
5-element Array{AbstractAlgebra.Generic.Poly{BigInt},1}:
 -x^20 - 2*x^19 - 3*x^18 - x^16 - x^15 - 2*x^14 - 3*x^13 - 2*x^12 - x^10 - x^9 - 2*x^8 - x^7 - x^6 + 2*x^5 - x^3 - 2*x^2 - x - 1
 x^20 - 19*x^19 - 2*x^17 - x^16 + 221*x^15 + x^13 - 31*x^12 - x^11 - 2*x^8 - 2*x^7 - x^5 + 22*x^4 + 49*x^2 - 4*x
 -x - 1
 -1
 -x^17 - 2*x^16 - 2*x^15 - 786*x^14 - x^9 - 2*x^7 - x^6 - x^3 - 7*x
```
One of the benefits of using `randt` compared to `rand` is when the parameters to supply to `rand` are non very meaningful and arbitrary, then `randt` can generate relatively sensible parameter. 

The couple implemented methods here, and modified examples, contain few comments to hopefully help understand how it works (there is of course no documentation yet).

This PR is currently just a preview. It also includes a (even) more speculative example using a `@quickcheck` macro (very rudimentary implementation), inspired by Haskell's [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library (I don't have a better link right now).
Unlike in the original QuickCheck, the focus is more on "scaling the size distribution of the generated values" rather than controlling directly the size. For example, to get bigger numbers than above:
```julia
julia> rand(scale(5, test(ZZ)), 10)
10-element Array{BigInt,1}:
                                                                                                                         -8664794006
                                                                                                                                -880
                                                                                                                           162545982
                           -10357559959107108727771427394847732419490268649410200387398639185727769360051063349600926020926791431022
 32186247245162422880932587914577229487125664700150545068048814970476825028737043270732181531127430350681341794026507099231043569702
                                                                                                                                  -9
                                                                                                                           -32465504
                                                                                                                                -691
                                                                                                             14715724230660819341839
                                                                                                                                   0
```
Of course, we can also define `test` methods which take a parameter to directly influence the size, e.g we could have `test(ZZ, 10)` or whatnot where 10 suggests or imposes a size.

The `RandomTest` package is not registered, you need to clone yourself in order to run the examples above.