### PR TITLE
Fix some inference issues for module code

### DIFF
--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -88,11 +88,11 @@ function show(io::IO, a::FreeModuleElem)
    print(io, "(")
    M = parent(a)
    for i = 1:rank(M) - 1
-      print(IOContext(io, :compact => true), a.v[1, i])
+      print(IOContext(io, :compact => true), _matrix(a)[1, i])
       print(io, ", ")
    end
    if rank(M) > 0
-      print(IOContext(io, :compact => true), a.v[1, rank(M)])
+      print(IOContext(io, :compact => true), _matrix(a)[1, rank(M)])
    end
    print(io, ")")
 end

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -172,7 +172,7 @@ function preimage(f::Map(AbstractAlgebra.FPModuleHomomorphism), v::AbstractAlgeb
    q = length(trels)
    m = nrows(M)
    n = ncols(M)
-   ncols(v.v) != n && error("Incompatible element")
+   ncols(_matrix(v)) != n && error("Incompatible element")
    if m == 0 || n == 0
        return D(zero_matrix(R, 1, m))
    else
@@ -189,7 +189,7 @@ function preimage(f::Map(AbstractAlgebra.FPModuleHomomorphism), v::AbstractAlgeb
          end
       end
       # Find left inverse of mat
-      x = solve_left(matr, v.v)
+      x = solve_left(matr, _matrix(v))
       if q != 0
          x = matrix(R, 1, m, T[x[1, i] for i in 1:m])
       end
@@ -231,7 +231,7 @@ function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T}, M2::AbstractAlgebra
 end
 
 function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T}, M2::AbstractAlgebra.FPModule{T}, v::Array{S, 1}) where {T <: RingElement, S<:AbstractAlgebra.FPModuleElem{T}}
-  return ModuleHomomorphism(M1, M2, vcat([x.v for x = v]...))
+   return ModuleHomomorphism(M1, M2, vcat([_matrix(x) for x = v]...))
 end
 
 @doc Markdown.doc"""


### PR DESCRIPTION
Unfortunately the whole module code has poor type inference, mainly because of
https://github.com/Nemocas/AbstractAlgebra.jl/blob/475bd212ac7b6fa757448bc298876c3acf00c872/src/generic/GenericTypes.jl#L1143
This makes the compiler crawl if this code is used in some non-trivial examples (see for example https://github.com/thofma/Hecke.jl/issues/111)

This is a quick fix for `sub` for @martinra, but does not solve the underlying issue.

I think it would be best if these fields were properly typed using concrete types or if the access was via a getter function with type assert. What do you think @wbhart?