### PR TITLE
Fit

### DIFF
--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -225,7 +225,6 @@ Return the modulus of the coefficients of the given power series.
 modulus(a::AbstractAlgebra.SeriesElem{T}) where {T <: ResElem} = modulus(base_ring(a))
 
 function deepcopy_internal(a::RelSeries{T}, dict::IdDict) where {T <: RingElement}
-   return parent(a)(deepcopy(a.coeffs), pol_length(a), precision(a), valuation(a))
    coeffs = Array{T}(undef, pol_length(a))
    for i = 1:pol_length(a)
       coeffs[i] = deepcopy(polcoeff(a, i - 1))

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -225,6 +225,7 @@ Return the modulus of the coefficients of the given power series.
 modulus(a::AbstractAlgebra.SeriesElem{T}) where {T <: ResElem} = modulus(base_ring(a))
 
 function deepcopy_internal(a::RelSeries{T}, dict::IdDict) where {T <: RingElement}
+   return parent(a)(deepcopy(a.coeffs), pol_length(a), precision(a), valuation(a))
    coeffs = Array{T}(undef, pol_length(a))
    for i = 1:pol_length(a)
       coeffs[i] = deepcopy(polcoeff(a, i - 1))
@@ -1081,10 +1082,11 @@ function fit!(c::RelSeries{T}, n::Int) where {T <: RingElement}
       for i = 1:c.length
          c.coeffs[i] = t[i]
       end
-      for i = pol_length(c) + 1:n
-         c.coeffs[i] = zero(base_ring(c))
-      end
-   end
+    end
+    for i = pol_length(c) + 1:n
+       @assert !isdefined(c.coeffs, i)
+       c.coeffs[i] = zero(base_ring(c))
+    end
    return nothing
 end
 

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1081,11 +1081,11 @@ function fit!(c::RelSeries{T}, n::Int) where {T <: RingElement}
       for i = 1:c.length
          c.coeffs[i] = t[i]
       end
-    end
-    for i = pol_length(c) + 1:n
-       @assert !isdefined(c.coeffs, i)
-       c.coeffs[i] = zero(base_ring(c))
-    end
+   end
+   for i = pol_length(c) + 1:n
+      @assert !isdefined(c.coeffs, i)
+      c.coeffs[i] = zero(base_ring(c))
+   end
    return nothing
 end
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -785,6 +785,16 @@ end
    c = addeq!(c, a)
 
    @test isequal(c, 1 + x + x^2 + x^3 + 2*x^4 + x^5 + x^6 + O(x^7))
+
+   B, x = PolynomialRing(QQ, "x")
+   S, s = PowerSeriesRing(B, 4, "s")
+   a = S([3*x, 2*x, 4*x], 3, 4, 1)
+   b = S([-3*x], 1, 4, 1)
+   addeq!(a, b)
+   b = S([-3*x, 4*x, 5*x], 3, 4, 1)
+   addeq!(a, b)
+   
+   @test isequal(a, -3*x*s + 6*x*s^2 + 9*x*s^3 + O(s^4))
 end
 
 @testset "Generic.RelSeries.special_functions..." begin


### PR DESCRIPTION
"Fixes" issue #759 
changes
```julia
B, x = PolynomialRing(QQ, "x")
S, t = PowerSeriesRing(B, 4, "s")
a = S([3*x, 2*x, 4*x], 3, 4, 1)
b = S([-3*x], 1, 4, 1)
AbstractAlgebra.addeq!(a, b)
b = S([-3*x, 4*x, 5*x], 3, 4, 1)
AbstractAlgebra.addeq!(a, b)
``` 
giving `-3*x*s + 6*x*s^2 + 6*x*s^3 + O(s^4)`
to `-3*x*s + 6*x*s^2 + 9*x*s^3 + O(s^4)`
which is more correct. However, there might be a different more correct fix lurking around.
