### PR TITLE
tests: remove vestigial "..." at the end of testset descriptions

### DIFF
--- a/test/Benchmark-test.jl
+++ b/test/Benchmark-test.jl
@@ -1,4 +1,4 @@
-@testset "Benchmark.fateman..." begin
+@testset "Benchmark.fateman" begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
    T, z = PolynomialRing(S, "z")
@@ -11,7 +11,7 @@
    @test length(q) == 21
 end
 
-@testset "Benchmark.pearce..." begin
+@testset "Benchmark.pearce" begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
    T, z = PolynomialRing(S, "z")

--- a/test/Factor-test.jl
+++ b/test/Factor-test.jl
@@ -1,10 +1,10 @@
-@testset "Fac.constructors..." begin
+@testset "Fac.constructors" begin
    f = Fac(-1, Dict{Int, Int}(2 => 3, 3 => 1))
 
    @test -24 == unit(f)*prod([p^e for (p, e) in f])
 end
 
-@testset "Fac.printing..." begin
+@testset "Fac.printing" begin
    f = Fac(-1, Dict{Int, Int}(2 => 3, 3 => 1))
 
    @test string(f) == "-1 * 2^3 * 3" || string(f) == "-1 * 3 * 2^3"

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -1,7 +1,7 @@
 include("generic/MatrixAlgebra-test.jl")
 include("generic/NCPoly-test.jl")
 
-@testset "NCRings.oftype..." begin
+@testset "NCRings.oftype" begin
    F = GF(3)
    Fx, x = PolynomialRing(F, "x")
    z = oftype(x, 3)
@@ -9,7 +9,7 @@ include("generic/NCPoly-test.jl")
    @test parent(z) === Fx
 end
 
-@testset "NCRings.powers..." begin
+@testset "NCRings.powers" begin
    
    # non-commutative rings
    A = MatrixAlgebra(ZZ, rand(1:9))

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -1,4 +1,4 @@
-@testset "PrettyPrinting..." begin
+@testset "PrettyPrinting" begin
 
    function just_string(x)
       return AbstractAlgebra.expr_to_string(x)

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -13,7 +13,7 @@ include("generic/Matrix-test.jl")
 include("generic/MPoly-test.jl")
 include("generic/MPolyFactor-test.jl")
 
-@testset "Generic.Rings.broadcast..." begin
+@testset "Generic.Rings.broadcast" begin
    F = GF(3)
    @test F(2) .* [F(1), F(2)] == [F(2), F(1)]
 end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -16,7 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-@testset "Generic.AbsSeries.constructors..." begin
+@testset "Generic.AbsSeries.constructors" begin
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
 
    S, t = PolynomialRing(QQ, "t")
@@ -80,7 +80,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.AbsSeries.manipulation..." begin
+@testset "Generic.AbsSeries.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x", model=:capped_absolute)
 
@@ -122,7 +122,7 @@ end
    @test modulus(T) == 7
 end
 
-@testset "Generic.AbsSeries.unary_ops..." begin
+@testset "Generic.AbsSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -152,7 +152,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.binary_ops..." begin
+@testset "Generic.AbsSeries.binary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:100
@@ -201,7 +201,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.adhoc_binary_ops..." begin
+@testset "Generic.AbsSeries.adhoc_binary_ops" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -291,7 +291,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.comparison..." begin
+@testset "Generic.AbsSeries.comparison" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -342,7 +342,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.adhoc_comparison..." begin
+@testset "Generic.AbsSeries.adhoc_comparison" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:500
@@ -439,7 +439,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.powering..." begin
+@testset "Generic.AbsSeries.powering" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
 
@@ -492,7 +492,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.shift..." begin
+@testset "Generic.AbsSeries.shift" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -555,7 +555,7 @@ end
    @test_throws DomainError shift_right(f, -rand(2:100))
 end
 
-@testset "Generic.AbsSeries.truncation..." begin
+@testset "Generic.AbsSeries.truncation" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -609,7 +609,7 @@ end
    @test_throws DomainError truncate(f, -rand(2:100))   
 end
 
-@testset "Generic.AbsSeries.inversion..." begin
+@testset "Generic.AbsSeries.inversion" begin
 
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
@@ -646,7 +646,7 @@ end
     end
  end
 
-@testset "Generic.AbsSeries.square_root..." begin
+@testset "Generic.AbsSeries.square_root" begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
     for iter = 1:300
@@ -666,7 +666,7 @@ end
     end
 end
 
-@testset "Generic.AbsSeries.exact_division..." begin
+@testset "Generic.AbsSeries.exact_division" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -717,7 +717,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.adhoc_exact_division..." begin
+@testset "Generic.AbsSeries.adhoc_exact_division" begin
    # Exact field
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)
    for iter = 1:300
@@ -756,7 +756,7 @@ end
    end
 end
 
-@testset "Generic.AbsSeries.special_functions..." begin
+@testset "Generic.AbsSeries.special_functions" begin
    # Exact field
    S, x = PowerSeriesRing(QQ, 10, "x", model=:capped_absolute)
 

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -1,6 +1,6 @@
 using Random
 
-@testset "Generic.DirectSum.constructors..." begin
+@testset "Generic.DirectSum.constructors" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)
@@ -28,7 +28,7 @@ using Random
    @test f == inj[1](gen(F,1)) + inj[2](gen(F, 2))
 end
 
-@testset "Generic.DirectSum.basic_manipulation..." begin
+@testset "Generic.DirectSum.basic_manipulation" begin
 
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -42,7 +42,7 @@ end
    end
 end
 
-@testset "Generic.DirectSum.maps..." begin
+@testset "Generic.DirectSum.maps" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)
@@ -71,7 +71,7 @@ end
 
 end
 
-@testset "Generic.DirectSum.isomorphism..." begin
+@testset "Generic.DirectSum.isomorphism" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          num = rand(1:5)

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.Frac.constructors..." begin
+@testset "Generic.Frac.constructors" begin
    S, x = PolynomialRing(ZZ, "x")
    T = FractionField(S)
 
@@ -49,7 +49,7 @@
    @test !(b in keys(Dict(a => 1)))
 end
 
-@testset "Generic.Frac.printing..." begin
+@testset "Generic.Frac.printing" begin
    S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 
    @test string((x+y)//z) == "(x + y)//z"
@@ -57,14 +57,14 @@ end
 end
 
 
-@testset "Generic.Frac.rand..." begin
+@testset "Generic.Frac.rand" begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
 
    test_rand(K, 0:3, -3:3)
 end
 
-@testset "Generic.Frac.manipulation..." begin
+@testset "Generic.Frac.manipulation" begin
    R = FractionField(ZZ)
    S, x = PolynomialRing(ZZ, "x")
 
@@ -85,13 +85,13 @@ end
    @test characteristic(R) == 0
 end
 
-@testset "Generic.Frac.unary_ops..." begin
+@testset "Generic.Frac.unary_ops" begin
    S, x = PolynomialRing(ZZ, "x")
 
    @test -((x + 1)//(-x^2 + 1)) == 1//(x - 1)
 end
 
-@testset "Generic.Frac.binary_ops..." begin
+@testset "Generic.Frac.binary_ops" begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
 
@@ -107,7 +107,7 @@ end
    end
 end
 
-@testset "Generic.Frac.adhoc_binary..." begin
+@testset "Generic.Frac.adhoc_binary" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (-x + 1)//(2x^2 + 3)
@@ -126,7 +126,7 @@ end
    @test (x + 1)*b == (-x-1)//(x-1)
 end
 
-@testset "Generic.Frac.comparison..." begin
+@testset "Generic.Frac.comparison" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = -((x + 1)//(-x^2 + 1))
@@ -136,7 +136,7 @@ end
    @test isequal(a, 1//(x - 1))
 end
 
-@testset "Generic.Frac.adhoc_comparison..." begin
+@testset "Generic.Frac.adhoc_comparison" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = 1//(x - 1)
@@ -150,7 +150,7 @@ end
    @test 1 == one(S)
 end
 
-@testset "Generic.Frac.powering..." begin
+@testset "Generic.Frac.powering" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1)
@@ -158,7 +158,7 @@ end
    @test a^-12 == x^12-12*x^11+66*x^10-220*x^9+495*x^8-792*x^7+924*x^6-792*x^5+495*x^4-220*x^3+66*x^2-12*x+1
 end
 
-@testset "Generic.Frac.inversion..." begin
+@testset "Generic.Frac.inversion" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1)
@@ -166,7 +166,7 @@ end
    @test inv(a) == -x + 1
 end
 
-@testset "Generic.Frac.exact_division..." begin
+@testset "Generic.Frac.exact_division" begin
    S, x = PolynomialRing(ZZ, "x")
    K = FractionField(S)
 
@@ -188,7 +188,7 @@ end
    end
 end
 
-@testset "Generic.Frac.adhoc_exact_division..." begin
+@testset "Generic.Frac.adhoc_exact_division" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (-x + 1)//(2x^2 + 3)
@@ -203,7 +203,7 @@ end
    @test 5//a == (-10*x^2-15)//(x-1)
 end
 
-@testset "Generic.Frac.divides..." begin
+@testset "Generic.Frac.divides" begin
    R, x = PolynomialRing(ZZ, "x")
    S = FractionField(R)
 
@@ -219,7 +219,7 @@ end
    end
 end
 
-@testset "Generic.Frac.square_root..." begin
+@testset "Generic.Frac.square_root" begin
    R, x = PolynomialRing(QQ, "x")
    S = FractionField(R)
 
@@ -232,7 +232,7 @@ end
    end
 end
 
-@testset "Generic.Frac.gcd..." begin
+@testset "Generic.Frac.gcd" begin
    S, x = PolynomialRing(ZZ, "x")
 
    a = (x + 1)//(-x^2 + 1) - x//(2x + 1)
@@ -241,7 +241,7 @@ end
 end
 
 if @isdefined fmpq
-    @testset "Generic.Frac.remove_valuation..." begin
+    @testset "Generic.Frac.remove_valuation" begin
         a = fmpq(2, 3)
 
         @test remove(a, BigInt(2)) == (1, fmpq(1, 3))
@@ -252,7 +252,7 @@ if @isdefined fmpq
     end
 end
 
-@testset "Generic.Frac.promotion..." begin
+@testset "Generic.Frac.promotion" begin
    S, x = PolynomialRing(QQ, "x")
    F = FractionField(S)
    T = elem_type(F)

--- a/test/generic/FreeModule-test.jl
+++ b/test/generic/FreeModule-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.FreeModule.constructors..." begin
+@testset "Generic.FreeModule.constructors" begin
    R, x = PolynomialRing(ZZ, "x")
    M = FreeModule(R, 5)
 
@@ -17,14 +17,14 @@
    @test isa(F([]), Generic.FreeModuleElem)
 end
 
-@testset "Generic.FreeModule.manipulation..." begin
+@testset "Generic.FreeModule.manipulation" begin
    R, x = PolynomialRing(ZZ, "x")
    M = FreeModule(R, 5)
 
    @test rank(M) == 5
 end
 
-@testset "Generic.FreeModule.unary_ops..." begin
+@testset "Generic.FreeModule.unary_ops" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10
@@ -48,7 +48,7 @@ end
    end
 end
 
-@testset "Generic.FreeModule.binary_ops..." begin
+@testset "Generic.FreeModule.binary_ops" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10
@@ -72,7 +72,7 @@ end
    end
 end
 
-@testset "Generic.FreeModule.adhoc_binary..." begin
+@testset "Generic.FreeModule.adhoc_binary" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter = 1:10

--- a/test/generic/InvariantFactorDecomposition-test.jl
+++ b/test/generic/InvariantFactorDecomposition-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.InvariantFactorDecomposition.constructors..." begin
+@testset "Generic.InvariantFactorDecomposition.constructors" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -16,7 +16,7 @@
    @test isa(m, Generic.SNFModuleElem)
 end
 
-@testset "Generic.InvariantFactorDecomposition.invariant_factors..." begin
+@testset "Generic.InvariantFactorDecomposition.invariant_factors" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -29,7 +29,7 @@ end
    end
 end
 
-@testset "Generic.InvariantFactorDecomposition.isomorphism..." begin
+@testset "Generic.InvariantFactorDecomposition.isomorphism" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -16,7 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-@testset "Generic.LaurentSeries.constructors..." begin
+@testset "Generic.LaurentSeries.constructors" begin
    R, x = LaurentSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -99,7 +99,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.LaurentSeries.rand..." begin
+@testset "Generic.LaurentSeries.rand" begin
    R, x = LaurentSeriesRing(ZZ, 10, "x")
 
    test_rand(R, -12:12, -10:10)
@@ -111,7 +111,7 @@ end
    test_rand(R, -12:12, make(RealField, -1:1))
 end
 
-@testset "Generic.LaurentSeries.manipulation..." begin
+@testset "Generic.LaurentSeries.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S, x = LaurentSeriesRing(R, 30, "x")
 
@@ -161,7 +161,7 @@ end
    @test modulus(T) == 7
 end
 
-@testset "Generic.LaurentSeries.unary_ops..." begin
+@testset "Generic.LaurentSeries.unary_ops" begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -191,7 +191,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.binary_ops..." begin
+@testset "Generic.LaurentSeries.binary_ops" begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -250,7 +250,7 @@ end
    @test c - ccp == 0
 end
 
-@testset "Generic.LaurentSeries.inplace_binary_ops..." begin
+@testset "Generic.LaurentSeries.inplace_binary_ops" begin
    #  Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -292,7 +292,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.adhoc_binary_ops..." begin
+@testset "Generic.LaurentSeries.adhoc_binary_ops" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -382,7 +382,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.comparison..." begin
+@testset "Generic.LaurentSeries.comparison" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -433,7 +433,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.adhoc_comparison..." begin
+@testset "Generic.LaurentSeries.adhoc_comparison" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -530,7 +530,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.powering..." begin
+@testset "Generic.LaurentSeries.powering" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
 
@@ -583,7 +583,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.shift..." begin
+@testset "Generic.LaurentSeries.shift" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -619,7 +619,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.truncation..." begin
+@testset "Generic.LaurentSeries.truncation" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -655,7 +655,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.inversion..." begin
+@testset "Generic.LaurentSeries.inversion" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -691,7 +691,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.square_root..." begin
+@testset "Generic.LaurentSeries.square_root" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -711,7 +711,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.exact_division..." begin
+@testset "Generic.LaurentSeries.exact_division" begin
    # Exact ring
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -751,7 +751,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.adhoc_exact_division..." begin
+@testset "Generic.LaurentSeries.adhoc_exact_division" begin
    # Exact field
    R, x = LaurentSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -790,7 +790,7 @@ end
    end
 end
 
-@testset "Generic.LaurentSeries.special_functions..." begin
+@testset "Generic.LaurentSeries.special_functions" begin
    # Exact field
    S, x = LaurentSeriesRing(QQ, 10, "x")
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.MPoly.constructors..." begin
+@testset "Generic.MPoly.constructors" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -80,7 +80,7 @@
    @test z isa Generic.MPoly{Generic.Poly{BigInt}}
 end
 
-@testset "Generic.MPoly.printing..." begin
+@testset "Generic.MPoly.printing" begin
    S, (x, y) = ZZ["x", "y"]
 
    @test string(zero(S)) == "0"
@@ -95,7 +95,7 @@ end
    @test string(y) == "y"
 end
 
-@testset "Generic.MPoly.geobuckets..." begin
+@testset "Generic.MPoly.geobuckets" begin
    R, x = ZZ["y"]
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
@@ -112,7 +112,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.rand..." begin
+@testset "Generic.MPoly.rand" begin
    R, x = ZZ["y"]
    num_vars = 5
    var_names = ["x$j" for j in 1:num_vars]
@@ -127,7 +127,7 @@ end
    test_rand(S, 0:5, 0:100, 0:0, -100:100)
 end
 
-@testset "Generic.MPoly.manipulation..." begin
+@testset "Generic.MPoly.manipulation" begin
    R, x = ZZ["y"]
 
    @test characteristic(R) == 0
@@ -269,7 +269,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.multivariate_coeff..." begin
+@testset "Generic.MPoly.multivariate_coeff" begin
    R = ZZ
 
    for iter = 1:5
@@ -359,7 +359,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.total_degree..." begin
+@testset "Generic.MPoly.total_degree" begin
    max = 50
    for nvars = 1:10
       var_names = ["x$j" for j in 1:nvars]
@@ -380,7 +380,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.unary_ops..." begin
+@testset "Generic.MPoly.unary_ops" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -397,7 +397,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.binary_ops..." begin
+@testset "Generic.MPoly.binary_ops" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -422,7 +422,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.adhoc_binary..." begin
+@testset "Generic.MPoly.adhoc_binary" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -463,7 +463,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.adhoc_comparison..." begin
+@testset "Generic.MPoly.adhoc_comparison" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -486,7 +486,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.powering..." begin
+@testset "Generic.MPoly.powering" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -523,7 +523,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.divides..." begin
+@testset "Generic.MPoly.divides" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -557,7 +557,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.square_root..." begin
+@testset "Generic.MPoly.square_root" begin
    for R in [ZZ, QQ]
       for num_vars = 1:10
          var_names = ["x$j" for j in 1:num_vars]
@@ -621,7 +621,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.euclidean_division..." begin
+@testset "Generic.MPoly.euclidean_division" begin
    R, x = QQ["y"]
 
    for num_vars = 1:10
@@ -662,7 +662,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.ideal_reduction..." begin
+@testset "Generic.MPoly.ideal_reduction" begin
    R, x = QQ["y"]
 
    for num_vars = 1:10
@@ -711,7 +711,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.deflation..." begin
+@testset "Generic.MPoly.deflation" begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -732,7 +732,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.gcd..." begin
+@testset "Generic.MPoly.gcd" begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -751,7 +751,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.lcm..." begin
+@testset "Generic.MPoly.lcm" begin
    for num_vars = 1:4
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -775,7 +775,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.evaluation..." begin
+@testset "Generic.MPoly.evaluation" begin
    R, x = ZZ["x"]
 
    for num_vars = 1:10
@@ -1057,7 +1057,7 @@ end
    @test evaluate(x + y, [K(1), K(1)]) isa BigFloat
 end
 
-@testset "Generic.MPoly.valuation..." begin
+@testset "Generic.MPoly.valuation" begin
    R, x = ZZ["y"]
 
    for num_vars = 1:10
@@ -1095,7 +1095,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.derivative..." begin
+@testset "Generic.MPoly.derivative" begin
    for num_vars=1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1120,7 +1120,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.change_base_ring..." begin
+@testset "Generic.MPoly.change_base_ring" begin
    F2 = ResidueRing(ZZ, 2)
    R, varsR = PolynomialRing(F2, ["x"])
    S, varsS = PolynomialRing(R, ["y"])
@@ -1154,7 +1154,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.vars..." begin
+@testset "Generic.MPoly.vars" begin
    for num_vars=1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1168,7 +1168,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.combine_like_terms..." begin
+@testset "Generic.MPoly.combine_like_terms" begin
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1202,7 +1202,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.exponents..." begin
+@testset "Generic.MPoly.exponents" begin
    for num_vars = 1:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
@@ -1273,7 +1273,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.to_univariate..." begin
+@testset "Generic.MPoly.to_univariate" begin
    for num_vars=1:10
       ord = rand_ordering()
 
@@ -1300,7 +1300,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.coefficients_of_univariate..." begin
+@testset "Generic.MPoly.coefficients_of_univariate" begin
    for num_vars=1:10
       ord = rand_ordering()
       var_names = ["x$j" for j in 1:num_vars]
@@ -1329,7 +1329,7 @@ end
    end
 end
 
-@testset "Generic.MPoly.ordering..." begin
+@testset "Generic.MPoly.ordering" begin
    n_mpolys = 100
    maxval = 10
    maxdeg = 20

--- a/test/generic/Map-test.jl
+++ b/test/generic/Map-test.jl
@@ -9,7 +9,7 @@ a(f::Map(MyMap)) = Generic.get_field(f, :a)
 
 (f::MyMap)(x) =  a(f)*(x + 1)
 
-@testset "Generic.Map.FunctionalMap..." begin
+@testset "Generic.Map.FunctionalMap" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
    g = map_from_func(x -> QQ(x), ZZ, QQ)
 
@@ -25,7 +25,7 @@ a(f::Map(MyMap)) = Generic.get_field(f, :a)
    @test image_fn(g)(ZZ(2)) == QQ(2)
 end
 
-@testset "Generic.Map.FunctionalCompositeMap..." begin
+@testset "Generic.Map.FunctionalCompositeMap" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
    g = map_from_func(x -> QQ(x), ZZ, QQ)
 
@@ -49,7 +49,7 @@ end
    @test map2(h) === g
 end
 
-@testset "Generic.Map.CompositeMap..." begin
+@testset "Generic.Map.CompositeMap" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
 
    s = MyMap(2)
@@ -69,7 +69,7 @@ end
    @test map2(t) === s
 end
 
-@testset "Generic.Map.IdentityMap..." begin
+@testset "Generic.Map.IdentityMap" begin
    f = map_from_func(x -> QQ(x + 1), ZZ, QQ)
    g = identity_map(ZZ)
    h = identity_map(QQ)

--- a/test/generic/MapCache-test.jl
+++ b/test/generic/MapCache-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.MapCache.constructors..." begin
+@testset "Generic.MapCache.constructors" begin
    f = cached(map_from_func(x -> x + 1, ZZ, ZZ))
    g = cached(map_from_func(x -> QQ(x), ZZ, QQ), limit=2)
    h = cached(map_from_func(x -> x + 2, ZZ, ZZ), enabled=false)
@@ -22,7 +22,7 @@
    @test image_fn(f)(ZZ(1)) == 2
 end
 
-@testset "Generic.MapCache.enable_disable..." begin
+@testset "Generic.MapCache.enable_disable" begin
    f = cached(map_from_func(x -> x + 1, ZZ, ZZ))
 
    @test f(ZZ(1)) == 2
@@ -52,7 +52,7 @@ end
    @test g(ZZ(3)) == 4
 end
 
-@testset "Generic.MapCache.limit..." begin
+@testset "Generic.MapCache.limit" begin
    g = cached(map_from_func(x -> QQ(x), ZZ, QQ), limit=2)
 
    set_limit!(g, 3)

--- a/test/generic/MapWithInverse-test.jl
+++ b/test/generic/MapWithInverse-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.MapWithInverse.constructors..." begin
+@testset "Generic.MapWithInverse.constructors" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
    g = map_from_func(x -> x - 1, ZZ, ZZ)
 
@@ -37,7 +37,7 @@
    @test u(ZZ(1)) == 2
 end
 
-@testset "Generic.MapWithInverse.composition..." begin
+@testset "Generic.MapWithInverse.composition" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
    g = map_from_func(x -> x - 1, ZZ, ZZ)
    h = map_from_func(x -> x + 2, ZZ, ZZ)
@@ -58,7 +58,7 @@ end
    @test u(ZZ(1)) == 4
 end
 
-@testset "Generic.MapWithInverse.inv..." begin
+@testset "Generic.MapWithInverse.inv" begin
    f = map_from_func(x -> x + 1, ZZ, ZZ)
    g = map_from_func(x -> x - 1, ZZ, ZZ)
    h = map_from_func(x -> x + 2, ZZ, ZZ)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -114,7 +114,7 @@ function AbstractAlgebra.matrix(R::F2, r::Int, c::Int, mat::AbstractMatrix{F2Ele
    matrix(R, mat)
 end
 
-@testset "Generic.Mat.constructors..." begin
+@testset "Generic.Mat.constructors" begin
    R, t = PolynomialRing(QQ, "t")
 
    S = MatrixSpace(R, 3, 3)
@@ -290,7 +290,7 @@ end
    @test A[1, 1] === a
 end
 
-@testset "Generic.Mat.size/axes..." begin
+@testset "Generic.Mat.size/axes" begin
    A = matrix(QQ, [1 2 3; 4 5 6; 7 8 9])
    B = matrix(QQ, [1 2 3 4; 5 6 7 8])
 
@@ -339,7 +339,7 @@ end
    @test !issquare(B)
 end
 
-@testset "Generic.Mat.manipulation..." begin
+@testset "Generic.Mat.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -453,7 +453,7 @@ end
    end
 end
 
-@testset "Generic.Mat.unary_ops..." begin
+@testset "Generic.Mat.unary_ops" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -507,7 +507,7 @@ end
    @test -z.m isa Generic.MatSpaceElem{F2Elem}
 end
 
-@testset "Generic.Mat.getindex..." begin
+@testset "Generic.Mat.getindex" begin
    S = MatrixSpace(ZZ, 3, 3)
 
    A = S([1 2 3; 4 5 6; 7 8 9])
@@ -728,7 +728,7 @@ end
    end
 end
 
-@testset "Generic.Mat.block_replacement..." begin
+@testset "Generic.Mat.block_replacement" begin
    _test_block_replacement = function(a, b, r, c)
       rr = r isa Colon ? (1:nrows(a)) : r
       cc = c isa Colon ? (1:ncols(a)) : c
@@ -837,7 +837,7 @@ end
    end
 end
 
-@testset "Generic.Mat.binary_ops..." begin
+@testset "Generic.Mat.binary_ops" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -968,7 +968,7 @@ end
 # add x to all the elements of the main diagonal of a copy of M
 add_diag(M::Matrix, x) = [i != j ? M[i, j] : M[i, j] + x for (i, j) in Tuple.(CartesianIndices(M))]
 
-@testset "Generic.Mat.adhoc_binary..." begin
+@testset "Generic.Mat.adhoc_binary" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1078,7 +1078,7 @@ add_diag(M::Matrix, x) = [i != j ? M[i, j] : M[i, j] + x for (i, j) in Tuple.(Ca
    end
 end
 
-@testset "Generic.Mat.permutation..." begin
+@testset "Generic.Mat.permutation" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1106,7 +1106,7 @@ end
    end
 end
 
-@testset "Generic.Mat.comparison..." begin
+@testset "Generic.Mat.comparison" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1148,7 +1148,7 @@ end
    end
 end
 
-@testset "Generic.Mat.adhoc_comparison..." begin
+@testset "Generic.Mat.adhoc_comparison" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1166,7 +1166,7 @@ end
    @test one(S) == one(S)
 end
 
-@testset "Generic.Mat.powering..." begin
+@testset "Generic.Mat.powering" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1183,7 +1183,7 @@ end
    @test A^-1 == inv(A)
 end
 
-@testset "Generic.Mat.adhoc_exact_division..." begin
+@testset "Generic.Mat.adhoc_exact_division" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1195,7 +1195,7 @@ end
    @test divexact((1 + t)*A, 1 + t) == A
 end
 
-@testset "Generic.Mat.issymmetric..." begin
+@testset "Generic.Mat.issymmetric" begin
    R, t = PolynomialRing(QQ, "t")
    @test !issymmetric(matrix(R, [t + 1 t R(1); t^2 t t]))
    @test issymmetric(matrix(R, [t + 1 t R(1); t t^2 t; R(1) t R(5)]))
@@ -1205,7 +1205,7 @@ end
    @test !issymmetric(S([t + 1 t R(1); t + 1 t^2 t; R(1) t R(5)]))
 end
 
-@testset "Generic.Mat.transpose..." begin
+@testset "Generic.Mat.transpose" begin
    R, t = PolynomialRing(QQ, "t")
    arr = [t + 1 t R(1); t^2 t t]
    A = matrix(R, arr)
@@ -1226,7 +1226,7 @@ end
    @test at[3, 1] == at[1, 2] == at[2, 2] == F2Elem(false)
 end
 
-@testset "Generic.Mat.gram..." begin
+@testset "Generic.Mat.gram" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1235,7 +1235,7 @@ end
    @test gram(A) == S([2*t^2 + 2*t + 2 t^3 + 2*t^2 + t 2*t^2 + t - 1; t^3 + 2*t^2 + t t^4 + 2*t^2 t^3 + 3*t; 2*t^2 + t - 1 t^3 + 3*t t^4 + 2*t^3 + 4*t^2 + 6*t + 9])
 end
 
-@testset "Generic.Mat.tr..." begin
+@testset "Generic.Mat.tr" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1244,7 +1244,7 @@ end
    @test tr(A) == t^2 + 3t + 2
 end
 
-@testset "Generic.Mat.content..." begin
+@testset "Generic.Mat.content" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
@@ -1253,7 +1253,7 @@ end
    @test content((1 + t)*A) == 1 + t
 end
 
-@testset "Generic.Mat.lu..." begin
+@testset "Generic.Mat.lu" begin
    # Exact field
    R = GF(7)
 
@@ -1322,7 +1322,7 @@ end
    @test P*A == L*U
 end
 
-@testset "Generic.Mat.fflu..." begin
+@testset "Generic.Mat.fflu" begin
    # Exact ring
    R = ZZ
 
@@ -1411,7 +1411,7 @@ end
    @test P*A == L*D*U
 end
 
-@testset "Generic.Mat.det..." begin
+@testset "Generic.Mat.det" begin
    S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
 
    for dim = 0:5
@@ -1454,7 +1454,7 @@ end
    end
 end
 
-@testset "Generic.Mat.minors..." begin
+@testset "Generic.Mat.minors" begin
    S, z = PolynomialRing(ZZ,"z")
    n = 5
    R = MatrixSpace(S,n,n)
@@ -1471,7 +1471,7 @@ end
    end
 end
 
-@testset "Generic.Mat.rank..." begin
+@testset "Generic.Mat.rank" begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
@@ -1544,7 +1544,7 @@ end
    end
 end
 
-@testset "Generic.Mat.can_solve_with_solution_fflu..." begin
+@testset "Generic.Mat.can_solve_with_solution_fflu" begin
    R = ZZ
 
    # Test random soluble systems
@@ -1596,7 +1596,7 @@ end
    end
 end
 
-@testset "Generic.Mat.can_solve_with_solution_lu..." begin
+@testset "Generic.Mat.can_solve_with_solution_lu" begin
    R = GF(17)
 
    for i = 1:100
@@ -1672,7 +1672,7 @@ end
    end
 end
 
-@testset "Generic.Mat.solve_ff..." begin
+@testset "Generic.Mat.solve_ff" begin
    # Exact field
    R = QQ
 
@@ -1717,7 +1717,7 @@ end
    end
 end
 
-@testset "Generic.Mat.solve_rational..." begin
+@testset "Generic.Mat.solve_rational" begin
    R = ZZ
 
    for i = 1:100
@@ -1833,7 +1833,7 @@ end
    @test M*x == d*b
 end
 
-@testset "Generic.Mat.solve..." begin
+@testset "Generic.Mat.solve" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          for dim = 0:5
@@ -1876,7 +1876,7 @@ end
    end
 end
 
-@testset "Generic.Mat.solve_left..." begin
+@testset "Generic.Mat.solve_left" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          for dim = 0:5
@@ -1920,7 +1920,7 @@ end
    end
 end
 
-@testset "Generic.Mat.can_solve..." begin
+@testset "Generic.Mat.can_solve" begin
    R, x = PolynomialRing(QQ, "x")
    S = FractionField(R)
 
@@ -2101,7 +2101,7 @@ end
    @test_throws TypeError can_solve_with_solution(matrix(ZZ, 2, 2, [1, 0, 0, 1]), matrix(ZZ, 2, 1, [2, 3]), side = "right")
 end
 
-@testset "Generic.Mat.can_solve_with_solution_interpolation..." begin
+@testset "Generic.Mat.can_solve_with_solution_interpolation" begin
    R1 = ResidueRing(ZZ, 65537)
    R, x = PolynomialRing(R1, "x")
    RZ, x = PolynomialRing(ZZ, "x")
@@ -2135,7 +2135,7 @@ end
    end
 end
 
-@testset "Generic.Mat.solve_triu..." begin
+@testset "Generic.Mat.solve_triu" begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
 
@@ -2152,7 +2152,7 @@ end
    end
 end
 
-@testset "Generic.Mat.solve_left_reduced_triu..." begin
+@testset "Generic.Mat.solve_left_reduced_triu" begin
    for iter = 1:40
       n = rand(1:6)
       m = rand(1:n)
@@ -2170,7 +2170,7 @@ end
    end
 end
 
-@testset "Generic.Mat.rref..." begin
+@testset "Generic.Mat.rref" begin
    # Non-integral domain
 
    S = ResidueRing(ZZ, 20011*10007)
@@ -2278,7 +2278,7 @@ end
    end
 end
 
-@testset "Generic.Mat.isinvertible..." begin
+@testset "Generic.Mat.isinvertible" begin
    R, x = PolynomialRing(QQ, "x")
 
    let
@@ -2362,7 +2362,7 @@ end
    end
 end
 
-@testset "Generic.Mat.nullspace..." begin
+@testset "Generic.Mat.nullspace" begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixSpace(S, 5, 5)
 
@@ -2433,7 +2433,7 @@ end
    end
 end
 
-@testset "Generic.Mat.kernel..." begin
+@testset "Generic.Mat.kernel" begin
    R = MatrixSpace(ZZ, 5, 5)
 
    for i = 0:5
@@ -2492,7 +2492,7 @@ end
    end
 end
 
-@testset "Generic.Mat.inversion..." begin
+@testset "Generic.Mat.inversion" begin
    for dim = 2:5
       R = MatrixSpace(ZZ, dim, dim)
       M = R(1)
@@ -2585,7 +2585,7 @@ end
    @test typeof(inv(M.m)) == typeof(M.m)
 end
 
-@testset "Generic.Mat.hessenberg..." begin
+@testset "Generic.Mat.hessenberg" begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -2607,7 +2607,7 @@ end
    @test H == matrix(ZZ, 3, 3, [10 -28 8; -1 4 -3; 0 50 -19])
 end
 
-@testset "Generic.Mat.kronecker_product..." begin
+@testset "Generic.Mat.kronecker_product" begin
    R = ResidueRing(ZZ, 18446744073709551629)
    S = MatrixSpace(R, 2, 3)
    S2 = MatrixSpace(R, 2, 2)
@@ -2621,7 +2621,7 @@ end
    @test kronecker_product(B*A,A*C) == kronecker_product(B,A) * kronecker_product(A,C)
 end
 
-@testset "Generic.Mat.charpoly..." begin
+@testset "Generic.Mat.charpoly" begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -2679,7 +2679,7 @@ end
    @test p1 == p2
 end
 
-@testset "Generic.Mat.minpoly..." begin
+@testset "Generic.Mat.minpoly" begin
    R = GF(103)
    T, y = PolynomialRing(R, "y")
 
@@ -2783,7 +2783,7 @@ end
    @test p1 == p2
 end
 
-@testset "Generic.Mat.row_col_swapping..." begin
+@testset "Generic.Mat.row_col_swapping" begin
    R, x = PolynomialRing(ZZ, "x")
    M = MatrixSpace(R, 3, 2)
 
@@ -2823,7 +2823,7 @@ end
    @test a == matrix(R, [3 2 1; 5 4 3; 7 6 5])
 end
 
-@testset "Generic.Mat.gen_mat_elem_op..." begin
+@testset "Generic.Mat.gen_mat_elem_op" begin
    R, x = PolynomialRing(ZZ, "x")
    for i in 1:10
       r = rand(1:50)
@@ -2946,7 +2946,7 @@ end
    end
 end
 
-@testset "Generic.Mat.concat..." begin
+@testset "Generic.Mat.concat" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for i = 1:10
@@ -3003,7 +3003,7 @@ end
                                     0 1 0 1 2;])
 end
 
-@testset "Generic.Mat.hnf_minors..." begin
+@testset "Generic.Mat.hnf_minors" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -3038,7 +3038,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.Mat.hnf_kb..." begin
+@testset "Generic.Mat.hnf_kb" begin
    M = matrix(ZZ, BigInt[4 6 2; 0 0 10; 0 5 3])
 
    H, U = AbstractAlgebra.hnf_kb_with_transform(M)
@@ -3104,7 +3104,7 @@ end
    @test B == b
 end
 
-@testset "Generic.Mat.hnf_cohen..." begin
+@testset "Generic.Mat.hnf_cohen" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -3139,7 +3139,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.Mat.hnf..." begin
+@testset "Generic.Mat.hnf" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -3174,7 +3174,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.Mat.snf_kb..." begin
+@testset "Generic.Mat.snf_kb" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -3234,7 +3234,7 @@ end
    @test C == c
 end
 
-@testset "Generic.Mat.snf..." begin
+@testset "Generic.Mat.snf" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixSpace(R, 4, 3)
@@ -3271,7 +3271,7 @@ end
    @test U*B*K == T
 end
 
-@testset "Generic.Mat.weak_popov..." begin
+@testset "Generic.Mat.weak_popov" begin
    R, x = PolynomialRing(QQ, "x")
 
    A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]))
@@ -3348,7 +3348,7 @@ end
    end
 end
 
-@testset "Generic.Mat.popov..." begin
+@testset "Generic.Mat.popov" begin
    R, x = PolynomialRing(QQ, "x")
 
    A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]))
@@ -3435,7 +3435,7 @@ end
    end
 end
 
-@testset "Generic.Mat.views..." begin
+@testset "Generic.Mat.views" begin
    M = matrix(ZZ, 3, 3, BigInt[1, 2, 3, 2, 3, 4, 3, 4, 5])
    M2 = deepcopy(M)
 
@@ -3454,7 +3454,7 @@ end
    @test M2 == M
 end
 
-@testset "Generic.Mat.change_base_ring..." begin
+@testset "Generic.Mat.change_base_ring" begin
    for (P, Q, T) in ((MatrixSpace(ZZ, 2, 3), MatrixSpace(ZZ, 3, 2), MatElem),
                      (MatrixAlgebra(ZZ, 3), MatrixAlgebra(ZZ, 3), MatAlgElem))
       M = rand(P, -10:10)
@@ -3478,7 +3478,7 @@ end
    @test change_base_ring(F2(), z.m) isa F2Matrix
 end
 
-@testset "Generic.Mat.map..." begin
+@testset "Generic.Mat.map" begin
    u, v = rand(0:9, 2)
    for (mat, algebra) = ((rand(1:9, u, v), false),
                          (rand(1:9, u, u), true))
@@ -3522,7 +3522,7 @@ end
    @test map(identity, z.m) isa F2Matrix
 end
 
-@testset "Generic.Mat.similar/zero..." begin
+@testset "Generic.Mat.similar/zero" begin
    for sim_zero in (similar, zero)
       test_zero = sim_zero === zero
       for R = (ZZ, GF(11))
@@ -3566,7 +3566,7 @@ end
    @test zero(m, 2, 3)    isa Generic.MatSpaceElem{F2Elem}
 end
 
-@testset "Generic.Mat.printing..." begin
+@testset "Generic.Mat.printing" begin
    # this is the REPL printing
    @test sprint(show, "text/plain", matrix(ZZ, [3 1 2; 2 0 1])) == "[3  1  2]\n[2  0  1]"
    @test sprint(show, "text/plain", matrix(ZZ, [3 1 2; 2 0 1])) == "[3  1  2]\n[2  0  1]"

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -14,7 +14,7 @@ function randprime(n::Int)
    return primes100[rand(1:n)]
 end
 
-@testset "Generic.MatAlg.constructors..." begin
+@testset "Generic.MatAlg.constructors" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -63,7 +63,7 @@ end
    @test_throws ErrorConstrDimMismatch S([t, t^2, t^3, t^4, t^5, t^6, t^7, t^8, t^9, t^10])
 end
 
-@testset "Generic.MatAlg.manipulation..." begin
+@testset "Generic.MatAlg.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -130,7 +130,7 @@ end
    @test_throws BoundsError axes(A, -rand(1:99))
 end
 
-@testset "Generic.MatAlg.unary_ops..." begin
+@testset "Generic.MatAlg.unary_ops" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -140,7 +140,7 @@ end
    @test -A == B
 end
 
-@testset "Generic.MatAlg.binary_ops..." begin
+@testset "Generic.MatAlg.binary_ops" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -154,7 +154,7 @@ end
    @test A*B == S([t^2 + 2*t + 1 2*t^2 + 4*t + 3 t^3 + t^2 + 3*t + 1; 3*t^2 - t (t^3 + 4*t^2 + t) t^4 + 2*t^2 + 2*t; t-5 t^4 + t^3 + 2*t^2 + 3*t - 4 t^5 + 1*t^4 + t^3 + t^2 + 4*t + 2])
 end
 
-@testset "Generic.MatAlg.adhoc_binary..." begin
+@testset "Generic.MatAlg.adhoc_binary" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -174,7 +174,7 @@ end
    @test (t - 1)*A == A*(t - 1)
 end
 
-@testset "Generic.MatAlg.permutation..." begin
+@testset "Generic.MatAlg.permutation" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -186,7 +186,7 @@ end
    @test A == inv(P)*(P*A)
 end
 
-@testset "Generic.MatAlg.comparison..." begin
+@testset "Generic.MatAlg.comparison" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -198,7 +198,7 @@ end
    @test A != one(S)
 end
 
-@testset "Generic.MatAlg.adhoc_comparison..." begin
+@testset "Generic.MatAlg.adhoc_comparison" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -216,7 +216,7 @@ end
    @test one(S) == one(S)
 end
 
-@testset "Generic.MatAlg.powering..." begin
+@testset "Generic.MatAlg.powering" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -227,7 +227,7 @@ end
    @test A^0 == one(S)
 end
 
-@testset "Generic.MatAlg.exact_division..." begin
+@testset "Generic.MatAlg.exact_division" begin
    S = MatrixAlgebra(QQ, 3)
 
    M = rand(S, -20:20)
@@ -237,7 +237,7 @@ end
    @test divexact_left(N*M, N) == M
 end
 
-@testset "Generic.MatAlg.adhoc_exact_division..." begin
+@testset "Generic.MatAlg.adhoc_exact_division" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -249,7 +249,7 @@ end
    @test divexact((1 + t)*A, 1 + t) == A
 end
 
-@testset "Generic.MatAlg.transpose..." begin
+@testset "Generic.MatAlg.transpose" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
    arr = [t + 1 t R(1); t^2 t t; t+1 t^2 R(-1)]
@@ -258,7 +258,7 @@ end
    @test transpose(A) == B
 end
 
-@testset "Generic.MatAlg.gram..." begin
+@testset "Generic.MatAlg.gram" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -267,7 +267,7 @@ end
    @test gram(A) == S([2*t^2 + 2*t + 2 t^3 + 2*t^2 + t 2*t^2 + t - 1; t^3 + 2*t^2 + t t^4 + 2*t^2 t^3 + 3*t; 2*t^2 + t - 1 t^3 + 3*t t^4 + 2*t^3 + 4*t^2 + 6*t + 9])
 end
 
-@testset "Generic.MatAlg.tr..." begin
+@testset "Generic.MatAlg.tr" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -276,7 +276,7 @@ end
    @test tr(A) == t^2 + 3t + 2
 end
 
-@testset "Generic.MatAlg.content..." begin
+@testset "Generic.MatAlg.content" begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixAlgebra(R, 3)
 
@@ -285,7 +285,7 @@ end
    @test content((1 + t)*A) == 1 + t
 end
 
-@testset "Generic.MatAlg.lu..." begin
+@testset "Generic.MatAlg.lu" begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixAlgebra(K, 3)
@@ -323,7 +323,7 @@ end
    @test P*A == L*U
 end
 
-@testset "Generic.MatAlg.fflu..." begin
+@testset "Generic.MatAlg.fflu" begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
    S = MatrixAlgebra(K, 3)
@@ -377,7 +377,7 @@ end
    @test P*A == L*D*U
 end
 
-@testset "Generic.MatAlg.det..." begin
+@testset "Generic.MatAlg.det" begin
    S, x = PolynomialRing(ResidueRing(ZZ, 1009*2003), "x")
 
    for dim = 0:5
@@ -420,7 +420,7 @@ end
    end
 end
 
-@testset "Generic.MatAlg.block_replacement..." begin
+@testset "Generic.MatAlg.block_replacement" begin
    _test_block_replacement = function(a, b, r, c)
       rr = r isa Colon ? (1:nrows(a)) : r
       cc = c isa Colon ? (1:ncols(a)) : c
@@ -529,7 +529,7 @@ end
    end
 end
 
-@testset "Generic.MatAlg.rank..." begin
+@testset "Generic.MatAlg.rank" begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
@@ -603,7 +603,7 @@ end
    end
 end
 
-@testset "Generic.MatAlg.solve_lu..." begin
+@testset "Generic.MatAlg.solve_lu" begin
    S = QQ
 
    for dim = 0:5
@@ -638,7 +638,7 @@ end
    end
 end
 
-@testset "Generic.MatAlg.rref..." begin
+@testset "Generic.MatAlg.rref" begin
    S = ResidueRing(ZZ, 20011*10007)
    R = MatrixAlgebra(S, 5)
 
@@ -702,7 +702,7 @@ end
    end
 end
 
-@testset "Generic.MatAlg.inversion..." begin
+@testset "Generic.MatAlg.inversion" begin
    indexing(n) = [(i,j) for i in 1:n for j in 1:n if i !=j ]
    E(R,i,j, val=1) = (M=one(R); M[i,j] = val; return M)
    E(R::MatAlgebra; vals=[1,-1]) = [E(R, i,j,val) for (i,j) in indexing(R.n) for val in vals]
@@ -837,9 +837,9 @@ end
       @test all(isone(m*inv(m)) for m in random_matrices)
    end
    end
-end # of @testset "Generic.MatAlg.inversion..."
+end # of @testset "Generic.MatAlg.inversion"
 
-@testset "Generic.MatAlg.hessenberg..." begin
+@testset "Generic.MatAlg.hessenberg" begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -856,7 +856,7 @@ end # of @testset "Generic.MatAlg.inversion..."
    end
 end
 
-@testset "Generic.MatAlg.charpoly..." begin
+@testset "Generic.MatAlg.charpoly" begin
    R = ResidueRing(ZZ, 18446744073709551629)
 
    for dim = 0:5
@@ -914,7 +914,7 @@ end
    @test p1 == p2
 end
 
-@testset "Generic.MatAlg.minpoly..." begin
+@testset "Generic.MatAlg.minpoly" begin
    R = GF(103)
    T, y = PolynomialRing(R, "y")
    S = MatrixAlgebra(R, 3)
@@ -1024,7 +1024,7 @@ end
    @test p1 == p2
 end
 
-@testset "Generic.MatAlg.row_swapping..." begin
+@testset "Generic.MatAlg.row_swapping" begin
    R, x = PolynomialRing(ZZ, "x")
    M = MatrixAlgebra(R, 3)
 
@@ -1038,7 +1038,7 @@ end
 end
 
 if false # see bug 160
-    @testset "Generic.MatAlg.hnf_minors..." begin
+    @testset "Generic.MatAlg.hnf_minors" begin
         R, x = PolynomialRing(QQ, "x")
 
         M = MatrixAlgebra(R, 3)
@@ -1074,7 +1074,7 @@ if false # see bug 160
     end
 end
 
-@testset "Generic.MatAlg.hnf_kb..." begin
+@testset "Generic.MatAlg.hnf_kb" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1109,7 +1109,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.MatAlg.hnf_cohen..." begin
+@testset "Generic.MatAlg.hnf_cohen" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1144,7 +1144,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.MatAlg.hnf..." begin
+@testset "Generic.MatAlg.hnf" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1179,7 +1179,7 @@ end
    @test U*B == H
 end
 
-@testset "Generic.MatAlg.snf_kb..." begin
+@testset "Generic.MatAlg.snf_kb" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1216,7 +1216,7 @@ end
    @test U*B*K == T
 end
 
-@testset "Generic.MatAlg.snf..." begin
+@testset "Generic.MatAlg.snf" begin
    R, x = PolynomialRing(QQ, "x")
 
    M = MatrixAlgebra(R, 3)
@@ -1253,7 +1253,7 @@ end
    @test U*B*K == T
 end
 
-@testset "Generic.MatAlg.$sim_zero..." for sim_zero in (similar, zero)
+@testset "Generic.MatAlg.$sim_zero" for sim_zero in (similar, zero)
    test_zero = sim_zero === zero
    for R = (ZZ, GF(11))
       M = MatrixAlgebra(R, rand(0:9))

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -13,13 +13,13 @@ function rand_homomorphism(M::AbstractAlgebra.FPModule{T}, vals...) where T <: R
    return S, hom1
 end
 
-@testset "Generic.Module.rand..." begin
+@testset "Generic.Module.rand" begin
    F = FreeModule(ZZ, 3)
 
    test_rand(F, 1:9)
 end
 
-@testset "Generic.Module.manipulation..." begin
+@testset "Generic.Module.manipulation" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          F = FreeModule(R, 3)
@@ -99,7 +99,7 @@ end
    U, k = quo(Q, T)
 end
 
-@testset "Generic.Module.elem_getindex..." begin
+@testset "Generic.Module.elem_getindex" begin
 
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -119,7 +119,7 @@ end
    end
 end
 
-@testset "Generic.Module.intersection..." begin
+@testset "Generic.Module.intersection" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          M = rand_module(R, -10:10)
@@ -161,7 +161,7 @@ end
    end
 end
 
-@testset "Generic.Module.is_isomorphic..." begin
+@testset "Generic.Module.is_isomorphic" begin
    # Test the first isomorphism theorem
    for R in [ZZ, QQ]
       for iter = 1:100
@@ -193,7 +193,7 @@ end
    end
 end
 
-@testset "Generic.Module.coercions..." begin
+@testset "Generic.Module.coercions" begin
    # Test the first isomorphism theorem
    for R in [ZZ, QQ]
       for iter = 1:20

--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.ModuleHomomorphism.constructors..." begin
+@testset "Generic.ModuleHomomorphism.constructors" begin
    M = FreeModule(ZZ, 2)
 
    f = ModuleHomomorphism(M, M, matrix(ZZ, 2, 2, [1, 2, 3, 4]))
@@ -18,7 +18,7 @@
    @test g(m2) == N([ZZ(12)])
 end
 
-@testset "Generic.ModuleHomomorphism.kernel..." begin
+@testset "Generic.ModuleHomomorphism.kernel" begin
    for R in [ZZ, QQ]
       for iter = 1:100
          # test kernels of canonical injection and projection
@@ -65,7 +65,7 @@ end
    end
 end
 
-@testset "Generic.ModuleHomomorphism.image..." begin
+@testset "Generic.ModuleHomomorphism.image" begin
    # To make it work on julia nightlies
 
    R = AbstractAlgebra.JuliaZZ
@@ -107,7 +107,7 @@ end
    end
 end
 
-@testset "Generic.ModuleIsomorphism..." begin
+@testset "Generic.ModuleIsomorphism" begin
    R = AbstractAlgebra.JuliaQQ
    for iter = 1:100
       # test image of composition of canonical injection and projection

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.NCPoly.constructors..." begin
+@testset "Generic.NCPoly.constructors" begin
    R = MatrixAlgebra(ZZ, 2)
    S1 = PolynomialRing(R, "y")
    S2 = R["y"]
@@ -57,7 +57,7 @@
    @test isa(n, NCPolyElem)
 end
 
-@testset "Generic.NCPoly.manipulation..." begin
+@testset "Generic.NCPoly.manipulation" begin
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
@@ -99,14 +99,14 @@ end
    @test !ismonomial(y^2 + y + 1)
 end
 
-@testset "Generic.NCPoly.rand..." begin
+@testset "Generic.NCPoly.rand" begin
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
 
    test_rand(S, 0:10, -10:10)
 end
 
-@testset "Generic.NCPoly.binary_ops..." begin
+@testset "Generic.NCPoly.binary_ops" begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -124,7 +124,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.adhoc_binary..." begin
+@testset "Generic.NCPoly.adhoc_binary" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -163,7 +163,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.comparison..." begin
+@testset "Generic.NCPoly.comparison" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -181,7 +181,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.adhoc_comparison..." begin
+@testset "Generic.NCPoly.adhoc_comparison" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -228,7 +228,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.unary_ops..." begin
+@testset "Generic.NCPoly.unary_ops" begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -240,7 +240,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.truncation..." begin
+@testset "Generic.NCPoly.truncation" begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -253,7 +253,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.reverse..." begin
+@testset "Generic.NCPoly.reverse" begin
    #  Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -275,7 +275,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.shift..." begin
+@testset "Generic.NCPoly.shift" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -290,7 +290,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.powering..." begin
+@testset "Generic.NCPoly.powering" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -315,7 +315,7 @@ end
    @test_throws DomainError f^-rand(2:100)
 end
 
-@testset "Generic.NCPoly.exact_division..." begin
+@testset "Generic.NCPoly.exact_division" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -332,7 +332,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.adhoc_exact_division..." begin
+@testset "Generic.NCPoly.adhoc_exact_division" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -381,7 +381,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.evaluation..." begin
+@testset "Generic.NCPoly.evaluation" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")
@@ -404,7 +404,7 @@ end
    end
 end
 
-@testset "Generic.NCPoly.derivative..." begin
+@testset "Generic.NCPoly.derivative" begin
    # Exact ring
    R = MatrixAlgebra(ZZ, 2)
    S, y = PolynomialRing(R, "y")

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -1,6 +1,6 @@
 IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
 
-@testset "Perm.abstract_types..." begin
+@testset "Perm.abstract_types" begin
    @test Generic.Perm <: GroupElem
    @test Generic.Perm <: AbstractAlgebra.AbstractPerm
 
@@ -8,7 +8,7 @@ IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
    @test Generic.SymmetricGroup <: AbstractAlgebra.AbstractPermutationGroup
 end
 
-@testset "Perm.constructors ($T)..." for T in IntTypes
+@testset "Perm.constructors ($T)" for T in IntTypes
    @test elem_type(Generic.SymmetricGroup{T}) == Generic.Perm{T}
    @test parent_type(Generic.Perm{T}) == Generic.SymmetricGroup{T}
 
@@ -68,7 +68,7 @@ end
    @test_throws MethodError Perm(Any[])
 end
 
-@testset "Perm.parsingGAP..." begin
+@testset "Perm.parsingGAP" begin
    @test Generic.parse_cycles("()") == (Int[], [1])
    @test Generic.parse_cycles("(1)(2)(3)") == ([1,2,3], [1,2,3,4])
    @test Generic.parse_cycles("Cycle Decomposition: (1)(2,3)") == ([1,2,3], [1,2,4])
@@ -126,7 +126,7 @@ end
    end
 end
 
-@testset "Perm.printing ($T)..." for T in IntTypes
+@testset "Perm.printing ($T)" for T in IntTypes
    G = SymmetricGroup(T(10))
 
    b = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
@@ -143,7 +143,7 @@ end
    @test string(Perm(Int[])) == "()"
 end
 
-@testset "Perm.basic_manipulation ($T)..." for T in IntTypes
+@testset "Perm.basic_manipulation ($T)" for T in IntTypes
    G = SymmetricGroup(T(10))
 
    a = one(G)
@@ -164,7 +164,7 @@ end
    @test a[1] == T(5)
 end
 
-@testset "Perm.iteration ($T)..." for T in IntTypes
+@testset "Perm.iteration ($T)" for T in IntTypes
    G = SymmetricGroup(T(6))
    @test length(AllPerms(T(6))) == 720
    @test length(unique([deepcopy(p) for p in AllPerms(T(6))])) == 720
@@ -183,7 +183,7 @@ end
    @test length(unique(collect(G))) == 720
 end
 
-@testset "Perm.binary_ops ($T)..." for T in IntTypes
+@testset "Perm.binary_ops ($T)" for T in IntTypes
    G = SymmetricGroup(T(3))
 
    a = Perm(T[2,1,3]) # (1,2)
@@ -229,7 +229,7 @@ end
    @test p^2 * p^-2 == one(G)
 end
 
-@testset "Perm.mixed_binary_ops..." begin
+@testset "Perm.mixed_binary_ops" begin
    G = SymmetricGroup(6)
    for T in IntTypes
       H = SymmetricGroup(T(6))
@@ -244,7 +244,7 @@ end
    end
 end
 
-@testset "Perm.inversion ($T)..." for T in IntTypes
+@testset "Perm.inversion ($T)" for T in IntTypes
    G = SymmetricGroup(T(10))
 
    a = one(G)
@@ -259,7 +259,7 @@ end
    end
 end
 
-@testset "Perm.misc ($T)..." for T in IntTypes
+@testset "Perm.misc ($T)" for T in IntTypes
    G = SymmetricGroup(T(10))
    a = G([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
@@ -308,7 +308,7 @@ end
    end
 end
 
-@testset "Perm.characters..." begin
+@testset "Perm.characters" begin
    for T in IntTypes
       N = T(7)
       G = SymmetricGroup(N)

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -16,7 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-@testset "Generic.Poly.constructors..." begin
+@testset "Generic.Poly.constructors" begin
    R, x = ZZ["x"]
    S1 = R["y"]
    S2 = ZZ["x"]["y"]
@@ -85,7 +85,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.Poly.printing..." begin
+@testset "Generic.Poly.printing" begin
    R, x = PolynomialRing(ZZ, "x")
 
    @test string(zero(R)) == "0"
@@ -101,7 +101,7 @@ end
    @test string(x+y+1) == "y + x + 1"
 end
 
-@testset "Generic.Poly.rand..." begin
+@testset "Generic.Poly.rand" begin
    R, x = PolynomialRing(ZZ, "x")
 
    # TODO: test more than just the result type
@@ -119,7 +119,7 @@ end
    test_rand(T, 0:4)
 end
 
-@testset "Generic.Poly.manipulation..." begin
+@testset "Generic.Poly.manipulation" begin
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
 
@@ -165,7 +165,7 @@ end
    @test characteristic(R) == 0
 end
 
-@testset "Generic.Poly.binary_ops..." begin
+@testset "Generic.Poly.binary_ops" begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:100
@@ -229,7 +229,7 @@ end
    end
 end
 
-@testset "Generic.Poly.adhoc_binary..." begin
+@testset "Generic.Poly.adhoc_binary" begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -342,7 +342,7 @@ end
    end
 end
 
-@testset "Generic.Poly.comparison..." begin
+@testset "Generic.Poly.comparison" begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -408,7 +408,7 @@ end
    end
 end
 
-@testset "Generic.Poly.adhoc_comparison..." begin
+@testset "Generic.Poly.adhoc_comparison" begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:500
@@ -525,7 +525,7 @@ end
    end
 end
 
-@testset "Generic.Poly.unary_ops..." begin
+@testset "Generic.Poly.unary_ops" begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:300
@@ -567,7 +567,7 @@ end
    end
 end
 
-@testset "Generic.Poly.truncation..." begin
+@testset "Generic.Poly.truncation" begin
    #  Exact ring
    R, x = PolynomialRing(ZZ, "x")
    for iter = 1:300
@@ -616,7 +616,7 @@ end
    end
 end
 
-@testset "Generic.Poly.reverse..." begin
+@testset "Generic.Poly.reverse" begin
    #  Exact ring
    R, x = ZZ["x"]
    for iter = 1:300
@@ -714,7 +714,7 @@ end
    @test_throws DomainError reverse(f, -rand(2:100))
 end
 
-@testset "Generic.Poly.shift..." begin
+@testset "Generic.Poly.shift" begin
    # Exact ring
    R, x = ZZ["x"]
    for iter = 1:300
@@ -792,7 +792,7 @@ end
    @test_throws DomainError shift_left(f, -rand(2:100))
 end
 
-@testset "Generic.Poly.powering..." begin
+@testset "Generic.Poly.powering" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -889,7 +889,7 @@ end
 end
 
 if false
-   @testset "Generic.Poly.modular_arithmetic..." begin
+   @testset "Generic.Poly.modular_arithmetic" begin
       # Exact ring
       R = ResidueRing(ZZ, 23)
       S, x = PolynomialRing(R, "x")
@@ -1068,7 +1068,7 @@ if false
    end
 end
 
-@testset "Generic.Poly.exact_division..." begin
+@testset "Generic.Poly.exact_division" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1129,7 +1129,7 @@ end
    end
 end
 
-@testset "Generic.Poly.adhoc_exact_division..." begin
+@testset "Generic.Poly.adhoc_exact_division" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1236,7 +1236,7 @@ end
    end
 end
 
-@testset "Generic.Poly.euclidean_division..." begin
+@testset "Generic.Poly.euclidean_division" begin
    # Exact ring
    R = ResidueRing(ZZ, 23)
    S, x = PolynomialRing(R, "x")
@@ -1350,7 +1350,7 @@ end
    end
 end
 
-@testset "Generic.Poly.pseudodivision..." begin
+@testset "Generic.Poly.pseudodivision" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1395,7 +1395,7 @@ end
    end
 end
 
-@testset "Generic.Poly.content_primpart_gcd..." begin
+@testset "Generic.Poly.content_primpart_gcd" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1527,7 +1527,7 @@ end
    end
 end
 
-@testset "Generic.Poly.evaluation..." begin
+@testset "Generic.Poly.evaluation" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1593,7 +1593,7 @@ end
    end
 end
 
-@testset "Generic.Poly.composition..." begin
+@testset "Generic.Poly.composition" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1629,7 +1629,7 @@ end
    end
 end
 
-@testset "Generic.Poly.derivative..." begin
+@testset "Generic.Poly.derivative" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1668,7 +1668,7 @@ end
    end
 end
 
-@testset "Generic.Poly.integral..." begin
+@testset "Generic.Poly.integral" begin
    # Exact field
    R, x = PolynomialRing(QQ, "x")
 
@@ -1713,7 +1713,7 @@ end
    end
 end
 
-@testset "Generic.Poly.sylvester_matrix..." begin
+@testset "Generic.Poly.sylvester_matrix" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter in 1:10
@@ -1741,7 +1741,7 @@ end
    end
 end
 
-@testset "Generic.Poly.resultant..." begin
+@testset "Generic.Poly.resultant" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1832,7 +1832,7 @@ end
    end
 end
 
-@testset "Generic.Poly.discriminant..." begin
+@testset "Generic.Poly.discriminant" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -1884,7 +1884,7 @@ end
 #   end
 end
 
-@testset "Generic.Poly.resx..." begin
+@testset "Generic.Poly.resx" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2018,7 +2018,7 @@ end
 #   end
 end
 
-@testset "Generic.Poly.gcdx..." begin
+@testset "Generic.Poly.gcdx" begin
    # Exact field
    R, x = PolynomialRing(QQ, "x")
 
@@ -2109,7 +2109,7 @@ end
    end
 end
 
-@testset "Generic.Poly.newton_representation..." begin
+@testset "Generic.Poly.newton_representation" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2198,7 +2198,7 @@ end
    end
 end
 
-@testset "Generic.Poly.interpolation..." begin
+@testset "Generic.Poly.interpolation" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2306,7 +2306,7 @@ end
 #   end
 end
 
-@testset "Generic.Poly.special..." begin
+@testset "Generic.Poly.special" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2424,7 +2424,7 @@ end
    end
 end
 
-@testset "Generic.Poly.mul_karatsuba..." begin
+@testset "Generic.Poly.mul_karatsuba" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
@@ -2436,7 +2436,7 @@ end
    @test mul_karatsuba(f^10, f^30) == mul_classical(f^10, f^30)
 end
 
-@testset "Generic.Poly.mul_ks..." begin
+@testset "Generic.Poly.mul_ks" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
    S, y = PolynomialRing(R, "y")
@@ -2448,7 +2448,7 @@ end
    @test mul_ks(f^10, f^30) == mul_classical(f^10, f^30)
 end
 
-@testset "Generic.Poly.remove_valuation..." begin
+@testset "Generic.Poly.remove_valuation" begin
    # Exact ring
    R, x = PolynomialRing(ZZ, "x")
 
@@ -2616,7 +2616,7 @@ end
    end
 end
 
-@testset "Generic.Poly.square_root..." begin
+@testset "Generic.Poly.square_root" begin
    # Exact ring
    S, x = PolynomialRing(ZZ, "x")
    for iter = 1:10
@@ -2689,7 +2689,7 @@ end
    end
 end
 
-@testset "Generic.Poly.generic_eval..." begin
+@testset "Generic.Poly.generic_eval" begin
    R, x = PolynomialRing(ZZ, "x")
 
    for iter in 1:10
@@ -2713,7 +2713,7 @@ end
    end
 end
 
-@testset "Generic.Poly.change_base_ring..." begin
+@testset "Generic.Poly.change_base_ring" begin
    Zx, x = PolynomialRing(ZZ,'x')
    @test 1 == map_coeffs(sqrt, x^0)
    p = Zx([i for i in 1:10])
@@ -2743,7 +2743,7 @@ end
    @test map_coeffs(t -> F(t) + 2, f) == 3y^2 + 5y^3 + 4y^6
 end
 
-@testset "Generic.Poly.printing..." begin
+@testset "Generic.Poly.printing" begin
    M = MatrixAlgebra(ZZ, 3)
    _, x = M['x']
    @test string(M(-1)*x) isa String

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -16,7 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-@testset "Generic.PuiseuxSeries.constructors..." begin
+@testset "Generic.PuiseuxSeries.constructors" begin
    R, x = PuiseuxSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -91,13 +91,13 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.PuiseuxSeries.printing..." begin
+@testset "Generic.PuiseuxSeries.printing" begin
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
 
    @test occursin("O", string(x^(-1//2) + 1 - x + x^2 + x^5))
 end
 
-@testset "Generic.PuiseuxSeries.rand..." begin
+@testset "Generic.PuiseuxSeries.rand" begin
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
 
    test_rand(R, -12:12, 1:6, -10:10)
@@ -109,7 +109,7 @@ end
    test_rand(R, -12:12, 1:6, make(RealField, -1:1))
 end
 
-@testset "Generic.PuiseuxSeries.manipulation..." begin
+@testset "Generic.PuiseuxSeries.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PuiseuxSeriesRing(R, 30, "x")
 
@@ -148,7 +148,7 @@ end
    @test modulus(T) == 7
 end
 
-@testset "Generic.PuiseuxSeries.unary_ops..." begin
+@testset "Generic.PuiseuxSeries.unary_ops" begin
    #  Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -178,7 +178,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.binary_ops..." begin
+@testset "Generic.PuiseuxSeries.binary_ops" begin
    #  Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -238,7 +238,7 @@ end
    @test isequal(g, f)
 end
 
-@testset "Generic.PuiseuxSeries.adhoc_binary_ops..." begin
+@testset "Generic.PuiseuxSeries.adhoc_binary_ops" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -328,7 +328,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.comparison..." begin
+@testset "Generic.PuiseuxSeries.comparison" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -379,7 +379,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.adhoc_comparison..." begin
+@testset "Generic.PuiseuxSeries.adhoc_comparison" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -476,7 +476,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.powering..." begin
+@testset "Generic.PuiseuxSeries.powering" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
 
@@ -529,7 +529,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.inversion..." begin
+@testset "Generic.PuiseuxSeries.inversion" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -565,7 +565,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.square_root..." begin
+@testset "Generic.PuiseuxSeries.square_root" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -585,7 +585,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.exact_division..." begin
+@testset "Generic.PuiseuxSeries.exact_division" begin
    # Exact ring
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -626,7 +626,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.adhoc_exact_division..." begin
+@testset "Generic.PuiseuxSeries.adhoc_exact_division" begin
    # Exact field
    R, x = PuiseuxSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -665,7 +665,7 @@ end
    end
 end
 
-@testset "Generic.PuiseuxSeries.special_functions..." begin
+@testset "Generic.PuiseuxSeries.special_functions" begin
    # Exact field
    S, x = PuiseuxSeriesRing(QQ, 10, "x")
 

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.QuotientModule.constructors..." begin
+@testset "Generic.QuotientModule.constructors" begin
    R = ZZ
    M = FreeModule(R, 2)
 
@@ -63,7 +63,7 @@
    @test isa(m, Generic.QuotientModuleElem)
 end
 
-@testset "Generic.QuotientModule.manipulation..." begin
+@testset "Generic.QuotientModule.manipulation" begin
    R = ZZ
    M = FreeModule(R, 2)
 
@@ -91,7 +91,7 @@ end
    end
 end
 
-@testset "Generic.QuotientModule.unary_ops..." begin
+@testset "Generic.QuotientModule.unary_ops" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -107,7 +107,7 @@ end
    end
 end
 
-@testset "Generic.QuotientModule.binary_ops..." begin
+@testset "Generic.QuotientModule.binary_ops" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -125,7 +125,7 @@ end
    end
 end
 
-@testset "Generic.QuotientModule.adhoc_binary..." begin
+@testset "Generic.QuotientModule.adhoc_binary" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -146,7 +146,7 @@ end
    end
 end
 
-@testset "Generic.QuotientModule.canonical_projection..." begin
+@testset "Generic.QuotientModule.canonical_projection" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -16,7 +16,7 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-@testset "Generic.RelSeries.constructors..." begin
+@testset "Generic.RelSeries.constructors" begin
    R, x = PowerSeriesRing(ZZ, 30, "x")
 
    S, t = PolynomialRing(QQ, "t")
@@ -82,13 +82,13 @@
    @test_throws DomainError O(0+O(x^0))
 end
 
-@testset "Generic.RelSeries.rand..." begin
+@testset "Generic.RelSeries.rand" begin
    R, x = PowerSeriesRing(ZZ, 10, "x")
 
    test_rand(R, 0:12, -10:10)
 end
 
-@testset "Generic.RelSeries.manipulation..." begin
+@testset "Generic.RelSeries.manipulation" begin
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x")
 
@@ -133,7 +133,7 @@ end
    @test modulus(T) == 7
 end
 
-@testset "Generic.RelSeries.unary_ops..." begin
+@testset "Generic.RelSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -163,7 +163,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.binary_ops..." begin
+@testset "Generic.RelSeries.binary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:100
@@ -212,7 +212,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.adhoc_binary_ops..." begin
+@testset "Generic.RelSeries.adhoc_binary_ops" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -302,7 +302,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.comparison..." begin
+@testset "Generic.RelSeries.comparison" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -353,7 +353,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.adhoc_comparison..." begin
+@testset "Generic.RelSeries.adhoc_comparison" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:500
@@ -450,7 +450,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.powering..." begin
+@testset "Generic.RelSeries.powering" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
 
@@ -515,7 +515,7 @@ end
    @test_throws DomainError f^-rand(2:100)
 end
 
-@testset "Generic.RelSeries.shift..." begin
+@testset "Generic.RelSeries.shift" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -578,7 +578,7 @@ end
    @test_throws DomainError shift_right(f, -rand(2:100))
 end
 
-@testset "Generic.RelSeries.truncation..." begin
+@testset "Generic.RelSeries.truncation" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -626,7 +626,7 @@ end
    @test_throws DomainError truncate(f, -rand(2:100))
 end
 
-@testset "Generic.RelSeries.inversion..." begin
+@testset "Generic.RelSeries.inversion" begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x")
     for iter = 1:300
@@ -662,7 +662,7 @@ end
     end
 end
 
-@testset "Generic.RelSeries.square_root..." begin
+@testset "Generic.RelSeries.square_root" begin
     # Exact ring
     R, x = PowerSeriesRing(ZZ, 10, "x")
     for iter = 1:300
@@ -682,7 +682,7 @@ end
     end
 end
 
-@testset "Generic.RelSeries.exact_division..." begin
+@testset "Generic.RelSeries.exact_division" begin
    # Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -733,7 +733,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.adhoc_exact_division..." begin
+@testset "Generic.RelSeries.adhoc_exact_division" begin
    # Exact field
    R, x = PowerSeriesRing(ZZ, 10, "x")
    for iter = 1:300
@@ -772,7 +772,7 @@ end
    end
 end
 
-@testset "Generic.RelSeries.unsafe_operators..." begin
+@testset "Generic.RelSeries.unsafe_operators" begin
    Qx, x = PowerSeriesRing(GF(13), 10, "x")
    a = 1 + O(x^3)
    c = x^4 + O(x^7)
@@ -797,7 +797,7 @@ end
    @test isequal(a, -3*x*s + 6*x*s^2 + 9*x*s^3 + O(s^4))
 end
 
-@testset "Generic.RelSeries.special_functions..." begin
+@testset "Generic.RelSeries.special_functions" begin
    # Exact field
    S, x = PowerSeriesRing(QQ, 10, "x")
 

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.Res.constructors..." begin
+@testset "Generic.Res.constructors" begin
    B = ZZ
 
    R = Generic.ResidueRing(B, 16453889)
@@ -51,7 +51,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.Res.rand..." begin
+@testset "Generic.Res.rand" begin
    R = Generic.ResidueRing(ZZ, 49)
 
    test_rand(R, 1:9) do f
@@ -65,7 +65,7 @@ end
    test_rand(R, 1:9, -3:3)
 end
 
-@testset "Generic.Res.manipulation..." begin
+@testset "Generic.Res.manipulation" begin
    R = Generic.ResidueRing(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -96,7 +96,7 @@ end
    @test characteristic(R) == 16453889
 end
 
-@testset "Generic.Res.unary_ops..." begin
+@testset "Generic.Res.unary_ops" begin
    R = Generic.ResidueRing(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -107,7 +107,7 @@ end
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
 end
 
-@testset "Generic.Res.binary_ops..." begin
+@testset "Generic.Res.binary_ops" begin
    R = Generic.ResidueRing(ZZ, 12)
 
    f = R(4)
@@ -133,7 +133,7 @@ end
    @test n*p == T(3x^2 + 4x + 4)
 end
 
-@testset "Generic.Res.gcd..." begin
+@testset "Generic.Res.gcd" begin
    R = Generic.ResidueRing(ZZ, 12)
 
    f = R(4)
@@ -151,7 +151,7 @@ end
    @test gcd(n, p) == 1
 end
 
-@testset "Generic.Res.adhoc_binary..." begin
+@testset "Generic.Res.adhoc_binary" begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -174,7 +174,7 @@ end
    @test f*5 == T(2*x^2+3*x+6)
 end
 
-@testset "Generic.Res.comparison..." begin
+@testset "Generic.Res.comparison" begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -200,7 +200,7 @@ end
    @test isequal(f, g)
 end
 
-@testset "Generic.Res.adhoc_comparison..." begin
+@testset "Generic.Res.adhoc_comparison" begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -216,7 +216,7 @@ end
    @test f != 5
 end
 
-@testset "Generic.Res.powering..." begin
+@testset "Generic.Res.powering" begin
    R = Generic.ResidueRing(ZZ, 7)
 
    a = R(3)
@@ -231,7 +231,7 @@ end
    @test f^100 == T(x^2 + 2x + 1)
 end
 
-@testset "Generic.Res.inversion..." begin
+@testset "Generic.Res.inversion" begin
    R = Generic.ResidueRing(ZZ, 49)
 
    a = R(5)
@@ -247,7 +247,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.Res.exact_division..." begin
+@testset "Generic.Res.exact_division" begin
    R = Generic.ResidueRing(ZZ, 49)
 
    a = R(5)

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.ResF.constructors..." begin
+@testset "Generic.ResF.constructors" begin
    B = ZZ
 
    R = Generic.ResidueField(B, 16453889)
@@ -49,7 +49,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.ResF.printing..." begin
+@testset "Generic.ResF.printing" begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    @test string(zero(R)) == "0"
@@ -63,7 +63,7 @@ end
    @test string(5*x^5+3*x^3+2*x^2+x+1) == "5*x^5 + 3*x^3 + 2*x^2 + x + 1"
 end
 
-@testset "Generic.ResF.rand..." begin
+@testset "Generic.ResF.rand" begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    test_rand(R, 1:9) do f
@@ -71,7 +71,7 @@ end
    end
 end
 
-@testset "Generic.ResF.manipulation..." begin
+@testset "Generic.ResF.manipulation" begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -100,7 +100,7 @@ end
    @test deepcopy(h) == h
 end
 
-@testset "Generic.ResF.unary_ops..." begin
+@testset "Generic.ResF.unary_ops" begin
    R = Generic.ResidueField(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -111,7 +111,7 @@ end
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
 end
 
-@testset "Generic.ResF.binary_ops..." begin
+@testset "Generic.ResF.binary_ops" begin
    R = Generic.ResidueField(ZZ, 13)
 
    f = R(4)
@@ -137,7 +137,7 @@ end
    @test n*p == T(3x^2 + 4x + 4)
 end
 
-@testset "Generic.ResF.gcd..." begin
+@testset "Generic.ResF.gcd" begin
    R = Generic.ResidueField(ZZ, 13)
 
    f = R(4)
@@ -155,7 +155,7 @@ end
    @test gcd(n, p) == 1
 end
 
-@testset "Generic.ResF.adhoc_binary..." begin
+@testset "Generic.ResF.adhoc_binary" begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -178,7 +178,7 @@ end
    @test f*5 == T(2*x^2+3*x+6)
 end
 
-@testset "Generic.ResF.comparison..." begin
+@testset "Generic.ResF.comparison" begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -204,7 +204,7 @@ end
    @test isequal(f, g)
 end
 
-@testset "Generic.ResF.adhoc_comparison..." begin
+@testset "Generic.ResF.adhoc_comparison" begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -220,7 +220,7 @@ end
    @test f != 5
 end
 
-@testset "Generic.ResF.powering..." begin
+@testset "Generic.ResF.powering" begin
    R = Generic.ResidueField(ZZ, 7)
 
    a = R(3)
@@ -235,7 +235,7 @@ end
    @test f^100 == T(x^2 + 2x + 1)
 end
 
-@testset "Generic.ResF.inversion..." begin
+@testset "Generic.ResF.inversion" begin
    R = Generic.ResidueField(ZZ, 47)
 
    a = R(5)
@@ -251,7 +251,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.ResF.exact_division..." begin
+@testset "Generic.ResF.exact_division" begin
    R = Generic.ResidueField(ZZ, 47)
 
    a = R(5)
@@ -269,7 +269,7 @@ end
    @test divexact(f, g) == T(7*x^2+25*x+26)
 end
 
-@testset "Generic.ResF.square_root..." begin
+@testset "Generic.ResF.square_root" begin
    for p in [3, 47, 733, 13913, 168937, 3980299, 57586577]
        R = Generic.ResidueField(ZZ, p)
 

--- a/test/generic/SparsePoly-test.jl
+++ b/test/generic/SparsePoly-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.SparsePoly.constructors..." begin
+@testset "Generic.SparsePoly.constructors" begin
    R, x = SparsePolynomialRing(ZZ, "x")
    S, y = SparsePolynomialRing(R, "y")
 
@@ -9,7 +9,7 @@
    @test typeof(T) <: Generic.SparsePolyRing
 end
 
-@testset "Generic.SparsePoly.printing..." begin
+@testset "Generic.SparsePoly.printing" begin
    R, x = SparsePolynomialRing(ZZ, "x")
 
    @test string(zero(R)) == "0"

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.Submodule.constructors..." begin
+@testset "Generic.Submodule.constructors" begin
    R = ZZ
    M = FreeModule(R, 2)
    m = M([R(1), R(3)])
@@ -53,7 +53,7 @@
    @test isa(m, Generic.SubmoduleElem)
 end
 
-@testset "Generic.Submodule.manipulation..." begin
+@testset "Generic.Submodule.manipulation" begin
    R = ZZ
    M = FreeModule(R, 2)
    m = M([R(1), R(3)])
@@ -78,7 +78,7 @@ end
    end
 end
 
-@testset "Generic.Submodule.unary_ops..." begin
+@testset "Generic.Submodule.unary_ops" begin
    for R in [ZZ, QQ]
       for iter = 1:20
          M = rand_module(R, -10:10)
@@ -93,7 +93,7 @@ end
    end
 end
 
-@testset "Generic.Submodule.binary_ops..." begin
+@testset "Generic.Submodule.binary_ops" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -110,7 +110,7 @@ end
    end
 end
 
-@testset "Generic.Submodule.adhoc_binary..." begin
+@testset "Generic.Submodule.adhoc_binary" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)
@@ -130,7 +130,7 @@ end
    end
 end
 
-@testset "Generic.Submodule.canonical_injection..." begin
+@testset "Generic.Submodule.canonical_injection" begin
    for R in [ZZ, QQ]
       for iter = 1:40
          M = rand_module(R, -10:10)

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -1,4 +1,4 @@
-@testset "youngtabs.partition_type..." begin
+@testset "youngtabs.partition_type" begin
    @test Partition([4,3,1]) isa Generic.Partition
    @test Partition([4,3,1]) isa AbstractVector{Int}
    @test Partition([3,4,1]) isa Generic.Partition
@@ -31,7 +31,7 @@
    @test p != r
 end
 
-@testset "youngtabs.partition_iter..." begin
+@testset "youngtabs.partition_iter" begin
    @test [Generic._numpart(i) for i in 0:10] == [1,1,2,3,5,7,11,15,22,30,42]
    @test Generic._numpart(100) == 190_569_292
    @test Generic._numpart(1000) == 24_061_467_864_032_622_473_692_149_727_991
@@ -43,7 +43,7 @@ end
    @test collect(AllParts(0)) == [Partition(Int[])]
 end
 
-@testset "youngtabs.youngtableau_type..." begin
+@testset "youngtabs.youngtableau_type" begin
    lambda = [4,3,1]
    @test YoungTableau(Partition(lambda)) isa Generic.YoungTableau
    @test YoungTableau(Partition(lambda)) isa AbstractArray{Int, 2}
@@ -80,7 +80,7 @@ end
    end
 end
 
-@testset "youngtabs.conjugation..." begin
+@testset "youngtabs.conjugation" begin
    @test conj(Partition([1,1,1,1])) == Partition([4])
    @test conj(Partition([2,1,1])) == Partition([3,1])
 
@@ -105,7 +105,7 @@ end
 end
 
 
-@testset "youngtabs.dim..." begin
+@testset "youngtabs.dim" begin
    y = YoungTableau([5,4,3,3,1,1])
    # ┌───┬───┬───┬───┬───┐
    # │ 1 │ 2 │ 3 │ 4 │ 5 │
@@ -172,7 +172,7 @@ end
    @test dim(YoungTableau(collect(10:-1:1))) == 44261486084874072183645699204710400
 end
 
-@testset "youngtabs.skewdiags..." begin
+@testset "youngtabs.skewdiags" begin
    l = Partition([5,3,2,2,2,1,1])
    m = Partition([2,2,1])
    xi = l/m
@@ -226,7 +226,7 @@ end
    @test has_bottom_neighbor(xi, 7, 1) == false
 end
 
-@testset "youngtabs.rimhooks..." begin
+@testset "youngtabs.rimhooks" begin
    xi = Partition([2,1])/Partition(Int[], false)
    @test isrimhook(xi) == true
 
@@ -275,7 +275,7 @@ end
    @test isrimhook(lambda/mu) == false # is disconnected
 end
 
-@testset "youngtabs.partitionseqs..." begin
+@testset "youngtabs.partitionseqs" begin
    @test partitionseq(Partition([1])) == BitVector([true, false])
    @test partitionseq([1]) == BitVector([true, false])
    @test partitionseq(Partition([1,1])) == BitVector([true, false, false])

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -1,4 +1,4 @@
-@testset "Julia.Floats.constructors..." begin
+@testset "Julia.Floats.constructors" begin
    R = RDF
    S = RealField
 
@@ -32,13 +32,13 @@
    @test isa(S(b), BigFloat)
 end
 
-@testset "Julia.Floats.printing...." begin
+@testset "Julia.Floats.printing." begin
    R, x = PolynomialRing(RealField, "x")
 
    @test !occursin("+", string(2*x^2-3*x))
 end
 
-@testset "Julia.Floats.rand..." begin
+@testset "Julia.Floats.rand" begin
    R = RealField
 
    test(x) = @test 1.0 <= x <= 9.0
@@ -47,7 +47,7 @@ end
    test_rand(test, R, UnitRange(big(1.0), big(9.0)))
 end
 
-@testset "Julia.Floats.manipulation..." begin
+@testset "Julia.Floats.manipulation" begin
    R = RDF
    S = RealField
 
@@ -63,7 +63,7 @@ end
    @test isunit(S(3))
 end
 
-@testset "Julia.Floats.exact_division..." begin
+@testset "Julia.Floats.exact_division" begin
    R = RDF
    S = RealField
 
@@ -86,7 +86,7 @@ end
    end
 end
 
-@testset "Julia.Floats.divrem..." begin
+@testset "Julia.Floats.divrem" begin
    R = RealField
 
    for iter = 1:1000
@@ -100,7 +100,7 @@ end
    end
 end
 
-@testset "Julia.Floats.gcd..." begin
+@testset "Julia.Floats.gcd" begin
    R = RDF
    S = RealField
 

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -1,4 +1,4 @@
-@testset "Julia.GFElem.constructors..." begin
+@testset "Julia.GFElem.constructors" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -32,7 +32,7 @@
    @test F isa AbstractAlgebra.GFField{Int64}
 end
 
-@testset "Julia.GFElem.printing..." begin
+@testset "Julia.GFElem.printing" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -47,7 +47,7 @@ end
    @test !occursin("1", string(x^2+2*x))
 end
 
-@testset "Julia.GFElem.manipulation..." begin
+@testset "Julia.GFElem.manipulation" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -81,11 +81,11 @@ end
    @test S === S1
 end
 
-@testset "Julia.GFElem.rand..." begin
+@testset "Julia.GFElem.rand" begin
    test_rand(GF(13))
 end
 
-@testset "Julia.GFElem.unary_ops..." begin
+@testset "Julia.GFElem.unary_ops" begin
    for (T, p) in [(Int8, 127),
                   (UInt8, 251),
                   (Int16, 32749),
@@ -106,7 +106,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.binary_ops..." begin
+@testset "Julia.GFElem.binary_ops" begin
    for (T, p) in [(Int8, 127),
                   (UInt8, 251),
                   (Int16, 32749),
@@ -149,7 +149,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.adhoc_binary..." begin
+@testset "Julia.GFElem.adhoc_binary" begin
    for (T, p) in [(Int8, 127),
                   (UInt8, 251),
                   (Int16, 32749),
@@ -182,7 +182,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.powering..." begin
+@testset "Julia.GFElem.powering" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -222,7 +222,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.comparison..." begin
+@testset "Julia.GFElem.comparison" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -243,7 +243,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.adhoc_comparison..." begin
+@testset "Julia.GFElem.adhoc_comparison" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -263,7 +263,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.inversion..." begin
+@testset "Julia.GFElem.inversion" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -279,7 +279,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.exact_division..." begin
+@testset "Julia.GFElem.exact_division" begin
    R = GF(13)
    S = GF(BigInt(13))
 
@@ -294,7 +294,7 @@ end
    end
 end
 
-@testset "Julia.GFElem.iteration..." begin
+@testset "Julia.GFElem.iteration" begin
    for n = [2, 3, 5, 13, 31]
       R = GF(n)
       elts = AbstractAlgebra.test_iterate(R)

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -1,4 +1,4 @@
-@testset "Julia.Integers.constructors..." begin
+@testset "Julia.Integers.constructors" begin
    R = zz
    S = ZZ
 
@@ -26,7 +26,7 @@
    @test isa(S(b), BigInt)
 end
 
-@testset "Julia.Integers.manipulation..." begin
+@testset "Julia.Integers.manipulation" begin
    R = zz
    S = ZZ
 
@@ -46,13 +46,13 @@ end
    @test isunit(S(-1))
 end
 
-@testset "Julia.Integers.rand..." begin
+@testset "Julia.Integers.rand" begin
    test_rand(ZZ, 0:22) do f
       f in 0:22
    end
 end
 
-@testset "Julia.Integers.modular_arithmetic..." begin
+@testset "Julia.Integers.modular_arithmetic" begin
    R = zz
    S = ZZ
 
@@ -82,7 +82,7 @@ end
    @test_throws DomainError powmod(123, -rand(2:100), 5)
 end
 
-@testset "Julia.Integers.exact_division..." begin
+@testset "Julia.Integers.exact_division" begin
    R = zz
    S = ZZ
 
@@ -115,7 +115,7 @@ end
    end
 end
 
-@testset "Julia.Integers.inv..." begin
+@testset "Julia.Integers.inv" begin
    @test AbstractAlgebra.inv(ZZ(1)) == 1
    @test AbstractAlgebra.inv(-ZZ(1)) == -1
    @test AbstractAlgebra.inv(zz(1)) == 1
@@ -125,7 +125,7 @@ end
    @test_throws DivideError AbstractAlgebra.inv(ZZ(0))
 end
 
-@testset "Julia.Integers.gcd..." begin
+@testset "Julia.Integers.gcd" begin
    R = zz
    S = ZZ
 
@@ -148,7 +148,7 @@ end
    end
 end
 
-@testset "Julia.Integers.square_root..." begin
+@testset "Julia.Integers.square_root" begin
    R = zz
    S = ZZ
 
@@ -166,7 +166,7 @@ end
    end
 end
 
-@testset "Julia.Integers.exp..." begin
+@testset "Julia.Integers.exp" begin
    @test AbstractAlgebra.exp(0) == 1
    @test_throws DomainError AbstractAlgebra.exp(1)
    @test_throws DomainError AbstractAlgebra.exp(rand(2:1000))

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -1,4 +1,4 @@
-@testset "Julia.Rationals.constructors..." begin
+@testset "Julia.Rationals.constructors" begin
    R = qq
    S = QQ
 
@@ -35,14 +35,14 @@
    @test isa(S(b), Rational{BigInt})
 end
 
-@testset "Julia.Rationals.rand..." begin
+@testset "Julia.Rationals.rand" begin
    test_rand(QQ, 1:9) do f
       @test 1 <= numerator(f) <= 9
       @test 1 <= denominator(f) <= 9
    end
 end
 
-@testset "Julia.Rationals.manipulation..." begin
+@testset "Julia.Rationals.manipulation" begin
    R = qq
    S = QQ
 
@@ -58,7 +58,7 @@ end
    @test isunit(S(3))
 end
 
-@testset "Julia.Rationals.exact_division..." begin
+@testset "Julia.Rationals.exact_division" begin
    R = qq
    S = QQ
 
@@ -95,7 +95,7 @@ end
    end
 end
 
-@testset "Julia.Rationals.gcd..." begin
+@testset "Julia.Rationals.gcd" begin
    R = qq
    S = QQ
 
@@ -112,7 +112,7 @@ end
    end
 end
 
-@testset "Julia.Rationals.square_root..." begin
+@testset "Julia.Rationals.square_root" begin
    R = qq
    S = QQ
 
@@ -130,14 +130,14 @@ end
    end
 end
 
-@testset "Julia.Rationals.exp..." begin
+@testset "Julia.Rationals.exp" begin
    @test AbstractAlgebra.exp(0//1) == 1
    @test_throws DomainError AbstractAlgebra.exp(1//1)
    @test_throws DomainError AbstractAlgebra.exp(rand(2:1000)//rand(1:1000))
    @test_throws DomainError AbstractAlgebra.exp(-rand(1:1000//rand(1:1000)))
 end
 
-@testset "Julia.Rationals.divrem..." begin
+@testset "Julia.Rationals.divrem" begin
    R = qq
    S = QQ
 


### PR DESCRIPTION
These come presumably from a time where `@testset`s were not used, and the three dots were
printed to indicate that the result is coming, but now the whole line comes at once,
so the three dots are pretty useless.