### PR TITLE
define Random.Sampler(rng, ::MatSpace) in simple enough cases

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2090,12 +2090,12 @@ function solve_fflu_precomp(p::Generic.Perm, FFLU::MatElem{T}, b::MatElem{T}) wh
                t = mul!(t, t, minus_one)
                y[i, k] = addeq!(y[i, k], t)
             end
-            
+
             flag, y[i, k] = divides(y[i, k], diag[l])
             if !flag
                return false, x
             end
-            
+
             l -= 1
          else
             y[i, k] = R()
@@ -2208,7 +2208,7 @@ function solve_lu_precomp(p::Generic.Perm, LU::MatElem{T}, b::MatrixElem{T}) whe
                t = mul_red!(t, y[j, k], -LU[l, j], false)
                y[i, k] = addeq!(y[i, k], t)
             end
-               
+
             y[i, k] = reduce!(y[i, k])
             y[i, k] = divexact(y[i, k], diag[l])
 
@@ -2453,7 +2453,7 @@ function can_solve_with_solution_interpolation_inner(M::AbstractAlgebra.MatElem{
             if !(e isa ErrorException)
                rethrow(e)
             end
-            return false, rnk, prm, pivots, zero(x), zero(R) 
+            return false, rnk, prm, pivots, zero(x), zero(R)
          end
       end
    end
@@ -2508,7 +2508,7 @@ function solve_rational(M::AbstractAlgebra.MatElem{T}, b::AbstractAlgebra.MatEle
       if !isa(e, ErrorException)
          rethrow(e)
       end
-      !flag && error("No solution in solve_rational") 
+      !flag && error("No solution in solve_rational")
       return solve_ff(M, b)
    end
 end
@@ -5731,6 +5731,12 @@ function RandomExtensions.make(S::AbstractAlgebra.MatSpace, vs...)
    end
 end
 
+# Sampler for a MatSpace not needing arguments (passed via make)
+# this allows to obtain the Sampler in simple cases without having to know about make
+# (when one can do `rand(M)`, one can expect to be able to do `rand(Sampler(rng, M))`)
+Random.Sampler(::Type{RNG}, S::AbstractAlgebra.MatSpace, n::Random.Repetition
+               ) where {RNG<:AbstractRNG} =
+   Random.Sampler(RNG, make(S), n)
 
 function rand(rng::AbstractRNG,
               sp::SamplerTrivial{<:Make2{<:AbstractAlgebra.MatElem,

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -364,6 +364,10 @@ function RandomExtensions.make(S::AbstractAlgebra.MatAlgebra, vs...)
    end
 end
 
+Random.Sampler(::Type{RNG}, S::AbstractAlgebra.MatAlgebra, n::Random.Repetition
+               ) where {RNG<:AbstractRNG} =
+   Random.Sampler(RNG, make(S), n)
+
 function rand(rng::AbstractRNG,
               sp::SamplerTrivial{<:Make2{<:AbstractAlgebra.MatAlgElem,
                                          <:AbstractAlgebra.MatAlgebra}})

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1612,7 +1612,7 @@ end
 
       @test M*x == d*b
    end
- 
+
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
 
@@ -1650,7 +1650,7 @@ end
 
       @test M*x == d*b
    end
- 
+
    R, t = PolynomialRing(AbstractAlgebra.JuliaQQ, "t")
    K, a = NumberField(t^3 + 3t + 1, "a")
    S, y = PolynomialRing(K, "y")
@@ -3393,6 +3393,12 @@ end
 
    M = MatrixSpace(GF(7), 3, 2)
    test_rand(M)
+
+   sp = Random.Sampler(MersenneTwister, M)
+   @test parent(rand(sp)) == M
+   v = rand(sp, 3)
+   @test v isa Vector{elem_type(M)}
+   @test all(x -> parent(x) == M, v)
 
    M = MatrixSpace(F2(), 2, 3)
    test_rand(M)

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -1187,4 +1187,10 @@ end
    M = MatrixAlgebra(GF(7), 2)
 
    test_rand(M)
+
+   sp = Random.Sampler(MersenneTwister, M)
+   @test parent(rand(sp)) == M
+   v = rand(sp, 3)
+   @test v isa Vector{elem_type(M)}
+   @test all(x -> parent(x) == M, v)
 end


### PR DESCRIPTION
This allows to obtain the Sampler in simple cases without having to know about `RandomExtensions.make` (when one can do `rand(M)`, it's natural to expect to be able to do `rand(Sampler(rng, M))` for `M::MatSpace`).