### PR TITLE
use one(::SymmetricGroup) instead of (G::SymmetricGroup)()

### DIFF
--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -5,13 +5,13 @@ DocTestSetup = quote
 end
 ```
 
-# Permutations and Permutation groups
+# Permutations and Symmetric groups
 
 AbstractAlgebra.jl provides rudimentary native support for permutation groups (implemented in `src/generic/PermGroups.jl`). All functionality of permutations is accesible in the `Generic` submodule.
 
-Permutations are represented internally via vector of integers, wrapped in type `Perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Permutation groups are singleton parent objects of type `SymmetricGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
+Permutations are represented internally via vector of integers, wrapped in type `Perm{T}`, where `T<:Integer` carries the information on the type of elements of a permutation. Symmetric groups are singleton parent objects of type `SymmetricGroup{T}` and are used mostly to store the length of a permutation, since it is not included in the permutation type.
 
-Permutation groups are created using the `SymmetricGroup` (inner) constructor.
+Symmetric groups are created using the `SymmetricGroup` (inner) constructor.
 
 Both `SymmetricGroup` and `Perm` and can be parametrized by any type `T<:Integer` .
 By default the parameter is the `Int`-type native to the systems architecture.
@@ -63,7 +63,7 @@ julia> H = SymmetricGroup(UInt16(5)); r = H([2,3,1,5,4])
 julia> typeof(r)
 Perm{UInt16}
 
-julia> H()
+julia> one(H)
 ()
 ```
 
@@ -115,7 +115,7 @@ Given the parent object `G` for a permutation group, the following coercion func
 Developers provide these by overloading the permutation group parent objects.
 
 ```julia
-G()
+one(G)
 ```
 
 Return the identity permutation.
@@ -202,13 +202,6 @@ The following coercions are available for `G::SymmetricGroup` parent objects.
 Each of the methods perform basic sanity checks on the input which can be switched off by the second argument.
 
 **Examples**
-
-```jldoctest
-julia> SymmetricGroup(4)()
-()
-```
-> Return the identity element of `G`.
-
 
 ```julia
 (G::SymmetricGroup)(::AbstractVector{<:Integer}[, check=true])

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -189,11 +189,11 @@ julia> @time dim(YoungTableau(λ))
 julia> G = SymmetricGroup(sum(λ))
 Full symmetric group over 78 elements
 
-julia> @time character(λ, G())
+julia> @time character(λ, one(G))
  24.154105 seconds (58.13 M allocations: 3.909 GiB, 42.84% gc time)
 9079590132732747656880081324531330222983622187548672000
 
-julia> @time character(λ, G())
+julia> @time character(λ, one(G))
   0.001439 seconds (195 allocations: 24.453 KiB)
 9079590132732747656880081324531330222983622187548672000
 ```

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -19,3 +19,8 @@
 @deprecate MatrixSpace(R::Ring, n::Int, m::Int, cached::Bool) MatrixSpace(R, n, m, cached = cached)
 
 @deprecate MatrixAlgebra(R::Ring, n::Int, cached::Bool) MatrixAlgebra(R, n, cached = cached)
+
+function (G::Generic.SymmetricGroup)()
+    Base.depwarn("(::SymmetricGroup)() to get the group identity is deprecated, use one(::SymmetricGroup) instead", :one)
+    return one(G)
+end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1298,7 +1298,7 @@ function lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldEle
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
-   p = P()
+   p = one(P)
    R = base_ring(A)
    U = deepcopy(A)
    L = similar(A, m, m)
@@ -1454,7 +1454,7 @@ function fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingEl
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
-   p = P()
+   p = one(P)
    R = base_ring(A)
    U = deepcopy(A)
    L = similar(A, m, m)
@@ -1502,7 +1502,7 @@ function rref_rational!(A::MatrixElem{T}) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    R = base_ring(A)
-   P = SymmetricGroup(m)()
+   P = one(SymmetricGroup(m))
    rank, d = fflu!(P, A)
    for i = rank + 1:m
       for j = 1:n
@@ -1572,7 +1572,7 @@ function rref!(A::MatrixElem{T}) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    R = base_ring(A)
-   P = SymmetricGroup(m)()
+   P = one(SymmetricGroup(m))
    rnk = lu!(P, A)
    if rnk == 0
       return 0
@@ -1868,7 +1868,7 @@ function det_fflu(M::MatrixElem{T}) where {T <: RingElement}
       return base_ring(M)()
    end
    A = deepcopy(M)
-   P = SymmetricGroup(n)()
+   P = one(SymmetricGroup(n))
    r, d = fflu!(P, A)
    return r < n ? base_ring(M)() : (parity(P) == 0 ? d : -d)
 end
@@ -2020,7 +2020,7 @@ function rank(M::MatrixElem{T}) where {T <: RingElement}
       return 0
    end
    A = deepcopy(M)
-   P = SymmetricGroup(n)()
+   P = one(SymmetricGroup(n))
    r, d = fflu!(P, A)
    return r
 end
@@ -2036,7 +2036,7 @@ function rank(M::MatrixElem{T}) where {T <: FieldElement}
       return 0
    end
    A = deepcopy(M)
-   P = SymmetricGroup(n)()
+   P = one(SymmetricGroup(n))
    return lu!(P, A)
 end
 
@@ -2060,7 +2060,7 @@ function can_solve_with_solution_fflu(A::MatElem{T}, b::MatElem{T}) where {T <: 
    base_ring(A) != base_ring(b) && error("Base rings don't match in can_solve_with_solution_fflu")
    nrows(A) != nrows(b) && error("Dimensions don't match in can_solve_with_solution_fflu")
    FFLU = deepcopy(A)
-   p = SymmetricGroup(nrows(A))()
+   p = one(SymmetricGroup(nrows(A)))
    rank, d = fflu!(p, FFLU)
    flag, y = solve_fflu_precomp(p, FFLU, b)
    n = nrows(A)
@@ -2186,7 +2186,7 @@ function can_solve_with_solution_lu(A::MatElem{T}, b::MatElem{T}) where {T <: Fi
    end
 
    LU = deepcopy(A)
-   p = SymmetricGroup(nrows(A))()
+   p = one(SymmetricGroup(nrows(A)))
    rank = lu!(p, LU)
 
    y = solve_lu_precomp(p, LU, b)
@@ -2299,7 +2299,7 @@ function can_solve_with_solution_with_det(M::AbstractAlgebra.MatElem{T}, b::Abst
    # the) permutation.
    R = base_ring(M)
    FFLU = deepcopy(M)
-   p = SymmetricGroup(nrows(M))()
+   p = one(SymmetricGroup(nrows(M)))
    rank, d = fflu!(p, FFLU)
    pivots = zeros(Int, nrows(M))
    c = 1
@@ -2371,7 +2371,7 @@ function can_solve_with_solution_interpolation_inner(M::AbstractAlgebra.MatElem{
    h = ncols(b)
    c = ncols(M)
    R = base_ring(M)
-   prm = SymmetricGroup(nrows(M))()
+   prm = one(SymmetricGroup(nrows(M)))
    pivots = zeros(Int, nrows(M))
    if m == 0
       return true, 0, prm, pivots, zero_matrix(R, c, h), one(R)

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -344,19 +344,19 @@ function Base.show(io::IO, g::Perm)
    if _permdisplaystyle.format == :array
       print(io, "[" * join(g.d, ", ") * "]")
    elseif _permdisplaystyle.format == :cycles
-      print(io, _permstring(g, last(displaysize(io))))
+      _print_perm(io, g)
    end
 end
 
-function _permstring(p::Perm, width::Integer)
+function _print_perm(io::IO, p::Perm, width::Integer=last(displaysize(io)))
    @assert width > 3
    if isone(p)
-      return "()"
+      return print(io, "()")
    else
       res = String[]
       cum_length = 0
       for c in cycles(p)
-         length(c) == 1 && continue            
+         length(c) == 1 && continue
          push!(res, join(c, ","))
          cum_length += 2length(c)+1
          if cum_length > width
@@ -365,9 +365,9 @@ function _permstring(p::Perm, width::Integer)
       end
       out = "("*join(res, ")(")*")"
       if length(out) > width
-         return out[1:width-3]*" … "
+         print(io, out[1:width-3]*" … ")
       else
-         return out
+         print(io, out)
       end
    end
 end

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -353,21 +353,19 @@ function _print_perm(io::IO, p::Perm, width::Integer=last(displaysize(io)))
    if isone(p)
       return print(io, "()")
    else
-      res = String[]
       cum_length = 0
       for c in cycles(p)
          length(c) == 1 && continue
-         push!(res, join(c, ","))
-         cum_length += 2length(c)+1
-         if cum_length > width
+         cyc = join(c, ",")
+
+         if width - cum_length >= length(cyc)+2
+            print(io, "(", cyc, ")")
+            cum_length += length(cyc)+2
+         else
+            available = width - cum_length - 3
+            print(io, "(", SubString(cyc, 1, available), " …")
             break
          end
-      end
-      out = "("*join(res, ")(")*")"
-      if length(out) > width
-         print(io, out[1:width-3]*" … ")
-      else
-         print(io, out)
       end
    end
 end

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -272,7 +272,7 @@ julia> permtype(g)
  2
  1
 
-julia> G = SymmetricGroup(5); e = parent(g)()
+julia> e = one(g)
 ()
 
 julia> permtype(e)
@@ -285,7 +285,7 @@ julia> permtype(e)
  1
 ```
 """
-permtype(g::Perm) = sort(diff(cycles(g).cptrs), rev=true)
+permtype(g::Perm) = sort!(diff(cycles(g).cptrs), rev=true)
 
 ###############################################################################
 #
@@ -340,15 +340,34 @@ function setpermstyle(format::Symbol)
    return format
 end
 
-function show(io::IO, g::Perm)
+function Base.show(io::IO, g::Perm)
    if _permdisplaystyle.format == :array
       print(io, "[" * join(g.d, ", ") * "]")
    elseif _permdisplaystyle.format == :cycles
-      cd = cycles(g)
-      if g == parent(g)()
-         print(io, "()")
+      print(io, _permstring(g, last(displaysize(io))))
+   end
+end
+
+function _permstring(p::Perm, width::Integer)
+   @assert width > 3
+   if isone(p)
+      return "()"
+   else
+      res = String[]
+      cum_length = 0
+      for c in cycles(p)
+         length(c) == 1 && continue            
+         push!(res, join(c, ","))
+         cum_length += 2length(c)+1
+         if cum_length > width
+            break
+         end
+      end
+      out = "("*join(res, ")(")*")"
+      if length(out) > width
+         return out[1:width-3]*" … "
       else
-         print(io, join(["("*join(c, ",")*")" for c in cd if length(c)>1],""))
+         return out
       end
    end
 end
@@ -757,7 +776,7 @@ function emb(G::SymmetricGroup, V::Vector{Int}, check::Bool=true)
       @assert length(Base.Set(V)) == length(V)
       @assert all(V .<= G.n)
    end
-   return p -> Generic.emb!(G(), p, V)
+   return p -> Generic.emb!(one(G), p, V)
 end
 
 @doc Markdown.doc"""
@@ -778,7 +797,8 @@ function perm(a::AbstractVector{<:Integer}, check::Bool = true)
   return Perm(a, check)
 end
 
-(G::SymmetricGroup)() = Perm(G.n)
+one(G::SymmetricGroup) = Perm(G.n)
+one(g::Perm) = one(parent(g))
 
 function (G::SymmetricGroup{T})(a::AbstractVector{S}, check::Bool=true) where {S, T}
    if check
@@ -948,7 +968,7 @@ Full symmetric group over 4 elements
 julia> chi = character(Partition([3,1])); # character of the regular representation
 
 
-julia> chi(G())
+julia> chi(one(G))
 3
 
 julia> chi(perm"(1,3)(2,4)")

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -26,15 +26,15 @@ end
    @test G0 isa Generic.SymmetricGroup{T}
 
    p = Perm(T[])
-   @test p == G0()
+   @test p == one(G0)
    @test parent(p) == G0
 
    G = SymmetricGroup(T(10))
    @test elem_type(G) == Generic.Perm{T}
 
-   @test G() isa GroupElem
-   @test G() isa Generic.Perm{T}
-   a = G()
+   @test one(G) isa GroupElem
+   @test one(G) isa Generic.Perm{T}
+   a = one(G)
    @test parent_type(typeof(a)) == Generic.SymmetricGroup{T}
    @test parent(a) == G
 
@@ -107,8 +107,8 @@ end
 
    for T in IntTypes
       G = SymmetricGroup(T(5))
-      @test G("()") == G()
-      @test G("()()") == G()
+      @test G("()") == one(G)
+      @test G("()()") == one(G)
       @test G("(1)(2,3)") == Perm(T[1,3,2,4,5])
       @test G("(2,3)") == G("(1)(2,3)")
       @test G("(3,2)") == G("(2,3)")
@@ -146,7 +146,7 @@ end
 @testset "Perm.basic_manipulation ($T)..." for T in IntTypes
    G = SymmetricGroup(T(10))
 
-   a = G()
+   a = one(G)
    b = deepcopy(a)
    c = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
@@ -176,7 +176,7 @@ end
 
    elts = collect(G)
 
-   @test elts[1] == G()
+   @test elts[1] == one(G)
    @test length(elts) == 720
    @test length(unique(elts)) == 720
    @test length(G) == 720
@@ -191,19 +191,19 @@ end
 
    @test a*b == G(T[3,2,1]) # (1,2)*(1,2,3) == (1,3)
    @test b*a == G(T[1,3,2]) # (1,2,3)*(1,2) == (2,3)
-   @test a*a == G()
-   @test b*b*b == G()
+   @test a*a == one(G)
+   @test b*b*b == one(G)
 
    # (1,2,3)*(2,3,4) == (1,3)(2,4)
    @test Perm(T[2,3,1,4])*Perm(T[1,3,4,2]) == Perm(T[3,4,1,2])
 
-   @test parity(G()) == 0
+   @test parity(one(G)) == 0
    p = parity(a)
    @test p == 1
    cycles(a)
    @test parity(a) == p
 
-   z = G()
+   z = one(G)
 
    for a in G, b in G
       @test parity(a*b) == (parity(b)+parity(a)) % 2
@@ -221,12 +221,12 @@ end
 
    G = SymmetricGroup(T(10))
    p = G(T[9,5,4,7,3,8,2,10,1,6]) # (1,9)(2,5,3,4,7)(6,8,10)
-   @test p^0 == G()
+   @test p^0 == one(G)
    @test p^1 == p
    @test p^-1 == inv(p)
    @test p^5 == p*p*p*p*p
    @test p^-4 == inv(p)*inv(p)*inv(p)*inv(p)
-   @test p^2 * p^-2 == G()
+   @test p^2 * p^-2 == one(G)
 end
 
 @testset "Perm.mixed_binary_ops..." begin
@@ -234,9 +234,9 @@ end
    for T in IntTypes
       H = SymmetricGroup(T(6))
 
-      @test G(H()) == G()
-      @test H(G()) == H()
-      @test G() == H()
+      @test G(one(H)) == one(G)
+      @test H(one(G)) == one(H)
+      @test one(G) == one(H)
       @test rand(G)*rand(H) isa Perm{promote_type(Int, T)}
       @test rand(H)*rand(G) isa Perm{promote_type(Int, T)}
       @test G(rand(H)) isa Perm{Int}
@@ -247,7 +247,7 @@ end
 @testset "Perm.inversion ($T)..." for T in IntTypes
    G = SymmetricGroup(T(10))
 
-   a = G()
+   a = one(G)
    b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
    @test a == inv(a)
@@ -263,11 +263,11 @@ end
    G = SymmetricGroup(T(10))
    a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
-   @test cycles(G()) isa Generic.CycleDec{T}
-   @test collect(cycles(G())) == [T[i] for i in 1:10]
-   @test order(G()) isa BigInt
-   @test order(T, G()) isa promote_type(Int, T)
-   @test order(G()) == 1
+   @test cycles(one(G)) isa Generic.CycleDec{T}
+   @test collect(cycles(one(G))) == [T[i] for i in 1:10]
+   @test order(one(G)) isa BigInt
+   @test order(T, one(G)) isa promote_type(Int, T)
+   @test order(one(G)) == 1
 
    @test collect(cycles(a)) == [T[1,2,3,5,6,7], T[4], T[8,9,10]]
    @test Generic.permtype(a) isa Vector{T}
@@ -281,7 +281,7 @@ end
    @test order(a) isa BigInt
    @test order(T, a) isa promote_type(Int, T)
    @test order(a) == 6
-   @test a^6 == G()
+   @test a^6 == one(G)
 
    p = G([9,5,4,7,3,8,2,10,1,6])
 
@@ -313,7 +313,7 @@ end
       N = T(7)
       G = SymmetricGroup(N)
 
-      @test all(character(p)(G()) == dim(YoungTableau(p)) for p in AllParts(N))
+      @test all(character(p)(one(G)) == dim(YoungTableau(p)) for p in AllParts(N))
 
       N = T(3)
       G = SymmetricGroup(N)
@@ -386,6 +386,6 @@ end
    # test for overflow
 
    p = Partition(collect(10:-1:1))
-   @test character(p, SymmetricGroup(big(55))()) == 44261486084874072183645699204710400
+   @test character(p, one(SymmetricGroup(big(55)))) == 44261486084874072183645699204710400
    @test dim(YoungTableau(p)) == 44261486084874072183645699204710400
 end


### PR DESCRIPTION
to follow group interface of oscar, e.g.
https://github.com/oscar-system/Oscar.jl/blob/ae0a3b0e4daa7fdeff73241b80bbeadc39cfe298/src/Groups/GAPGroups.jl#L189

(@fingolfin, is there a doc with the interface we drafted?)

btw. given that GAP permutations are the permutations of oscar I'd also stop exporting `perm` (why lowercase?) to allow this
https://github.com/oscar-system/Oscar.jl/blob/ae0a3b0e4daa7fdeff73241b80bbeadc39cfe298/src/Groups/GAPGroups.jl#L258
to move on.

Also: given the remarkably small impact of this change, is it really worth keeping here? (all usages inside AA only need the storage vector of a permutation).

@rfourquet @fingolfin @thofma

EDIT: In the meantime I forgot why have I started this:
* added compact printing of perms :)
```julia
julia> p = randperm(100);

julia> Perm(p)
(1,18,54,50,69,80,58,47,81,24,70,16,93,46,31,90,56,5,57,51,99,76,49,3,62,40,10,27,78,14,25,82,53,45,37,13,44,22,87,97,21,3 … 

```