### PR TITLE
Allow more general setindex!(::MatrixElem, ...)

### DIFF
--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -420,6 +420,115 @@ end
    end
 end
 
+@testset "Generic.MatAlg.block_replacement..." begin
+   _test_block_replacement = function(a, b, r, c)
+      rr = r isa Colon ? (1:nrows(a)) : r
+      cc = c isa Colon ? (1:ncols(a)) : c
+      if (b isa Vector)
+         return all([a[i1, j1] == b[i + j - 1] for (i, i1) in enumerate(rr) for (j, j1) in enumerate(cc)])
+      else
+         return all([a[i1, j1] == b[i, j] for (i, i1) in enumerate(rr) for (j, j1) in enumerate(cc)])
+      end
+   end
+
+   S = MatrixAlgebra(ZZ, 9)
+   (r, c) = (rand(1:9), rand(1:9))
+   T = MatrixSpace(ZZ, r, c)
+   a = rand(S, -100:100)
+   b = rand(T, -100:100)
+   startr = rand(1:(9-r+1))
+   endr = startr + r - 1
+   startc = rand(1:(9-c+1))
+   endc = startc + c - 1
+   a[startr:endr, startc:endc] = b
+   @test _test_block_replacement(a, b, startr:endr, startc:endc)
+
+   for i in 1:10
+      n = rand(1:9)
+      m = n
+      S = MatrixAlgebra(ZZ, n)
+      a = rand(S, -100:100)
+      (r, c) = (rand(1:n), rand(1:m))
+      T = MatrixSpace(zz, r, c)
+      b = rand(T, -2:2)
+      startr = rand(1:(n-r+1))
+      endr = startr + r - 1
+      startc = rand(1:(m-c+1))
+      endc = startc + c - 1
+
+      rrs = Int[]
+      for j in 1:rand(1:n)
+         rr = rand(1:n)
+         while (rr in rrs)
+            rr = rand(1:n)
+         end
+         push!(rrs, rr)
+      end
+
+      ccs = Int[]
+      for j in 1:rand(1:m)
+         cc = rand(1:m)
+         while (cc in ccs)
+            cc = rand(1:m)
+         end
+         push!(ccs, cc)
+      end
+
+      for r in [rand(1:n), Colon(), rrs, startr:endr]
+         for c in [rand(1:m), Colon(), ccs, startc:endc]
+            if c isa Int && r isa Int
+               continue
+            end
+            for R in [zz, ZZ]
+               lr = r isa Colon ? nrows(a) : length(r)
+               lc = c isa Colon ? ncols(a) : length(c)
+               T = MatrixSpace(zz, lr, lc)
+               b = rand(T, -2:2)
+               aa = deepcopy(a)
+               a[r, c] = b
+               @test _test_block_replacement(a, b, r, c)
+               bb = Matrix(b)
+               aa[r, c] = bb
+               @test _test_block_replacement(aa, bb, r, c)
+            end
+         end
+      end
+      for r in [rand(1:n)]
+         for c in [rand(1:m), Colon(), ccs, startc:endc]
+            if c isa Int && r isa Int
+               continue
+            end
+            for R in [zz, ZZ]
+               lr = r isa Colon ? nrows(a) : length(r)
+               lc = c isa Colon ? ncols(a) : length(c)
+               T = MatrixSpace(zz, lr, lc)
+               _b = rand(T, -2:2)
+               b = vec(Matrix(_b))
+               a[r, c] = b
+               @test _test_block_replacement(a, b, r, c)
+            end
+         end
+      end
+      for r in [rand(1:n), Colon(), rrs, startr:endr]
+         for c in [rand(1:m)]
+            if c isa Int && r isa Int
+               continue
+            end
+            for R in [zz, ZZ]
+               lr = r isa Colon ? nrows(a) : length(r)
+               lc = c isa Colon ? ncols(a) : length(c)
+               T = MatrixSpace(zz, lr, lc)
+               _b = rand(T, -2:2)
+               b = vec(Matrix(_b))
+               a[r, c] = b
+               @test _test_block_replacement(a, b, r, c)
+            end
+         end
+      end
+
+   end
+end
+
 @testset "Generic.MatAlg.rank..." begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)


### PR DESCRIPTION
This generalizes the `setindex!` function call `A[r, c] = B` for more situations:

1. It allows `A` to be a `MatrixElem`, which means all matrices we have (not sure why it was restricted before).
2. `r` and `c` can be `Vector{Int}, UnitRange{Int}, Int, :`.
3. `B` can be a `MatrixElem`, `Matrix` or `Vector` (in this case the slice must be one-dimensional, that is, `length(r) == 1` or `length(c) == 1`.

For example, one can now just do `z[2, 1:3] = [1,2,3]`.

I had it partially in Hecke, but I think it should live here.

P.S.: There is a chance one could do it more compactly doing some metaprogramming, but I think in this case it is not worth it.