### PR TITLE
Implement WeakValueDict and use it for caching

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -306,6 +306,34 @@ function force_op(op::Function, a...)
 end
 
 ###############################################################################
+#
+#  Weak value dictionaries
+#
+###############################################################################
+
+include("WeakValueDict.jl")
+
+###############################################################################
+#
+#  Type for the Hash dictionary
+#
+###############################################################################
+
+@static if VERSION >= v"1.6"
+  const CacheDictType = WeakValueDict
+else
+  const CacheDictType = Dict
+end
+
+function get_cached!(default::Base.Callable, dict::CacheDictType, key, use_cache::Bool)
+   return use_cache ? Base.get!(default, dict, key) : default()
+end
+
+###############################################################################
+#
+#  Types
+#
+################################################################################
 
 include("AbstractTypes.jl")
 
@@ -666,7 +694,7 @@ function SparsePolynomialRing(R::Ring, s::Char; cached::Bool = true)
 end
 
 @doc (@doc Generic.LaurentPolynomialRing)
-LaurentPolynomialRing(R::Ring, s::AbstractString) = Generic.LaurentPolynomialRing(R, s)
+LaurentPolynomialRing(R::Ring, s::AbstractString; cached::Bool = true) = Generic.LaurentPolynomialRing(R, s)
 
 function MatrixSpace(R::Ring, r::Int, c::Int; cached::Bool = true)
    Generic.MatrixSpace(R, r, c; cached = cached)

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -325,7 +325,9 @@ else
   const CacheDictType = Dict
 end
 
-function get_cached!(default::Base.Callable, dict::CacheDictType, key, use_cache::Bool)
+function get_cached!(default::Base.Callable, dict::AbstractDict,
+                                             key,
+                                             use_cache::Bool)
    return use_cache ? Base.get!(default, dict, key) : default()
 end
 
@@ -694,7 +696,7 @@ function SparsePolynomialRing(R::Ring, s::Char; cached::Bool = true)
 end
 
 @doc (@doc Generic.LaurentPolynomialRing)
-LaurentPolynomialRing(R::Ring, s::AbstractString; cached::Bool = true) = Generic.LaurentPolynomialRing(R, s)
+LaurentPolynomialRing(R::Ring, s::AbstractString) = Generic.LaurentPolynomialRing(R, s)
 
 function MatrixSpace(R::Ring, r::Int, c::Int; cached::Bool = true)
    Generic.MatrixSpace(R, r, c; cached = cached)

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -25,6 +25,9 @@ import Base: floor, ceil, hypot, log, log1p, expm1, sin, cos, sinpi, cospi,
              tan, cot, sinh, cosh, tanh, coth, atan, asin, acos, atanh, asinh,
              acosh, sinpi, cospi
 
+# The type and helper function for the dictionaries for hashing
+import ..AbstractAlgebra: CacheDictType, get_cached!
+
 import ..AbstractAlgebra: Integers, Rationals, NCRing, NCRingElem, Ring,
                           RingElem, RingElement, Field, FieldElement,
                           isexact_type, isdomain_type, Map, promote_rule

--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -1,0 +1,222 @@
+# Weak value dictionaries
+#
+# This file is a modification of base/weakkeydict.jl from the Julia project.
+
+import Base: isempty, setindex!, getkey, length, iterate, empty, delete!, pop!, get, sizehint!, copy
+"""
+    WeakValueDict([itr])
+
+`WeakValueDict()` constructs a hash table where the values are weak
+references to objects which may be garbage collected even when
+used as keys in a hash table.
+"""
+mutable struct WeakValueDict{K,V} <: AbstractDict{K,V}
+    ht::Dict{K,WeakRef}
+    lock::ReentrantLock
+    finalizer::Function
+    dirty::Bool
+
+    # Constructors mirror Dict's
+    function WeakValueDict{K,V}() where V where K
+        t = new(Dict{K,Any}(), ReentrantLock(), identity, 0)
+        t.finalizer = v -> t.dirty = true
+        return t
+    end
+end
+function WeakValueDict{K,V}(kv) where V where K
+    h = WeakValueDict{K,V}()
+    for (k,v) in kv
+
+        h[k] = v
+    end
+    return h
+end
+WeakValueDict{K,V}(p::Pair) where V where K = setindex!(WeakValueDict{K,V}(), p.second, p.first)
+
+function WeakValueDict{K,V}(ps::Pair...) where V where K
+    h = WeakValueDict{K,V}()
+    sizehint!(h, length(ps))
+    for p in ps
+        h[p.first] = p.second
+    end
+    return h
+end
+WeakValueDict() = WeakValueDict{Any,Any}()
+
+WeakValueDict(kv::Tuple{}) = WeakValueDict()
+Base.copy(d::WeakValueDict) = WeakValueDict(d)
+
+WeakValueDict(ps::Pair{K,V}...)           where {K,V} = WeakValueDict{K,V}(ps)
+WeakValueDict(ps::Pair{K}...)             where {K}   = WeakValueDict{K,Any}(ps)
+WeakValueDict(ps::(Pair{K,V} where K)...) where {V}   = WeakValueDict{Any,V}(ps)
+WeakValueDict(ps::Pair...)                            = WeakValueDict{Any,Any}(ps)
+
+function WeakValueDict(kv)
+    try
+        Base.dict_with_eltype((K, V) -> WeakValueDict{K, V}, kv, eltype(kv))
+    catch
+        if !Base.isiterable(typeof(kv)) || !all(x->isa(x,Union{Tuple,Pair}),kv)
+            throw(ArgumentError("WeakValueDict(kv): kv needs to be an iterator of tuples or pairs"))
+        else
+            rethrow()
+        end
+    end
+end
+
+function _cleanup_locked(h::WeakValueDict)
+    if h.dirty
+        h.dirty = false
+        idx = Base.skip_deleted_floor!(h.ht)
+        while idx != 0
+            if h.ht.vals[idx].value === nothing
+                Base._delete!(h.ht, idx)
+            end
+            idx = Base.skip_deleted(h.ht, idx + 1)
+        end
+    end
+    return h
+end
+
+Base.sizehint!(d::WeakValueDict, newsz) = sizehint!(d.ht, newsz)
+empty(d::WeakValueDict, ::Type{K}, ::Type{V}) where {K, V} = WeakValueDict{K, V}()
+
+IteratorSize(::Type{<:WeakValueDict}) = SizeUnknown()
+
+islocked(wkh::WeakValueDict) = Base.islocked(wkh.lock)
+lock(f, wkh::WeakValueDict) = Base.lock(f, wkh.lock)
+trylock(f, wkh::WeakValueDict) = Base.trylock(f, wkh.lock)
+
+function Base.setindex!(wkh::WeakValueDict{K}, v, key) where K
+    !isa(key, K) && throw(ArgumentError("$(Base.limitrepr(key)) is not a valid key for type $K"))
+    # 'nothing' is not valid both because 'finalizer' will reject it,
+    # and because we therefore use it as a sentinel value
+    v === nothing && throw(ArgumentError("`nothing` is not a valid WeakValueDict key"))
+    lock(wkh) do
+        _cleanup_locked(wkh)
+        k = getkey(wkh.ht, key, nothing)
+        # The object gets the finalizer no matter if the key is already there or not.
+        finalizer(wkh.finalizer, v)
+        if k === nothing
+            k = key
+        end
+        wkh.ht[k] = WeakRef(v)
+    end
+    return wkh
+end
+function get!(wkh::WeakValueDict{K}, key, default) where {K}
+    v = lock(wkh) do
+        if key !== nothing && haskey(wkh.ht, key)
+            wkh.ht[key].value
+        else
+            wkh[key] = WeakRef(default)
+            default
+        end
+    end
+    return v
+end
+function Base.get!(default::Base.Callable, wkh::WeakValueDict{K}, key) where {K}
+    v = lock(wkh) do
+        _cleanup_locked(wkh)
+        if key !== nothing && haskey(wkh.ht, key)
+            wkh.ht[key].value
+        else
+            wkh[key] = default()
+        end
+    end
+    return v
+end
+
+function Base.getkey(wkh::WeakValueDict{K}, kk, default) where K
+    k = lock(wkh) do
+        k = getkey(wkh.ht, kk, nothing)
+        k === nothing && return nothing
+        return k
+    end
+    return k === nothing ? default : k::K
+end
+
+map!(f, iter::Base.ValueIterator{<:WeakValueDict})= map!(f, values(iter.dict.ht))
+
+function Base.get(wkh::WeakValueDict{K, V}, key, default) where {K, V}
+    key === nothing && throw(KeyError(nothing))
+    lock(wkh) do
+        _cleanup_locked(wkh)
+        x = get(wkh.ht, key, default)
+        if x === default
+            return x
+        else
+            return x.value::V
+        end
+    end
+end
+function Base.get(default::Base.Callable, wkh::WeakValueDict{K}, key) where {K}
+    key === nothing && throw(KeyError(nothing))
+    lock(wkh) do
+        return get(default, wkh.ht, key)
+    end
+end
+function Base.pop!(wkh::WeakValueDict{K}, key) where {K}
+    key === nothing && throw(KeyError(nothing))
+    lock(wkh) do
+        return pop!(wkh.ht, key).value
+    end
+end
+function Base.pop!(wkh::WeakValueDict{K}, key, default) where {K}
+    key === nothing && return default
+    lock(wkh) do
+        return pop!(wkh.ht, key, default)
+    end
+end
+function Base.delete!(wkh::WeakValueDict, key)
+    key === nothing && return wkh
+    lock(wkh) do
+        delete!(wkh.ht, key)
+    end
+    return wkh
+end
+function Base.empty!(wkh::WeakValueDict)
+    lock(wkh) do
+        empty!(wkh.ht)
+    end
+    return wkh
+end
+function Base.haskey(wkh::WeakValueDict{K}, key) where {K}
+    key === nothing && return false
+    lock(wkh) do
+        return haskey(wkh.ht, key)
+    end
+end
+function Base.getindex(wkh::WeakValueDict{K}, key) where {K}
+    key === nothing && throw(KeyError(nothing))
+    lock(wkh) do
+        return getindex(wkh.ht, key).value
+    end
+end
+
+Base.isempty(wkh::WeakValueDict) = length(wkh) == 0
+function Base.length(t::WeakValueDict)
+    lock(t) do
+        _cleanup_locked(t)
+        return length(t.ht)
+    end
+end
+
+function Base.iterate(t::WeakValueDict{K,V}, state...) where {K, V}
+    return lock(t) do
+        while true
+            y = iterate(t.ht, state...)
+            y === nothing && return nothing
+            wkv, state = y
+            k = wkv[1]
+            v = wkv[2].value
+            if VERSION >= v"1.6"
+              GC.safepoint() # ensure `v` is now gc-rooted
+            end
+            k === nothing && continue # indicates `k` is scheduled for deletion
+            kv = Pair{K,V}(k::K, v)
+            return (kv, state)
+        end
+    end
+end
+
+filter!(f, d::WeakValueDict) = Base.filter_in_one_pass!(f, d)

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -319,19 +319,13 @@ mutable struct PolyRing{T <: RingElement} <: AbstractAlgebra.PolyRing{T}
    S::Symbol
 
    function PolyRing{T}(R::Ring, s::Symbol, cached::Bool = true) where T <: RingElement
-      if cached && haskey(PolyID, (R, s))
-         return PolyID[R, s]::PolyRing{T}
-      else
-         z = new{T}(R, s)
-         if cached
-           PolyID[R, s] = z
-         end
-         return z
-      end
+      return get_cached!(PolyID, (R, s), cached) do
+         new{T}(R, s)
+      end::PolyRing{T}
    end
 end
 
-const PolyID = Dict{Tuple{Ring, Symbol}, Ring}()
+const PolyID = CacheDictType{Tuple{Ring, Symbol}, Ring}()
 
 mutable struct Poly{T <: RingElement} <: AbstractAlgebra.PolyElem{T}
    coeffs::Array{T, 1}
@@ -360,19 +354,13 @@ mutable struct NCPolyRing{T <: NCRingElem} <: AbstractAlgebra.NCPolyRing{T}
    S::Symbol
 
    function NCPolyRing{T}(R::NCRing, s::Symbol, cached::Bool = true) where T <: NCRingElem
-      if cached && haskey(NCPolyID, (R, s))
-         return NCPolyID[R, s]::NCPolyRing{T}
-      else
-         z = new{T}(R, s)
-         if cached
-           NCPolyID[R, s] = z
-         end
-         return z
-      end
+      return get_cached!(NCPolyID, (R, s), cached) do
+         new{T}(R, s)
+      end::NCPolyRing{T}
    end
 end
 
-const NCPolyID = Dict{Tuple{NCRing, Symbol}, NCRing}()
+const NCPolyID = CacheDictType{Tuple{NCRing, Symbol}, NCRing}()
 
 mutable struct NCPoly{T <: NCRingElem} <: AbstractAlgebra.NCPolyElem{T}
    coeffs::Array{T, 1}
@@ -416,19 +404,13 @@ mutable struct MPolyRing{T <: RingElement} <: AbstractAlgebra.MPolyRing{T}
 
    function MPolyRing{T}(R::Ring, s::Array{Symbol, 1}, ord::Symbol, N::Int,
                          cached::Bool = true) where T <: RingElement
-      if cached && haskey(MPolyID, (R, s, ord, N))
-         return MPolyID[R, s, ord, N]::MPolyRing{T}
-      else
-         z = new{T}(R, s, ord, length(s), N)
-         if cached
-           MPolyID[R, s, ord, N] = z
-         end
-         return z
-      end
+      return get_cached!(MPolyID, (R, s, ord, N), cached) do
+         new{T}(R, s, ord, length(s), N)
+      end::MPolyRing{T}
    end
 end
 
-const MPolyID = Dict{Tuple{Ring, Array{Symbol, 1}, Symbol, Int}, Ring}()
+const MPolyID = CacheDictType{Tuple{Ring, Array{Symbol, 1}, Symbol, Int}, Ring}()
 
 mutable struct MPoly{T <: RingElement} <: AbstractAlgebra.MPolyElem{T}
    coeffs::Array{T, 1}
@@ -491,19 +473,13 @@ mutable struct SparsePolyRing{T <: RingElement} <: AbstractAlgebra.Ring
    num_vars::Int
 
    function SparsePolyRing{T}(R::Ring, s::Symbol, cached::Bool = true) where T <: RingElement
-      if cached && haskey(SparsePolyID, (R, s))
-         return SparsePolyID[R, s]::SparsePolyRing{T}
-      else
-         z = new{T}(R, s)
-         if cached
-           SparsePolyID[R, s] = z
-         end
-         return z
-      end
+      return get_cached!(SparsePolyID, (R, s), cached) do
+         new{T}(R, s)
+      end::SparsePolyRing{T}
    end
 end
 
-const SparsePolyID = Dict{Tuple{Ring, Symbol}, SparsePolyRing}()
+const SparsePolyID = CacheDictType{Tuple{Ring, Symbol}, SparsePolyRing}()
 
 mutable struct SparsePoly{T <: RingElement} <: AbstractAlgebra.RingElem
    coeffs::Array{T, 1}
@@ -572,19 +548,15 @@ mutable struct ResRing{T <: RingElement} <: AbstractAlgebra.ResRing{T}
       if !isone(c)
         modulus = divexact(modulus, c)
       end
-      if cached && haskey(ModulusDict, (parent(modulus), modulus))
-         return ModulusDict[parent(modulus), modulus]::ResRing{T}
-      else
-         z = new{T}(parent(modulus), modulus)
-         if cached
-            ModulusDict[parent(modulus), modulus] = z
-         end
-         return z
-      end
+      R = parent(modulus)
+
+      return get_cached!(ModulusDict, (R, modulus), cached) do
+         new{T}(R, modulus)
+      end::ResRing{T}
    end
 end
 
-const ModulusDict = Dict{Tuple{Ring, RingElement}, Ring}()
+const ModulusDict = CacheDictType{Tuple{Ring, RingElement}, Ring}()
 
 mutable struct Res{T <: RingElement} <: AbstractAlgebra.ResElem{T}
    data::T
@@ -608,19 +580,14 @@ mutable struct ResField{T <: RingElement} <: AbstractAlgebra.ResField{T}
       if !isone(c)
         modulus = divexact(modulus, c)
       end
-      if cached && haskey(ModulusFieldDict, (parent(modulus), modulus))
-         return ModulusFieldDict[parent(modulus), modulus]::ResField{T}
-      else
-         z = new{T}(parent(modulus), modulus)
-         if cached
-            ModulusFieldDict[parent(modulus), modulus] = z
-         end
-         return z
-      end
+      R = parent(modulus)
+      return get_cached!(ModulusFieldDict, (R, modulus), cached) do
+         new{T}(R, modulus)
+      end::ResField{T}
    end
 end
 
-const ModulusFieldDict = Dict{Tuple{Ring, RingElement}, Field}()
+const ModulusFieldDict = CacheDictType{Tuple{Ring, RingElement}, Field}()
 
 mutable struct ResF{T <: RingElement} <: AbstractAlgebra.ResFieldElem{T}
    data::T
@@ -641,19 +608,13 @@ mutable struct RelSeriesRing{T <: RingElement} <: AbstractAlgebra.SeriesRing{T}
    S::Symbol
 
    function RelSeriesRing{T}(R::Ring, prec::Int, s::Symbol, cached::Bool = true) where T <: RingElement
-      if cached && haskey(RelSeriesID, (R, prec, s))
-         return RelSeriesID[R, prec, s]::RelSeriesRing{T}
-      else
-         z = new{T}(R, prec, s)
-         if cached
-            RelSeriesID[R, prec, s] = z
-         end
-         return z
-      end
+      return get_cached!(RelSeriesID, (R, prec, s), cached) do
+         new{T}(R, prec, s)
+      end::RelSeriesRing{T}
    end
 end
 
-const RelSeriesID = Dict{Tuple{Ring, Int, Symbol}, Ring}()
+const RelSeriesID = CacheDictType{Tuple{Ring, Int, Symbol}, Ring}()
 
 mutable struct RelSeries{T <: RingElement} <: AbstractAlgebra.RelSeriesElem{T}
    coeffs::Array{T, 1}
@@ -681,19 +642,13 @@ mutable struct AbsSeriesRing{T <: RingElement} <: AbstractAlgebra.SeriesRing{T}
    S::Symbol
 
    function AbsSeriesRing{T}(R::Ring, prec::Int, s::Symbol, cached::Bool = true) where T <: RingElement
-      if cached && haskey(AbsSeriesID, (R, prec, s))
-         return AbsSeriesID[R, prec, s]::AbsSeriesRing{T}
-      else
-         z = new{T}(R, prec, s)
-         if cached
-            AbsSeriesID[R, prec, s] = z
-         end
-         return z
-      end
+      return get_cached!(AbsSeriesID, (R, prec, s), cached) do
+         new{T}(R, prec, s)
+      end::AbsSeriesRing{T}
    end
 end
 
-const AbsSeriesID = Dict{Tuple{Ring, Int, Symbol}, Ring}()
+const AbsSeriesID = CacheDictType{Tuple{Ring, Int, Symbol}, Ring}()
 
 mutable struct AbsSeries{T <: RingElement} <: AbstractAlgebra.AbsSeriesElem{T}
    coeffs::Array{T, 1}
@@ -717,19 +672,13 @@ mutable struct LaurentSeriesRing{T <: RingElement} <: AbstractAlgebra.Ring
    S::Symbol
 
    function LaurentSeriesRing{T}(R::Ring, prec::Int, s::Symbol, cached::Bool = true) where T <: RingElement
-      if cached && haskey(LaurentSeriesID, (R, prec, s))
-         return LaurentSeriesID[R, prec, s]::LaurentSeriesRing{T}
-      else
-         z = new{T}(R, prec, s)
-         if cached
-            LaurentSeriesID[R, prec, s] = z
-         end
-         return z
-      end
+      return get_cached!(LaurentSeriesID, (R, prec, s), cached) do
+         new{T}(R, prec, s)
+      end::LaurentSeriesRing{T}
    end
 end
 
-const LaurentSeriesID = Dict{Tuple{Ring, Int, Symbol}, Ring}()
+const LaurentSeriesID = CacheDictType{Tuple{Ring, Int, Symbol}, Ring}()
 
 mutable struct LaurentSeriesRingElem{T <: RingElement} <: AbstractAlgebra.RingElem
    coeffs::Array{T, 1}
@@ -756,15 +705,9 @@ mutable struct LaurentSeriesField{T <: FieldElement} <: AbstractAlgebra.Field
    S::Symbol
 
    function LaurentSeriesField{T}(R::Field, prec::Int, s::Symbol, cached::Bool = true) where T <: FieldElement
-      if cached && haskey(LaurentSeriesID, (R, prec, s))
-         return LaurentSeriesID[R, prec, s]::LaurentSeriesField{T}
-      else
-         z = new{T}(R, prec, s)
-         if cached
-            LaurentSeriesID[R, prec, s] = z
-         end
-         return z
-      end
+      return get_cached!(LaurentSeriesID, (R, prec, s), cached) do
+         new{T}(R, prec, s)
+      end::LaurentSeriesField{T}
    end
 end
 
@@ -793,19 +736,13 @@ mutable struct PuiseuxSeriesRing{T <: RingElement} <: AbstractAlgebra.Ring
    laurent_ring::Ring
 
    function PuiseuxSeriesRing{T}(R::LaurentSeriesRing{T}, cached::Bool = true) where T <: RingElement
-      if cached && haskey(PuiseuxSeriesID, R)
-         return PuiseuxSeriesID[R]::PuiseuxSeriesRing{T}
-      else
-         z = new{T}(R)
-         if cached
-            PuiseuxSeriesID[R] = z
-         end
-         return z
-      end
+      return get_cached!(PuiseuxSeriesID, R, cached) do
+         new{T}(R)
+      end::PuiseuxSeriesRing{T}
    end
 end
 
-const PuiseuxSeriesID = Dict{Ring, Ring}()
+const PuiseuxSeriesID = CacheDictType{Ring, Ring}()
 
 mutable struct PuiseuxSeriesRingElem{T <: RingElement} <: AbstractAlgebra.RingElem
    data::LaurentSeriesRingElem{T}
@@ -827,17 +764,13 @@ mutable struct PuiseuxSeriesField{T <: FieldElement} <: AbstractAlgebra.Field
    laurent_ring::Field
 
    function PuiseuxSeriesField{T}(R::LaurentSeriesField{T}, cached::Bool = true) where T <: FieldElement
-      if cached && haskey(PuiseuxSeriesID, R)
-         return PuiseuxSeriesID[R]::PuiseuxSeriesField{T}
-      else
-         z = new{T}(R)
-         if cached
-            PuiseuxSeriesID[R] = z
-         end
-         return z
-      end
+      return get_cached!(PuiseuxSeriesFieldID, R, cached) do
+         new{T}(R)
+      end::PuiseuxSeriesField{T}
    end
 end
+
+const PuiseuxSeriesFieldID = CacheDictType{Ring, Field}()
 
 mutable struct PuiseuxSeriesFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
    data::LaurentSeriesFieldElem{T}
@@ -861,19 +794,13 @@ mutable struct FracField{T <: RingElem} <: AbstractAlgebra.FracField{T}
    base_ring::Ring
 
    function FracField{T}(R::Ring, cached::Bool = true) where T <: RingElem
-      if cached && haskey(FracDict, R)
-         return FracDict[R]::FracField{T}
-      else
-         z = new{T}(R)
-         if cached
-            FracDict[R] = z
-         end
-         return z
-      end
+      return get_cached!(FracDict, R, cached) do
+         new{T}(R)
+      end::FracField{T}
    end
 end
 
-const FracDict = Dict{Ring, Ring}()
+const FracDict = CacheDictType{Ring, Ring}()
 
 mutable struct Frac{T <: RingElem} <: AbstractAlgebra.FracElem{T}
    num::T
@@ -899,19 +826,13 @@ mutable struct MatSpace{T <: RingElement} <: AbstractAlgebra.MatSpace{T}
    base_ring::Ring
 
    function MatSpace{T}(R::Ring, r::Int, c::Int, cached::Bool = true) where T <: RingElement
-      if cached && haskey(MatDict, (R, r, c))
-         return MatDict[R, r, c]::MatSpace{T}
-      else
-         z = new{T}(r, c, R)
-         if cached
-            MatDict[R, r, c] = z
-         end
-         return z
-      end
+      return get_cached!(MatDict, (R, r, c), cached) do
+         new{T}(r, c, R)
+      end::MatSpace{T}
    end
 end
 
-const MatDict = Dict{Tuple{Ring, Int, Int}, MatSpace}()
+const MatDict = CacheDictType{Tuple{Ring, Int, Int}, MatSpace}()
 
 mutable struct MatSpaceElem{T <: RingElement} <: Mat{T}
    entries::Array{T, 2}
@@ -952,19 +873,13 @@ mutable struct MatAlgebra{T <: RingElement} <: AbstractAlgebra.MatAlgebra{T}
    base_ring::Ring
 
    function MatAlgebra{T}(R::Ring, n::Int, cached::Bool = true) where T <: RingElement
-      if cached && haskey(MatAlgDict, (R, n))
-         return MatAlgDict[R, n]::MatAlgebra{T}
-      else
-         z = new{T}(n, R)
-         if cached
-            MatAlgDict[R, n] = z
-         end
-         return z
-      end
+      return get_cached!(MatAlgDict, (R, n), cached) do
+         new{T}(n, R)
+      end::MatAlgebra{T}
    end
 end
 
-const MatAlgDict = Dict{Tuple{Ring, Int}, NCRing}()
+const MatAlgDict = CacheDictType{Tuple{Ring, Int}, NCRing}()
 
 mutable struct MatAlgElem{T <: RingElement} <: AbstractAlgebra.MatAlgElem{T}
    entries::Array{T, 2}
@@ -1125,19 +1040,13 @@ mutable struct FreeModule{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebr
    AbstractAlgebra.@declare_other
 
    function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true) where T <: Union{RingElement, NCRingElem}
-      if cached && haskey(FreeModuleDict, (R, rank))
-         return FreeModuleDict[R, rank]::FreeModule{T}
-      else
-         z = new{T}(rank, R)
-         if cached
-            FreeModuleDict[R, rank] = z
-         end
-         return z
-      end
+      return get_cached!(FreeModuleDict, (R, rank), cached) do
+         new{T}(rank, R)
+      end::FreeModule{T}
    end
 end
 
-const FreeModuleDict = Dict{Tuple{NCRing, Int}, FreeModule}()
+const FreeModuleDict = CacheDictType{Tuple{NCRing, Int}, FreeModule}()
 
 mutable struct FreeModuleElem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
     v::AbstractAlgebra.MatElem{T}

--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -1,3 +1,4 @@
+include("WeakValueDict-test.jl")
 include("Groups-test.jl")
 include("NCRings-test.jl")
 include("Rings-test.jl")

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -1,0 +1,61 @@
+WeakValueDict = AbstractAlgebra.WeakValueDict
+
+@testset "WeakValueDict" begin
+    A = [1]
+    B = [2]
+    C = [3]
+
+    # construction
+    wkd = WeakValueDict()
+    wkd[2] = A
+    wkd[3] = B
+    wkd[4] = C
+    dd = convert(Dict{Any,Any},wkd)
+    @test WeakValueDict(dd) == wkd
+    @test convert(WeakValueDict{Any, Any}, dd) == wkd
+    @test isa(WeakValueDict(dd), WeakValueDict{Any,Any})
+    @test WeakValueDict(2=>A, 3=>B, 4=>C) == wkd
+    @test isa(WeakValueDict(2=>A, 3=>B, 4=>C), WeakValueDict{Int, Vector{Int}})
+    @test WeakValueDict((i+1)=>a for (i,a) in enumerate([A,B,C]) ) == wkd
+    @test WeakValueDict([(2,A), (3,B), (4,C)]) == wkd
+    @test WeakValueDict{Int, typeof(A)}(Pair(2,A), Pair(3,B), Pair(4,C)) == wkd
+    @test WeakValueDict(Pair(2,A), Pair(3,B), Pair(4,C)) == wkd
+    D = [[4.0]]
+    @test WeakValueDict(Pair(2,A), Pair(3,B), Pair(4.0,D)) isa WeakValueDict{Any, Any}
+    @test isa(WeakValueDict(Pair(2,A), Pair(3.0,B), Pair(4,C)), WeakValueDict{Any, Vector{Int}})
+    @test copy(wkd) == wkd
+
+    @test length(wkd) == 3
+    @test !isempty(wkd)
+    res = pop!(wkd, 3)
+    @test res == B
+    @test length(wkd) == 2
+    res = pop!(wkd, 3, C)
+    @test res == C
+    @test 3 ∉ keys(wkd)
+    @test B ∉ values(wkd)
+    @test length(wkd) == 2
+    @test !isempty(wkd)
+    wkd = filter!( p -> p.first != 2, wkd)
+    @test 3 ∉ keys(wkd)
+    @test B ∉ values(wkd)
+    @test length(wkd) == 1
+    @test WeakValueDict(Pair(4, C)) == wkd
+    @test !isempty(wkd)
+
+    wkd = empty!(wkd)
+    @test wkd == empty(wkd)
+    @test typeof(wkd) == typeof(empty(wkd))
+    @test length(wkd) == 0
+    @test isempty(wkd)
+    @test isa(wkd, WeakValueDict)
+
+    @test_throws ArgumentError WeakValueDict([1, 2, 3])
+
+    wkd = WeakValueDict(1=>A)
+    @test delete!(wkd, 1) == empty(wkd)
+    @test delete!(wkd, 1) === wkd
+
+    GC.@preserve A B C D nothing
+end
+

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -78,6 +78,12 @@
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
+
+   R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
+   S, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
+   @test R === S
+   S, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute, cached = false)
+   @test R !== S
 end
 
 @testset "Generic.AbsSeries.manipulation" begin

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -2,6 +2,9 @@
    S, x = PolynomialRing(ZZ, "x")
    T = FractionField(S)
 
+   @test FractionField(S, cached = true) === FractionField(S, cached = true)
+   @test FractionField(S, cached = false) !== FractionField(S, cached = true)
+
    @test elem_type(T) == Generic.Frac{elem_type(S)}
    @test elem_type(Generic.FracField{elem_type(S)}) == Generic.Frac{elem_type(S)}
    @test parent_type(Generic.Frac{elem_type(S)}) == Generic.FracField{elem_type(S)}

--- a/test/generic/FreeModule-test.jl
+++ b/test/generic/FreeModule-test.jl
@@ -2,6 +2,9 @@
    R, x = PolynomialRing(ZZ, "x")
    M = FreeModule(R, 5)
 
+   @test FreeModule(R, 5, cached = true) === FreeModule(R, 5, cached = true)
+   @test FreeModule(R, 5, cached = true) !== FreeModule(R, 5, cached = false)
+
    @test isa(M, Generic.FreeModule)
 
    @test elem_type(M) == Generic.FreeModuleElem{elem_type(R)}

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -10,6 +10,7 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
       for R in (ZZ, GF(5))
          P, _ = PolynomialRing(R, "x0")
          L, y = LaurentPolynomialRing(R, "y")
+
          x = y.poly
 
          @test L isa LaurentPolyWrapRing{elem_type(R)}

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -19,6 +19,9 @@
 @testset "Generic.LaurentSeries.constructors" begin
    R, x = LaurentSeriesRing(ZZ, 30, "x")
 
+   @test LaurentSeriesRing(ZZ, 30, "x", cached = true)[1] === LaurentSeriesRing(ZZ, 30, "x", cached = true)[1]
+   @test LaurentSeriesRing(ZZ, 30, "x", cached = false)[1] !== LaurentSeriesRing(ZZ, 30, "x", cached = true)[1]
+
    S, t = PolynomialRing(QQ, "t")
    T, y = LaurentSeriesRing(S, 30, "y")
 
@@ -97,6 +100,12 @@
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
+   
+   R, x = LaurentSeriesRing(ZZ, 30, "x")
+   RR, x = LaurentSeriesRing(ZZ, 30, "x")
+   @test R === RR
+   RR, x = LaurentSeriesRing(ZZ, 30, "x", cached = false)
+   @test R !== RR
 end
 
 @testset "Generic.LaurentSeries.rand" begin

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -7,6 +7,9 @@
 
       S, varlist = PolynomialRing(R, var_names, ordering = ord)
 
+      @test PolynomialRing(R, var_names, ordering = ord, cached = true)[1] === PolynomialRing(R, var_names, ordering = ord, cached = true)[1]
+      @test PolynomialRing(R, var_names, ordering = ord, cached = false)[1] !== PolynomialRing(R, var_names, ordering = ord, cached = true)[1]
+
       @test elem_type(S) == Generic.MPoly{elem_type(R)}
       @test elem_type(Generic.MPolyRing{elem_type(R)}) == Generic.MPoly{elem_type(R)}
       @test parent_type(Generic.MPoly{elem_type(R)}) == Generic.MPolyRing{elem_type(R)}

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -3,6 +3,9 @@
    S1 = PolynomialRing(R, "y")
    S2 = R["y"]
 
+   @test PolynomialRing(R, "y", cached = true)[1] === PolynomialRing(R, "y", cached = true)[1]
+   @test PolynomialRing(R, "y", cached = true)[1] !== PolynomialRing(R, "y", cached = false)[1]
+
    for (S, y) in (S1, S2)
       @test elem_type(S) == Generic.NCPoly{elem_type(R)}
       @test elem_type(Generic.NCPolyRing{elem_type(R)}) == Generic.NCPoly{elem_type(R)}

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -21,6 +21,9 @@
    S1 = R["y"]
    S2 = ZZ["x"]["y"]
 
+   @test PolynomialRing(R, "y", cached = true)[1] === PolynomialRing(R, "y", cached = true)[1]
+   @test PolynomialRing(R, "y", cached = true)[1] !== PolynomialRing(R, "y", cached = false)[1]
+
    for (S, y) in (S1, S2)
       @test elem_type(S) == Generic.Poly{elem_type(R)}
       @test elem_type(Generic.PolyRing{elem_type(R)}) == Generic.Poly{elem_type(R)}

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -22,6 +22,9 @@
    S, t = PolynomialRing(QQ, "t")
    T, y = PuiseuxSeriesRing(S, 30, "y")
 
+   @test PuiseuxSeriesRing(S, 30, "y", cached = true)[1] === PuiseuxSeriesRing(S, 30, "y", cached = true)[1]
+   @test PuiseuxSeriesRing(S, 30, "y", cached = false)[1] !== PuiseuxSeriesRing(S, 30, "y", cached = true)[1]
+
    U, z = PuiseuxSeriesField(QQ, 30, "z")
 
    @test elem_type(R) == Generic.PuiseuxSeriesRingElem{BigInt}

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -22,6 +22,9 @@
    S, t = PolynomialRing(QQ, "t")
    T, y = PowerSeriesRing(S, 30, "y")
 
+   @test PowerSeriesRing(S, 30, "y", cached = true)[1] === PowerSeriesRing(S, 30, "y", cached = true)[1]
+   @test PowerSeriesRing(S, 30, "y", cached = false)[1] !== PowerSeriesRing(S, 30, "y", cached = true)[1]
+
    @test elem_type(R) == Generic.RelSeries{BigInt}
    @test elem_type(Generic.RelSeriesRing{BigInt}) == Generic.RelSeries{BigInt}
    @test parent_type(Generic.RelSeries{BigInt}) == Generic.RelSeriesRing{BigInt}

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -3,6 +3,9 @@
 
    R = Generic.ResidueRing(B, 16453889)
 
+   @test Generic.ResidueRing(B, 16453889, cached = true) === Generic.ResidueRing(B, 16453889, cached = true)
+   @test Generic.ResidueRing(B, 16453889, cached = false) !== Generic.ResidueRing(B, 16453889, cached = true)
+
    @test_throws DomainError Generic.ResidueRing(B, 0)
 
    @test elem_type(R) == Generic.Res{elem_type(B)}

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -3,6 +3,9 @@
 
    R = Generic.ResidueField(B, 16453889)
 
+   @test Generic.ResidueField(B, 16453889, cached = true) === Generic.ResidueField(B, 16453889, cached = true)
+   @test Generic.ResidueField(B, 16453889, cached = true) !== Generic.ResidueField(B, 16453889, cached = false)
+
    @test elem_type(R) == Generic.ResF{elem_type(B)}
    @test elem_type(Generic.ResField{elem_type(B)}) == Generic.ResF{elem_type(B)}
    @test parent_type(Generic.ResF{elem_type(B)}) == Generic.ResField{elem_type(B)}

--- a/test/generic/SparsePoly-test.jl
+++ b/test/generic/SparsePoly-test.jl
@@ -2,6 +2,9 @@
    R, x = SparsePolynomialRing(ZZ, "x")
    S, y = SparsePolynomialRing(R, "y")
 
+   @test SparsePolynomialRing(R, "y", cached = true)[1] === SparsePolynomialRing(R, "y", cached = true)[1]
+   @test SparsePolynomialRing(R, "y", cached = true)[1] !== SparsePolynomialRing(R, "y", cached = false)[1]
+
    @test typeof(S) <: Generic.SparsePolyRing
 
    T, z = SparsePolynomialRing(S, "z")


### PR DESCRIPTION
This is the `WeakValueDict` silbling of `Base.WeakKeyDict`, which is exactly what we need for caching. This seems to work pretty well.

```julia
julia> using Revise, AbstractAlgebra         
                                             
julia> for s in 'a':'z'                      
         Qx, x = PolynomialRing(QQ, s)       
       end                                   
                                             
julia> length(AbstractAlgebra.Generic.PolyID)
26                                           
                                             
julia> GC.gc()                               
                                             
julia> length(AbstractAlgebra.Generic.PolyID)
0                                            
```

I put it in AA mainly to test it. This will be fine if we only need it in AA/Nemo/Hecke/Oscar/Singular. I don't know if we need it for GAP.jl or Polymake.jl though. Otherwise it would have to go in a small separate package, which would also be no problem.

@fingolfin @benlorenz

<s>Edit: I have to fix some things for julia < 1.6.</s>