### PR TITLE
fix aliasing in matrix algebra constructor

### DIFF
--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -598,7 +598,7 @@ function (a::MatAlgebra{T})(b::S) where {S <: RingElement, T <: RingElement}
          if i != j
             entries[i, j] = zero(R)
          else
-            entries[i, j] = rb
+            entries[i, j] = i == 1 ? rb : deepcopy(rb)
          end
       end
    end

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -27,6 +27,7 @@ end
    f = S(t^2 + 1)
 
    @test isa(f, MatAlgElem)
+   @test !(f[1,1] === f[2,2])
 
    g = S(2)
 


### PR DESCRIPTION
Previously diagonal elements of matrices converted from the base ring were aliased.