### PR TITLE
Fix (co)domain delegation for maps with retraction/section

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -483,6 +483,8 @@ end
 #
 ###############################################################################
 
+# Q: Why is SparsePolyRing not a subtype of AbstractAlgebra.PolyRing{T} ?
+
 mutable struct SparsePolyRing{T <: RingElement} <: AbstractAlgebra.Ring
    base_ring::Ring
    S::Symbol

--- a/src/generic/MapWithInverse.jl
+++ b/src/generic/MapWithInverse.jl
@@ -16,8 +16,8 @@ export map_with_preimage_from_func, map_with_section_from_func,
 
 map_with_section(f::Map{D, C}, g::Map{C, D}) where {D, C} = MapWithSection(f, g)
 
-domain(f::MapWithSection{D, C}) where {D, C} = get_field(f.map, :domain)::D
-codomain(f::MapWithSection{D, C}) where {D, C} = get_field(f.map, :codomain)::C
+domain(f::MapWithSection{D, C}) where {D, C} = domain(f.map)::D
+codomain(f::MapWithSection{D, C}) where {D, C} = codomain(f.map)::C
 image_fn(f::MapWithSection) = image_fn(f.map)
 inverse_fn(f::MapWithSection) = image_fn(f.section)
 image_map(f::MapWithSection) = f.map
@@ -81,8 +81,8 @@ end
 
 map_with_retraction(f::Map{D, C}, g::Map{C, D}) where {D, C} = MapWithRetraction(f, g)
 
-domain(f::MapWithRetraction{D, C}) where {D, C} = get_field(f.map, :domain)::D
-codomain(f::MapWithRetraction{D, C}) where {D, C} = get_field(f.map, :codomain)::C
+domain(f::MapWithRetraction{D, C}) where {D, C} = domain(f.map)::D
+codomain(f::MapWithRetraction{D, C}) where {D, C} = codomain(f.map)::C
 image_fn(f::MapWithRetraction) = image_fn(f.map)
 inverse_fn(f::MapWithRetraction) = image_fn(f.retraction)
 image_map(f::MapWithRetraction) = f.map


### PR DESCRIPTION
Don't make assumptions about how the wrapped maps store the (co)domain; instead, go through the official API, i.e., call `domain` resp. `codomain` on the wrapped map.