### PR TITLE
add iteration for finite fields

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -9,6 +9,8 @@ using Markdown
 
 using InteractiveUtils
 
+using Test # for "interface-conformance" functions
+
 # A list of all symbols external packages should not import from AbstractAlgebra
 import_exclude = [:import_exclude, :QQ, :ZZ,
                   :RealField, :NumberField,
@@ -350,6 +352,7 @@ include("julia/JuliaTypes.jl")
 
 include("algorithms/generic_functions.jl")
 include("algorithms/LaurentPoly.jl")
+include("algorithms/FinField.jl")
 
 ###############################################################################
 #

--- a/src/algorithms/FinField.jl
+++ b/src/algorithms/FinField.jl
@@ -18,7 +18,7 @@ struct FinFieldIterator{F}
 
    function FinFieldIterator(f)
       deg = degree(f)
-      characteristic(f)^deg == order(f) ||
+      BigInt(characteristic(f))^deg == order(f) ||
          throw(ArgumentError("iteration only supported for extension fields over a prime field"))
       basis = [one(f)]
       if deg > 1

--- a/src/algorithms/FinField.jl
+++ b/src/algorithms/FinField.jl
@@ -1,0 +1,66 @@
+###############################################################################
+#
+#   FinField.jl : Generic algorithms for abstract finite fields
+#
+###############################################################################
+
+###############################################################################
+#
+#   Iteration
+#
+###############################################################################
+
+struct FinFieldIterator{F}
+   basis::Vector{F}
+   current::Vector{Int}
+
+   function FinFieldIterator(f)
+      deg = degree(f)
+      basis = [one(f)]
+      if deg > 1
+         a = gen(f) # not defined if deg == 1
+         for d = 2:deg
+            push!(basis, basis[end]*a)
+         end
+      end
+      new{elem_type(f)}(basis, Int[])
+   end
+end
+
+function Base.iterate(f::FinField, st=FinFieldIterator(f))
+   basis, current = st.basis, st.current
+   deg = degree(f)
+   char = Int(characteristic(f)) # we currently support only "small" characteristic
+   elt = zero(f)
+   if isempty(current) # "flag" indicating that this is the first iteration
+      resize!(current, deg)
+      fill!(current, 0)
+   else
+      allzero = true
+      for d=1:deg
+         if allzero
+            current[d] += 1
+            if current[d] == char
+               current[d] = 0
+            else
+               allzero = false
+            end
+         end
+         if !iszero(current[d]) # add! only when necessary
+            elt = add!(elt, elt, current[d]*basis[d])
+         end
+      end
+      allzero && return nothing
+   end
+   elt, st
+end
+
+Base.length(f::FinField) = Int(order(f))
+Base.eltype(f::FinField) = elem_type(f)
+
+function test_iterate(f::FinField)
+   elts = collect(f)
+   @test elts isa Vector{elem_type(f)}
+   @test allunique(elts)
+   elts
+end

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -290,7 +290,7 @@ end
 end
 
 @testset "Julia.GFElem.iteration..." begin
-   for n = [2, 3, 5, 13]
+   for n = [2, 3, 5, 13, 31]
       R = GF(n)
       elts = AbstractAlgebra.test_iterate(R)
       @test elts == R.(0:n-1)

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -288,3 +288,11 @@ end
       @test b2 == 0 || divexact(b1, b2)*b2 == b1
    end
 end
+
+@testset "Julia.GFElem.iteration..." begin
+   for n = [2, 3, 5, 13]
+      R = GF(n)
+      elts = AbstractAlgebra.test_iterate(R)
+      @test elts == R.(0:n-1)
+   end
+end


### PR DESCRIPTION
This adds iteration for finite fields:
1. but tests only AA fields (of degree 1), should we consider adding `Nemo` as a test dependency to test generic algorithms more thoroughly?
2. the code is put under "src/algorithms/FinField.jl" as I did for Laurent polynomials, with the idea of separating generic algorithms from algebraic structures provided by AA (I understood this was a desired feature and I still wish to untangle the code in AA in this direction);
3. I added a `test_iteration` function in the "src/" directory, to make it easier to test the functionality from other repositories; a similar function `test_rand` could be moved in the "src/" directory away from the "runtests.jl" file to avoid the duplication that I committed in AA and `Nemo`; this means adding `using Test` in "src/AbstractAlgebra.jl", but this should be basically free as `Test` is compiled in Julia's system image;
4. more efficient specialized implemention of iteration would probably be possible for `Nemo`'s finite fields.

Points 2. and 3. could match what has been referred to as "innovations", and I'm fine to revert these.