### PR TITLE
Remove Base.show piracy

### DIFF
--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -38,7 +38,7 @@ function obj_to_latex_string(@nospecialize(x); context = nothing)
   return expr_to_latex_string(canonicalize(expressify(x, context = context)))
 end
 
-function Base.show(io::IO, ::MIME"text/latex", x::RingElement)
+function Base.show(io::IO, ::MIME"text/latex", x::RingElem)
   S = obj_to_latex_string(x)
   print(io, S)
 end


### PR DESCRIPTION
Currently, when I load DifferentialEquations.jl, this causes AbstractAlgebra.jl to be loaded which pirates the method
```julia
 show(::IO, ::MIME{Symbol("text/latex")}, x::Union{AbstractFloat, Integer, Rational})
```
because
```julia
julia> RingElement
Union{RingElem, AbstractFloat, Integer, Rational}
```
I find this quite aggravating sometimes so I hope it can be removed.