### PR TITLE
Enable series inv from Hecke.

### DIFF
--- a/src/generic/Misc/Series.jl
+++ b/src/generic/Misc/Series.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-function inv(a::RelSeriesElem{T}) where T <: FieldElement
+function Base.inv(a::RelSeriesElem{T}) where T <: FieldElement
     @assert valuation(a) == 0
     # x -> x*(2-xa) is the lifting recursion
     x = parent(a)(inv(coeff(a, 0)))


### PR DESCRIPTION
This simply uses the code from Hecke for series inv over a field instead of the existing implementation that was in AbstractAlgebra.

It was missed in the original movement of code from Hecke.