### PR TITLE
RelSeries: remove useless "isdefined" test

### DIFF
--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1083,7 +1083,6 @@ function fit!(c::RelSeries{T}, n::Int) where {T <: RingElement}
       end
    end
    for i = pol_length(c) + 1:n
-      @assert !isdefined(c.coeffs, i)
       c.coeffs[i] = zero(base_ring(c))
    end
    return nothing


### PR DESCRIPTION
`isdefined` was presumably used in lieu of `isassigned`, but then the assertion fail in tests.