### PR TITLE
add linear indexing for matrices which have only one row or column

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -369,6 +369,17 @@ canonical_unit(a::MatrixElem) = canonical_unit(a[1, 1])
 #
 ###############################################################################
 
+# linear indexing for row- or column- vectors
+Base.@propagate_inbounds function getindex(M::MatElem, x::Integer)
+   if nrows(M) == 1
+      M[1, x]
+   elseif ncols(M) == 1
+      M[x, 1]
+   else
+      throw(ArgumentError("linear indexing not supported for non-vector matrices"))
+   end
+end
+
 @doc Markdown.doc"""
     Base.getindex(M::AbstractAlgebra.MatElem, rows, cols)
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -558,6 +558,29 @@ end
    @test size(A[:, :]) == (0, 0)
    @test_throws BoundsError A[2:3, 1:10]
 
+   function test_linear_indexing(A)
+      nr, nc = size(A)
+      if nr == 1
+         c = rand(1:nc)
+         @test A[c] == A[1, c]
+      elseif nc == 1
+         r = rand(1:nr)
+         @test A[r] == A[r, 1]
+      elseif length(A) >= 1
+         @test_throws ArgumentError A[1]
+      end
+   end
+
+   for (_, (R, rand_params)) in RINGS
+      len = rand(1:9)
+      A = matrix(R, 1, len, rand(make(R, rand_params...), len))
+      test_linear_indexing(A)
+      A = matrix(R, len, 1, rand(make(R, rand_params...), len))
+      test_linear_indexing(A)
+      A = matrix(R, 2, len, rand(make(R, rand_params...), 2*len))
+      test_linear_indexing(A)
+   end
+
    # Exact ring
    R = ZZ
    S = MatrixSpace(R, rand(1:9), rand(1:9))
@@ -573,6 +596,8 @@ end
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
+
+   test_linear_indexing(A)
 
    # Exact field
    R = GF(7)
@@ -590,6 +615,8 @@ end
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
 
+   test_linear_indexing(A)
+
    # Inexact ring
    R = RealField["t"][1]
    S = MatrixSpace(R, rand(1:9), rand(1:9))
@@ -605,6 +632,8 @@ end
 
    rows, cols = randsubseq.(axes(A), rand(2))
    @test A[rows, cols] == matrix(R, A.entries[rows, cols])
+
+   test_linear_indexing(A)
 
    # Inexact field
    R = RealField


### PR DESCRIPTION
As we currently don't handle multiplication between matrices and vector spaces elements (#572), it can be convenient to use AA matrices as row- or column vecors (`ncols(M) == 1` or `nrows(M) == 1`). But indexing into these vectors still requires providing two indices, which is annoying. There was quite some controversy in #540 on whether AA matrices should support so-called "linear indexing", so this feature was removed from this PR. But linear indexing into "1-dim" matrices (vectors) will likely not meet the same resistance. C.f. also this [comment (if I understood it correctly)](https://github.com/Nemocas/AbstractAlgebra.jl/pull/540#issuecomment-605653519):

> However, it is incredible useful of 1-dim matrices...

and in [the next comment](https://github.com/Nemocas/AbstractAlgebra.jl/pull/540#issuecomment-605666838):

> 1-dim is important as there it does not matter if I do row or column major...