### PR TITLE
interpret rand(matspace, 2) as creating a Vector

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2111,9 +2111,9 @@ function can_solve_with_solution_lu(A::MatElem{T}, b::MatElem{T}) where {T <: Fi
    LU = deepcopy(A)
    p = SymmetricGroup(nrows(A))()
    rank = lu!(p, LU)
-   
+
    y = solve_lu_precomp(p, LU, b)
-   
+
    n = nrows(A)
    flag = true
    if rank < n
@@ -2128,7 +2128,7 @@ end
 
 # Given an LU decomposition `LU` of `p(A)` over a field with `L` invertible,
 # this function will return `y` such that the first `r` rows of `p(A)y = p(b)`
-# hold, where `r` is the rank of `A`. The remaining rows must be checked by 
+# hold, where `r` is the rank of `A`. The remaining rows must be checked by
 # the caller.
 function solve_lu_precomp(p::Generic.Perm, LU::MatElem{T}, b::MatrixElem{T}) where {T <: FieldElement}
    x = p * b
@@ -2139,7 +2139,7 @@ function solve_lu_precomp(p::Generic.Perm, LU::MatElem{T}, b::MatrixElem{T}) whe
    t = base_ring(b)()
    s = base_ring(b)()
    y = similar(x, c, m)
-   
+
    for k in 1:m
       x[1, k] = deepcopy(x[1, k])
       for i in 2:n
@@ -2192,7 +2192,7 @@ function solve_lu_precomp(p::Generic.Perm, LU::MatElem{T}, b::MatrixElem{T}) whe
          y[i, j] = R()
       end
    end
-    
+
    return y
 end
 
@@ -5553,6 +5553,12 @@ end
 rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...) = rand(rng, make(S, v...))
 
 rand(S::AbstractAlgebra.MatSpace, v...) = rand(Random.GLOBAL_RNG, S, v...)
+
+# resolve ambiguities
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, dims::Integer...) =
+   rand(rng, make(S), dims...)
+
+rand(S::AbstractAlgebra.MatSpace, dims::Integer...) = rand(Random.GLOBAL_RNG, S, dims...)
 
 function randmat_triu(rng::AbstractRNG, S::AbstractAlgebra.MatSpace, v...)
    M = S()

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -383,6 +383,12 @@ rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...) = rand(rng, make(S, 
 
 rand(S::AbstractAlgebra.MatAlgebra, v...) = rand(Random.GLOBAL_RNG, S, v...)
 
+# resolve ambiguities
+rand(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, dims::Integer...) =
+   rand(rng, make(S), dims...)
+
+rand(S::AbstractAlgebra.MatAlgebra, dims::Integer...) = rand(Random.GLOBAL_RNG, S, dims...)
+
 function randmat_triu(rng::AbstractRNG, S::AbstractAlgebra.MatAlgebra, v...)
    M = S()
    n = degree(M)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1378,8 +1378,8 @@ end
 
 @testset "Generic.Mat.can_solve_with_solution_fflu..." begin
    R = ZZ
-  
-   # Test random soluble systems 
+
+   # Test random soluble systems
    for i = 1:100
       m = rand(0:30)
       n = rand(0:30)
@@ -3275,7 +3275,7 @@ end
             MatrixSpace(F2(), 2, 3))
       m = make(M)
       for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
-                   rand(M), rand(rng, M)]
+                   rand(M), rand(rng, M), rand(M, 3)...]
          @test A isa elem_type(M)
       end
       @test reproducible(m)

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1192,7 +1192,7 @@ end
    M = MatrixAlgebra(GF(7), 2)
    m = make(M)
    for A in Any[rand(m), rand(rng, m), rand(m, 3)...,
-                rand(M), rand(rng, M)]
+                rand(M), rand(rng, M), rand(M, 3)...]
       @test A isa elem_type(M)
    end
    @test reproducible(m)


### PR DESCRIPTION
Currently, `rand(matspace, 2)` is ambiguous; it could mean:
* `rand(make(matspace), 2)`, which creates a vector
* `rand(make(matspace, 2)) == rand(make(matspace, make(base_ring(matspace), 2)))`,
  i.e. the "2" is used as a make-argument to specify how to generate random
  elements of the matrix

We choose the first interpretation here, as we are used to interpret
a call like `rand(X, 2)` as creating a vector, `rand(X, 2, 3)` as
creating a matrix and so on. On the other hand, there are almost no
(or not at all) cases in Oscar where an integer is used as
an argument to make.