### PR TITLE
Enable Codecov integration, GH action tests on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,12 +8,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', 'nightly']
-        julia-arch: [x64]
-        os: [ubuntu-latest, macOS-latest]
-    
+        julia-version:
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - 'nightly'
+        julia-arch:
+          - x64
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
@@ -34,3 +45,7 @@ jobs:
         uses: julia-actions/julia-buildpkg@master
       - name: "Run tests"
         uses: julia-actions/julia-runtest@master
+      - name: "Process code coverage"
+        uses: julia-actions/julia-processcoverage@v1
+      - name: "Upload coverage data to Codecov"
+        uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # AbstractAlgebra
 
-[![Build Status](https://travis-ci.com/Nemocas/AbstractAlgebra.jl.svg?branch=master)](https://travis-ci.com/Nemocas/AbstractAlgebra.jl) [![Build status](https://ci.appveyor.com/api/projects/status/1w9ninmoidxkxshp/branch/master?svg=true)](https://ci.appveyor.com/project/thofma/abstractalgebra-jl/branch/master)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://nemocas.github.io/AbstractAlgebra.jl/latest)
+[![Build Status](https://travis-ci.com/Nemocas/AbstractAlgebra.jl.svg?branch=master)](https://travis-ci.com/Nemocas/AbstractAlgebra.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/1w9ninmoidxkxshp/branch/master?svg=true)](https://ci.appveyor.com/project/thofma/abstractalgebra-jl/branch/master)
+[![Build Status](https://github.com/Nemocas/AbstractAlgebra.jl/workflows/Run%20tests/badge.svg)](https://github.com/Nemocas/AbstractAlgebra.jl/actions?query=workflow%3A%22Run%20tests%22+branch%3Amaster)
+[![Codecov](https://codecov.io/github/Nemocas/AbstractAlgebra.jl/coverage.svg?branch=master&token=)](https://codecov.io/gh/Nemocas/AbstractAlgebra.jl)
 
 AbstractAlgebra is a pure Julia package for computational abstract algebra. It grew out of the Nemo project and provides all of the abstract types and generic implementations that Nemo relies on.
 


### PR DESCRIPTION
Also updates badges in README.md, and reformat CI.yml to make future diffs in there clearer.

Preview of updated README with new badges: https://github.com/fingolfin/AbstractAlgebra.jl/blob/mh/coverage/README.md

I would recommend to remove some of the macOS tests, as GitHub offers fewer parallel runners for that, so they hold up processing of the tests for a given PR. E.g. just test on 1.0, 1.5 and nightly. If desired, I can add that to this PR or a future PR.

Also, perhaps consider dropping Travis as that is now heavily rate limited (Nemocas already used up all its credits for December 2020, and they stopped their offer for additional credits to open source software, so there's that). I'd also suggest to drop AppVeyor support, it doesn't seem to add anything compared to the GitHub Action tests on Windows.