### PR TITLE
Deploy documentation to website using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,3 +49,28 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         uses: codecov/codecov-action@v1
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
... this was lost with the removal of Travis (resp. with Travis stopping to work).

However, for the final step (the actual deployment) to work, someone with admin rights for this repo may have to set a `DOCUMENTER_KEY`. To generate one, you can do this:
```julia
julia> using DocumenterTools, AbstractAlgebra
julia> DocumenterTools.genkeys(AbstractAlgebra)
```
Then go to "Settings" -> "Deploy Keys" (should be something like <https://github.com/Nemocas/AbstractAlgebra.jl/settings/keys>) and add it there.
