### PR TITLE
Add cdot for printing * with spaces

### DIFF
--- a/src/Factor.jl
+++ b/src/Factor.jl
@@ -92,7 +92,7 @@ end
 ################################################################################
 
 function expressify(@nospecialize(a::Fac); context = nothing)
-   prod = Expr(:call, :*)
+   prod = Expr(:call, :cdot)
    if isdefined(a, :unit)
       push!(prod.args, expressify(a.unit, context = context))
    else

--- a/test/Factor-test.jl
+++ b/test/Factor-test.jl
@@ -7,7 +7,13 @@ end
 @testset "Fac.printing..." begin
    f = Fac(-1, Dict{Int, Int}(2 => 3, 3 => 1))
 
-   @test string(f) == "-2^3*3" || string(f) == "-3*2^3"
+   @test string(f) == "-1 * 2^3 * 3" || string(f) == "-1 * 3 * 2^3"
 
    @test string(Fac{BigInt}()) isa String
+
+   R, (x, y) = PolynomialRing(ZZ, ["x", "y"])
+   f = Fac(x, Dict(x*y => 1, x + y => 1))
+
+   @test string(f) == "x * (x + y) * (x*y)" ||
+         string(f) == "x * (x*y) * (x + y)"
 end

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -74,6 +74,9 @@
 
    @test canonical_string(:(x^((-1)//2))) == "x^(-1//2)"
 
+   @test canonical_string(:(cdot(cdot(-a,b),cdot(c,d)))) == "(-a * b) * (c * d)"
+
+
    @test canonical_string(:([a b; c d])) == "[a b; c d]"
    @test canonical_string(:(if a; b; end;)) isa String
    @test canonical_string(1.2) isa String
@@ -111,6 +114,10 @@
                   "-\\frac{a}{b} c + d \\frac{e}{f} g^{h} - \\frac{i j}{k^{l}}"
 
    @test latex_string(:(x^((-1)//2))) == "x^{-\\frac{1}{2}}"
+
+   @test latex_string(:(cdot(cdot(-a,b),cdot(c,d)))) ==
+             "\\left(-a \\cdot b\\right) \\cdot \\left(c \\cdot d\\right)"
+
    @test latex_string(:(2*α^2-1*α+1)) == "2 \\alpha^{2} - \\alpha + 1"
 
    @test latex_string(:([a b; c d])) == "[a b; c d]"

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -115,6 +115,14 @@
 
    @test latex_string(:(x^((-1)//2))) == "x^{-\\frac{1}{2}}"
 
+   # / has same precedence as * in julia
+   @test latex_string(:(x^(-a*b/c))) == "x^{-\\frac{a b}{c}}"
+   # // has higher precedence in julia
+   @test latex_string(:(x^(-a*b//c))) == "x^{-a \\frac{b}{c}}"
+
+   @test latex_string(:((-a*b/c)^x)) == "\\left(-\\frac{a b}{c}\\right)^{x}"
+   @test latex_string(:((a*b/c)^x)) == "\\left(\\frac{a b}{c}\\right)^{x}"
+
    @test latex_string(:(cdot(cdot(-a,b),cdot(c,d)))) ==
              "\\left(-a \\cdot b\\right) \\cdot \\left(c \\cdot d\\right)"
 


### PR DESCRIPTION
It is probably desired to restore the printing of the spaces around the "*"  in Fac{T}.