### PR TITLE
fix part of #535, deduplicate divexact docstrings

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -85,7 +85,7 @@ end
 """
     divexact(x, y)
 
-Return the exact quotient of `x` by `y`, i.e. an element
+Return an exact quotient of `x` by `y`, i.e. an element
 `z` such that `x == yz`; when `x` and `y` do not belong to the same ring,
 they are first coerced into a common ring.
 If no exact division is possible, an exception is raised.

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -85,7 +85,7 @@ end
 """
     divexact(x, y)
 
-Return the exact division of `x` by `y`, i.e. an element
+Return the exact quotient of `x` by `y`, i.e. an element
 `z` such that `x == yz`; when `x` and `y` do not belong to the same ring,
 they are first coerced into a common ring.
 If no exact division is possible, an exception is raised.

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -81,6 +81,17 @@ end
 
 *(x::RingElement, y::RingElem) = parent(y)(x)*y
 
+
+"""
+    divexact(x, y)
+
+Return the exact division of `x` by `y`, i.e. an element
+`z` such that `x == yz`; when `x` and `y` do not belong to the same ring,
+they are first coerced into a common ring.
+If no exact division is possible, an exception is raised.
+"""
+function divexact end
+
 function divexact(x::S, y::T) where {S <: RingElem, T <: RingElem}
    if S == promote_rule(S, T)
       divexact(x, parent(x)(y))

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -634,11 +634,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
-
-Return $x/y$.
-"""
 function divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
    check_parent(x, y)
    iszero(y) && throw(DivideError())
@@ -678,11 +673,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.AbsSeriesElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::AbstractAlgebra.AbsSeriesElem, y::Union{Integer, Rational, AbstractFloat})
    y == 0 && throw(DivideError())
    lenx = length(x)
@@ -695,11 +685,6 @@ function divexact(x::AbstractAlgebra.AbsSeriesElem, y::Union{Integer, Rational, 
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::T) where {T <: RingElem}
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::AbstractAlgebra.AbsSeriesElem{T}, y::T) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    lenx = length(x)

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -632,11 +632,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a/b$.
-"""
 function divexact(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
    n1 = numerator(a, false)
@@ -687,11 +682,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a/b$.
-"""
 function divexact(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    b == 0 && throw(DivideError())
    c = base_ring(a)(b)
@@ -701,11 +691,6 @@ function divexact(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, Abstr
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    divexact(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
-
-Return $a/b$.
-"""
 function divexact(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
    iszero(b) && throw(DivideError())
    c = base_ring(b)(a)
@@ -715,11 +700,6 @@ function divexact(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra
    return parent(b)(n, d)
 end
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-
-Return $a/b$.
-"""
 function divexact(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    iszero(b) && throw(DivideError())
    g = gcd(numerator(a, false), b)
@@ -728,11 +708,6 @@ function divexact(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    divexact(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a/b$.
-"""
 function divexact(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    iszero(b) && throw(DivideError())
    g = gcd(numerator(b, false), a)

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1122,11 +1122,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::Generic.LaurentSeriesElem{T}, y::Generic.LaurentSeriesElem{T}) where {T <: RingElement}
-
-Return $x/y$.
-"""
 function divexact(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: RingElement}
    check_parent(x, y)
    iszero(y) && throw(DivideError())
@@ -1171,11 +1166,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::Generic.LaurentSeriesElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::LaurentSeriesElem, y::Union{Integer, Rational, AbstractFloat})
    y == 0 && throw(DivideError())
    lenx = pol_length(x)
@@ -1190,11 +1180,6 @@ function divexact(x::LaurentSeriesElem, y::Union{Integer, Rational, AbstractFloa
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(x::Generic.LaurentSeriesElem{T}, y::T) where {T <: RingElem}
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::LaurentSeriesElem{T}, y::T) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    lenx = pol_length(x)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -973,12 +973,6 @@ otherwise return `false`.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::Generic.MatrixElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $x/y$, i.e. the matrix where each of the entries has been divided by
-$y$. Each division is expected to be exact.
-"""
 function divexact(x::MatrixElem, y::Union{Integer, Rational, AbstractFloat})
    z = similar(x)
    for i = 1:nrows(x)
@@ -989,12 +983,6 @@ function divexact(x::MatrixElem, y::Union{Integer, Rational, AbstractFloat})
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(x::Generic.MatrixElem{T}, y::T) where {T <: RingElem}
-
-Return $x/y$, i.e. the matrix where each of the entries has been divided by
-$y$. Each division is expected to be exact.
-"""
 function divexact(x::MatrixElem{T}, y::T) where {T <: RingElem}
    z = similar(x)
    for i = 1:nrows(x)

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1119,11 +1119,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-
-Return $f/g$ where the quotient is expected to be exact.
-"""
 function divexact(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    check_parent(f, g)
    iszero(g) && throw(DivideError())
@@ -1157,11 +1152,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem}
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem}
    iszero(b) && throw(DivideError())
    z = parent(a)()
@@ -1173,11 +1163,6 @@ function divexact(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.PolyElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(a::AbstractAlgebra.PolyElem, b::Union{Integer, Rational, AbstractFloat})
    iszero(b) && throw(DivideError())
    z = parent(a)()

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -480,20 +480,10 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::Generic.PuiseuxSeriesElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(x::PuiseuxSeriesElem, y::Union{Integer, Rational, AbstractFloat})
    return parent(x)(divexact(x.data, y), x.scale)
 end
 
-@doc Markdown.doc"""
-    divexact(x::Generic.PuiseuxSeriesElem{T}, y::T) where {T <: RingElem}
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(x::PuiseuxSeriesElem{T}, y::T) where {T <: RingElem}
    return parent(x)(divexact(x.data, y), x.scale)
 end

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -873,11 +873,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
-
-Return $x/y$.
-"""
 function divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    check_parent(x, y)
    iszero(y) && throw(DivideError())
@@ -918,11 +913,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.RelSeriesElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::AbstractAlgebra.RelSeriesElem, y::Union{Integer, Rational, AbstractFloat})
    y == 0 && throw(DivideError())
    lenx = pol_length(x)
@@ -936,11 +926,6 @@ function divexact(x::AbstractAlgebra.RelSeriesElem, y::Union{Integer, Rational, 
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::T) where {T <: RingElem}
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::AbstractAlgebra.RelSeriesElem{T}, y::T) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    lenx = pol_length(x)

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -455,11 +455,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
    check_parent(a, b)
    fl, q = divides(a, b)

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -459,11 +459,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
-
-Return $a/b$ where the quotient is expected to be exact.
-"""
 function divexact(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
    check_parent(a, b)
    fl, q = divides(a, b)


### PR DESCRIPTION
This does not try to unify the implementation notes found in the documention (e.g. in ["required interace" for rings](https://nemocas.github.io/AbstractAlgebra.jl/latest/rings/#Exact-division)) with the only remaining docstring.

The deleted docstrings were also not referred to from the documentation, so no change was necessary there.

cc. @fingolfin