### PR TITLE
Fixes for caching

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -654,12 +654,12 @@ end
 @doc (@doc Generic.LaurentPolynomialRing)
 LaurentPolynomialRing(R::Ring, s::AbstractString) = Generic.LaurentPolynomialRing(R, s)
 
-function MatrixSpace(R::Ring, r::Int, c::Int, cached::Bool = true)
-   Generic.MatrixSpace(R, r, c, cached)
+function MatrixSpace(R::Ring, r::Int, c::Int; cached::Bool = true)
+   Generic.MatrixSpace(R, r, c; cached = cached)
 end
 
-function MatrixAlgebra(R::Ring, n::Int, cached::Bool = true)
-   Generic.MatrixAlgebra(R, n, cached)
+function MatrixAlgebra(R::Ring, n::Int; cached::Bool = true)
+   Generic.MatrixAlgebra(R, n, cached = cached)
 end
 
 function FractionField(R::Ring; cached=true)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -13,3 +13,9 @@
 @deprecate rref(a::MatrixElem{<:RingElement}) rref_rational(a)
 
 @deprecate rref!(a::MatrixElem{<:RingElement}) rref_rational!(a)
+
+# Deprecated in 0.12.*
+
+@deprecate MatrixSpace(R::Ring, n::Int, m::Int, cached::Bool) MatrixSpace(R, n, m, cached = cached)
+
+@deprecate MatrixAlgebra(R::Ring, n::Int, cached::Bool) MatrixAlgebra(R, n, cached = cached)

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -952,7 +952,7 @@ mutable struct MatAlgebra{T <: RingElement} <: AbstractAlgebra.MatAlgebra{T}
    base_ring::Ring
 
    function MatAlgebra{T}(R::Ring, n::Int, cached::Bool = true) where T <: RingElement
-      if haskey(MatAlgDict, (R, n))
+      if cached && haskey(MatAlgDict, (R, n))
          return MatAlgDict[R, n]::MatAlgebra{T}
       else
          z = new{T}(n, R)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -6051,14 +6051,14 @@ diagonal_matrix(x::RingElement, m::Int) = diagonal_matrix(x, m, m)
 ###############################################################################
 
 @doc Markdown.doc"""
-    MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int, cached::Bool = true)
+    MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int; cached::Bool = true)
 
 Return parent object corresponding to the space of $r\times c$ matrices over
 the ring $R$. If `cached == true` (the default), the returned parent object
 is cached so that it can returned by future calls to the constructor with the
 same dimensions and base ring.
 """
-function MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int, cached::Bool = true)
+function MatrixSpace(R::AbstractAlgebra.Ring, r::Int, c::Int; cached::Bool = true)
    T = elem_type(R)
    return MatSpace{T}(R, r, c, cached)
 end

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -651,7 +651,7 @@ the ring $R$. If `cached == true` (the default), the returned parent object
 is cached so that it can returned by future calls to the constructor with the
 same degree and base ring.
 """
-function MatrixAlgebra(R::AbstractAlgebra.Ring, n::Int, cached::Bool = true)
+function MatrixAlgebra(R::AbstractAlgebra.Ring, n::Int; cached::Bool = true)
    T = elem_type(R)
    return MatAlgebra{T}(R, n, cached)
 end

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -116,7 +116,11 @@ end
 
 @testset "Generic.Mat.constructors..." begin
    R, t = PolynomialRing(QQ, "t")
+
    S = MatrixSpace(R, 3, 3)
+
+   @test MatrixSpace(R, 3, 3, cached = false) !== MatrixSpace(R, 3, 3, cached = false)
+   @test MatrixSpace(R, 3, 3, cached = true) === MatrixSpace(R, 3, 3, cached = true)
 
    @test elem_type(S) == Generic.MatSpaceElem{elem_type(R)}
    @test elem_type(Generic.MatSpace{elem_type(R)}) == Generic.MatSpaceElem{elem_type(R)}

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -18,6 +18,9 @@ end
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
+   @test MatrixAlgebra(R, 3, cached = false) !== MatrixAlgebra(R, 3, cached = false)
+   @test MatrixAlgebra(R, 3, cached = true) === MatrixAlgebra(R, 3, cached = true)
+
    @test elem_type(S) == Generic.MatAlgElem{elem_type(R)}
    @test elem_type(Generic.MatAlgebra{elem_type(R)}) == Generic.MatAlgElem{elem_type(R)}
    @test parent_type(Generic.MatAlgElem{elem_type(R)}) == Generic.MatAlgebra{elem_type(R)}


### PR DESCRIPTION
- Make it a keyword for `MatrixSpace` and `MatrixAlgebra` (It is already a keyword argument for the matrix spaces and matrix algebras defined in Nemo.)
- Fix the caching for `Generic.MatAlg`

