### PR TITLE
make Integers, Rationals and Floats immutable structs

### DIFF
--- a/src/julia/JuliaTypes.jl
+++ b/src/julia/JuliaTypes.jl
@@ -4,19 +4,8 @@
 #
 ###############################################################################
 
-mutable struct Integers{T <: Integer} <: Ring
-   function Integers{T}() where T <: Integer
-      if haskey(IntegersID, T)
-         z = IntegersID[T]::Integers{T}
-      else 
-         z = new{T}()
-         IntegersID[T] = z
-      end
-      return z
-   end
+struct Integers{T <: Integer} <: Ring
 end
-
-const IntegersID = Dict{DataType, Ring}()
 
 ###############################################################################
 #
@@ -24,19 +13,8 @@ const IntegersID = Dict{DataType, Ring}()
 #
 ###############################################################################
 
-mutable struct Rationals{T <: Integer} <: Field
-   function Rationals{T}() where T <: Integer
-      if haskey(RationalsID, T)
-         z = RationalsID[T]::Rationals{T}
-      else 
-         z = new{T}()
-         RationalsID[T] = z
-      end
-      return z
-   end
+struct Rationals{T <: Integer} <: Field
 end
-
-const RationalsID = Dict{DataType, Ring}()
 
 ###############################################################################
 #
@@ -44,20 +22,8 @@ const RationalsID = Dict{DataType, Ring}()
 #
 ###############################################################################
 
-mutable struct Floats{T <: AbstractFloat} <: Field
-   function Floats{T}() where T <: AbstractFloat
-      if haskey(FloatsID, T)
-         z = FloatsID[T]::Floats{T}
-      else 
-         z = new{T}()
-         FloatsID[T] = z
-      end
-      return z
-   end
+struct Floats{T <: AbstractFloat} <: Field
 end
-
-const FloatsID = Dict{DataType, Field}()
-
 
 ###############################################################################
 #
@@ -96,4 +62,3 @@ const RingElement   = Union{RingElem,   Integer, Rational, AbstractFloat}
 const NCRingElement = Union{NCRingElem, Integer, Rational, AbstractFloat}
 
 const FieldElement = Union{FieldElem, Rational, AbstractFloat}
-


### PR DESCRIPTION
Instances of these types are meant to be singleton objects
via the caching mechanism, but as they no fields, the
same can be achieved by making them immutable
(having no fields implies that they are bitstypes and
automatically have the singleton property, like e.g. `nothing`;
this also means that comparison should be at leas as cheap
as comparing pointers like was previously the case when mutable).

Moreover, in a `Distributed` setting, uniqueness of instances
was broken, in particular instances from two process would
compare unequal (an alternative fix for that would be to
define `==`).