### PR TITLE
fix reproducibility of rand for MPoly, and add reproducibility tests

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2102,7 +2102,7 @@ function sqrt_heap(a::MPoly{T}, bits::Int, check::Bool=true) where {T <: RingEle
    m = length(a)
    if m == 0
       return true, par()
-   end 
+   end
    # ordering mask
    drmask = monomial_drmask(par, bits)
    # mask for checking for overflows in halves!
@@ -4698,7 +4698,7 @@ end
 
 ################################################################################
 #
-#  Map                                                                      
+#  Map
 #
 ################################################################################
 
@@ -4760,7 +4760,7 @@ function rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make4{
    f = S()
    g = gens(S)
    R = base_ring(S)
-   for i = 1:rand(term_range)
+   for i = 1:rand(rng, term_range)
       term = S(1)
       for j = 1:length(g)
          term *= g[j]^rand(rng, exp_bound)

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -58,6 +58,8 @@ end
                 rand(rng, K, 0:3, -3:3)]
       @test f isa Generic.Frac
    end
+   @test reproducible(m)
+   @test reproducible(K, 0:3, -3:3)
 end
 
 @testset "Generic.Frac.manipulation..." begin

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -386,6 +386,8 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
             @test coeff(f, i) ∈ -10:10
          end
       end
+      @test reproducible(m)
+      @test reproducible(L, -5:5, -10:10)
    end
 
    @testset "change_base_ring & map_coeffs" begin

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -111,7 +111,9 @@ end
       for f in (rand(m), rand(rng, m))
          @test f isa Generic.LaurentSeriesRingElem{BigInt}
       end
+      @test reproducible(m)
    end
+   @test reproducible(R, -12:12, -10:10)
 
    R, x = LaurentSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, -1:1)
@@ -124,7 +126,9 @@ end
       for f in (rand(m), rand(rng, m))
          @test f isa Generic.LaurentSeriesFieldElem{BigFloat}
       end
+      @test reproducible(m)
    end
+   @test reproducible(R, -12:12, -1:1)
 end
 
 @testset "Generic.LaurentSeries.manipulation..." begin
@@ -168,7 +172,7 @@ end
    @test_throws DomainError upscale(a, -rand(1:100))
    @test_throws DomainError downscale(a, 0)
    @test_throws DomainError downscale(a, -rand(1:100))
-  
+
    @test characteristic(S) == 0
 
    T = ResidueRing(ZZ, 7)

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -114,6 +114,8 @@ end
              rand(rng, S, 0:5, 0:100, 0:0, -100:100))
       @test f isa Generic.MPoly
    end
+   @test reproducible(m)
+   @test reproducible(S, 0:5, 0:100, 0:0, -100:100)
 end
 
 @testset "Generic.MPoly.manipulation..." begin
@@ -560,7 +562,7 @@ end
             p = f^2
 
             @test issquare(p)
-         
+
             q = sqrt(f^2)
 
             @test q^2 == f^2
@@ -1413,4 +1415,3 @@ end
       end
    end
 end
-

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1088,7 +1088,7 @@ end
 @testset "Generic.Mat.lu..." begin
    # Exact field
    R = GF(7)
-   
+
    for iters = 1:50
       m = rand(0:100)
       n = rand(0:100)
@@ -1170,7 +1170,7 @@ end
             A[i, j] = rand(-10:10)
          end
       end
-                                       
+
       r, d, P, L, U = fflu(A)
 
       R2 = parent(1//one(R))
@@ -1184,8 +1184,8 @@ end
             D[j + 1, j + 1] = (1//L[j, j])*(1//L[j + 1, j + 1])
          end
       end
-      L2 = change_base_ring(R2, L)                                   
-      U2 = change_base_ring(R2, U)                                   
+      L2 = change_base_ring(R2, L)
+      U2 = change_base_ring(R2, U)
       @test change_base_ring(R2, P*A) == L2*D*U2
    end
 
@@ -3091,6 +3091,8 @@ end
                 rand(M, 1:9), rand(rng, M, 1:9)]
       @test A isa elem_type(M)
    end
+   @test reproducible(m)
+   @test reproducible(M, 1:9)
 
    for M = (MatrixSpace(GF(7), 3, 2),
             MatrixSpace(F2(), 2, 3))
@@ -3099,5 +3101,6 @@ end
                    rand(M), rand(rng, M)]
          @test A isa elem_type(M)
       end
+      @test reproducible(m)
    end
 end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1186,6 +1186,8 @@ end
                 rand(M, 1:9), rand(rng, M, 1:9)]
       @test A isa elem_type(M)
    end
+   @test reproducible(m)
+   @test reproducible(M, 1:9)
 
    M = MatrixAlgebra(GF(7), 2)
    m = make(M)
@@ -1193,4 +1195,6 @@ end
                 rand(M), rand(rng, M)]
       @test A isa elem_type(M)
    end
+   @test reproducible(m)
+   @test reproducible(M)
 end

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -20,6 +20,8 @@ end
                 rand(F, 1:9), rand(rng, F, 1:9)]
       @test f isa Generic.FreeModuleElem
    end
+   @test reproducible(m)
+   @test reproducible(F, 1:9)
 end
 
 @testset "Generic.Module.manipulation..." begin

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -109,6 +109,8 @@ end
              rand(rng, S, 0:10, -10:10))
       @test f isa Generic.NCPoly
    end
+   @test reproducible(m)
+   @test reproducible(S, 0:10, -10:10)
 end
 
 @testset "Generic.NCPoly.binary_ops..." begin
@@ -315,7 +317,7 @@ end
 
    f = rand(S, 0:10, -10:10)
    @test_throws DomainError f^-1
-   @test_throws DomainError f^-3   
+   @test_throws DomainError f^-3
    @test_throws DomainError f^identity(-1)
    @test_throws DomainError f^-rand(2:100)
 end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -101,7 +101,9 @@ end
       end
       @test rand(m, 3) isa Vector{Generic.Poly{BigInt}}
       @test size(rand(rng, m, 2, 3)) == (2, 3)
+      @test reproducible(m)
    end
+   @test reproducible(R, 0:10, -10:10)
 
    S, y = PolynomialRing(R, "y")
    for m in (make(S, 0:5, make(R, 0:10, make(ZZ, -10:10))),
@@ -114,6 +116,7 @@ end
       a = rand(m, 3)
       @test length(a) == 3
       @test a isa Vector{Generic.Poly{Generic.Poly{BigInt}}}
+      @test reproducible(m)
    end
 
    T, z = PolynomialRing(GF(7), "z")
@@ -121,6 +124,8 @@ end
    for f in (rand(m), rand(rng, m))
       @test f isa Generic.Poly{AbstractAlgebra.GFElem{Int64}}
    end
+   @test reproducible(m)
+   @test reproducible(T, 0:4)
 end
 
 @testset "Generic.Poly.manipulation..." begin
@@ -2670,12 +2675,12 @@ end
       R = ResidueField(ZZ, p)
 
       S, x = PolynomialRing(R, "x")
-      
+
       for iter = 1:10
          f = rand(S, 0:20, 0:Int(p))
-         
+
          s = f^2
-         
+
          @test issquare(s)
 
          q = sqrt(f^2)

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -103,7 +103,9 @@ end
       for f in (rand(m), rand(rng, m))
          @test f isa Generic.PuiseuxSeriesRingElem{BigInt}
       end
+      @test reproducible(m)
    end
+   @test reproducible(R, -2:12, 1:6, -10:10)
 
    R, x = PuiseuxSeriesField(RealField, 10, "x")
    f = rand(R, -12:12, 1:6, -1:1)
@@ -116,6 +118,7 @@ end
       for f in (rand(m), rand(rng, m))
          @test f isa Generic.PuiseuxSeriesFieldElem{BigFloat}
       end
+      @test reproducible(m)
    end
 end
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -90,6 +90,8 @@ end
                 rand(rng, R, 0:12, -10:10)]
       @test f isa Generic.RelSeries
    end
+   @test reproducible(m)
+   @test reproducible(R, 0:12, -10:10)
 end
 
 @testset "Generic.RelSeries.manipulation..." begin
@@ -128,7 +130,7 @@ end
 
    @test_throws DomainError polcoeff(a, -1)
    @test_throws DomainError polcoeff(a, -rand(2:100))
-   
+
    @test characteristic(S) == 0
 
    T = ResidueRing(ZZ, 7)
@@ -513,7 +515,7 @@ end
          r2 *= f
       end
    end
-   
+
    f = rand(R, 0:12, 0:rand(1:25))
    @test_throws DomainError f^-1
    @test_throws DomainError f^-rand(2:100)
@@ -533,7 +535,7 @@ end
       @test isequal(shift_left(f, s), x^s*f)
       @test precision(shift_right(f, s)) == max(0, precision(f) - s)
    end
-   
+
    f = rand(R, 0:12, -10:10)
    @test_throws DomainError shift_left(f, -1)
    @test_throws DomainError shift_left(f, -rand(2:100))
@@ -594,7 +596,7 @@ end
       @test precision(truncate(f, s)) == min(precision(f), s)
    end
 
-   f = rand(R, 0:12, -10:10)   
+   f = rand(R, 0:12, -10:10)
    @test_throws DomainError truncate(f, -1)
    @test_throws DomainError truncate(f, -rand(2:100))
 
@@ -627,7 +629,7 @@ end
 
    f = rand(R, 0:12, 0:5)
    @test_throws DomainError truncate(f, -1)
-   @test_throws DomainError truncate(f, -rand(2:100))      
+   @test_throws DomainError truncate(f, -rand(2:100))
 end
 
 @testset "Generic.RelSeries.inversion..." begin

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -62,12 +62,16 @@ end
       @test f isa Generic.Res
       @test 1 <= f.data <= 9
    end
+   @test reproducible(m)
+   @test reproducible(R, 1:9)
 
    # make with 3 arguments
    P, x = PolynomialRing(RealField, "x")
    R = Generic.ResidueRing(P, x^3)
    m = make(R, 1:9, -3:3)
    @test rand(m) isa Generic.Res{AbstractAlgebra.Generic.Poly{BigFloat}}
+   @test reproducible(m)
+   @test reproducible(R, 1:9, -3:3)
 end
 
 @testset "Generic.Res.manipulation..." begin

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -61,6 +61,9 @@ end
       @test f isa Generic.ResF
       @test 1 <= f.data <= 9
    end
+
+   @test reproducible(m)
+   @test reproducible(R, 1:9)
 end
 
 @testset "Generic.ResF.manipulation..." begin
@@ -283,8 +286,8 @@ end
    end
 
    for p in [ZZ(3), ZZ(53), ZZ(727), ZZ(8893), ZZ(191339), ZZ(2369093), ZZ(52694921)]
-       R = Generic.ResidueField(ZZ, p)                                                                                  
-       
+       R = Generic.ResidueField(ZZ, p)
+
        for i = 1:10
           a = rand(R, 0:Int(p - 1))^2
           b = sqrt(a)

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -36,8 +36,10 @@ end
    R = RealField
    f = rand(R, 1:9)
    @test f isa elem_type(R)
+   @test reproducible(R, 1:9)
    f = rand(R, UnitRange(1.0, 9.0))
    @test f isa elem_type(R)
+   @test reproducible(R, UnitRange(1.0, 9.0))
    f = rand(R, UnitRange(big(1.0), big(9.0)))
    @test f isa elem_type(R)
    f = rand(rng, R, 1:9)
@@ -54,6 +56,7 @@ end
       @test 1.0 <= rand(m) <= 9.0
       @test rand(rng, m) isa elem_type(R)
       @test rand(m, 2, 3) isa Matrix{elem_type(R)}
+      @test reproducible(m)
    end
 end
 

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -82,6 +82,7 @@ end
    @test rand(rng, R) isa AbstractAlgebra.GFElem
    @test rand(R, 2, 3) isa Matrix{<:AbstractAlgebra.GFElem}
    @test rand(rng, R, 2, 3) isa Matrix{<:AbstractAlgebra.GFElem}
+   @test reproducible(R)
 end
 
 @testset "Julia.GFElem.unary_ops..." begin

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -52,9 +52,11 @@ end
    @test f isa elem_type(R)
    f = rand(rng, R, 0:22)
    @test f isa elem_type(R)
+   @test reproducible(R, 0:22)
    f = rand(make(R, 0:22))
    @test f isa elem_type(R)
    @test f in 0:22
+   @test reproducible(make(R, 0:22))
 end
 
 @testset "Julia.Integers.modular_arithmetic..." begin

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -49,6 +49,8 @@ end
       @test 1 <= numerator(f) <= 9
       @test 1 <= denominator(f) <= 9
    end
+   @test reproducible(m)
+   @test reproducible(R, 1:9)
 end
 
 @testset "Julia.Rationals.manipulation..." begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,14 @@ using RandomExtensions: make
 
 const rng = MersenneTwister()
 
+# tests if rand(rng, args...) gives reproducible results
+function reproducible(args...)
+  Random.seed!(rng)
+  x = rand(rng, args...)
+  Random.seed!(rng, rng.seed)
+  x == rand(rng, args...)
+end
+
 if VERSION < v"0.7.0-DEV.2004"
    using Base.Test
 else


### PR DESCRIPTION
This adds a `reproducible(args...)` function in tests, which checks that `rand(rng, args...)` gives reproducible results. All `rand` methods are tested with this now, and the one for `MPoly` is fixed (a call was wrongly using the global RNG).