### PR TITLE
Solve fraction field

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2274,6 +2274,14 @@ function can_solve_with_solution_with_det(M::AbstractAlgebra.MatElem{T}, b::Abst
    return flag, r, p, pivots, x, d
 end
 
+# This can be removed once Nemo implements can_solve_with_solution_with_det
+# It's here now only because Nemo overloads it
+function solve_with_det(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}) where {T <: RingElement}
+   flag, r, p, piv, x, d = can_solve_with_solution_with_det(M, b)
+   !flag && error("System not solvable in solve_with_det")
+   return x, d
+end
+
 function solve_ff(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatElem{T}) where {T <: RingElement}
    m = nrows(M)
    n = ncols(M)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1710,6 +1710,30 @@ end
 end
 
 @testset "Generic.Mat.can_solve..." begin
+   R, x = PolynomialRing(QQ, "x")
+   S = FractionField(R)
+
+   for iter = 1:8
+      m = rand(0:7)
+
+      T = MatrixSpace(R, m, m)
+      U = MatrixSpace(R, m, m)
+
+      M = rand(T, 0:2, -10:10)
+      X2 = rand(U, 0:2, -10:10)
+      b = M*X2
+
+      flag, X = Generic.can_solve_with_solution(M, b)
+
+      @test flag && M*X == b
+
+      b = X2*M
+
+      flag, X = Generic.can_solve_with_solution(M, b; side=:left)
+
+      @test flag && X*M == b
+   end
+ 
    for R in [ZZ, QQ]
       for iter = 1:40
          for dim = 0:5


### PR DESCRIPTION
* Hooks can_solve_with_solution_fflu up to can_solve_with_solution in the case of matrices over a fraction field
* Left side is handled via naive transposes
* Test code for same
* Puts solve_with_det back in, as Nemo overloads this, and crashes if it isn't there (naughty Nemo!)