### PR TITLE
remove redundant docstrings for * ^ + -

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -185,11 +185,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.AbsSeriesElem)
-
-Return $-a$.
-"""
 function -(a::AbstractAlgebra.AbsSeriesElem)
    len = length(a)
    z = parent(a)()
@@ -207,11 +202,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = length(a)
@@ -240,11 +230,6 @@ function +(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = length(a)
@@ -273,11 +258,6 @@ function -(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.AbsSeriesElem{T}, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
 
@@ -326,11 +306,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::T, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElem}
    len = length(b)
    z = parent(b)()
@@ -343,11 +318,6 @@ function *(a::T, b::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.AbsSeriesElem)
-
-Return $a\times b$.
-"""
 function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.AbsSeriesElem)
    len = length(b)
    z = parent(b)()
@@ -360,18 +330,8 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.AbsSer
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.AbsSeriesElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.AbsSeriesElem{T}, b::T) where {T <: RingElem} = b*a
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.AbsSeriesElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.AbsSeriesElem, b::Union{Integer, Rational, AbstractFloat}) = b*a
 
 ###############################################################################

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -209,11 +209,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.FracElem)
-
-Return $-a$.
-"""
 function -(a::AbstractAlgebra.FracElem)
    return parent(a)(-numerator(a, false), deepcopy(denominator(a, false)))
 end
@@ -224,11 +219,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
    d1 = denominator(a, false)
@@ -276,11 +266,6 @@ function +(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where
    return parent(a)(rnum, rden)
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
    d1 = denominator(a, false)
@@ -328,11 +313,6 @@ function -(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where
    return parent(a)(rnum, rden)
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.FracElem{T}, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    check_parent(a, b)
    n1 = numerator(a, false)
@@ -383,11 +363,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    c = base_ring(a)(b)
    g = gcd(denominator(a, false), c)
@@ -396,11 +371,6 @@ function *(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloa
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
-
-Return $a\times b$.
-"""
 function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
    c = base_ring(b)(a)
    g = gcd(denominator(b, false), c)
@@ -409,11 +379,6 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracEl
    return parent(b)(n, d)
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    g = gcd(denominator(a, false), b)
    n = numerator(a, false)*divexact(b, g)
@@ -421,11 +386,6 @@ function *(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    g = gcd(denominator(b, false), a)
    n = numerator(b, false)*divexact(a, g)
@@ -433,80 +393,40 @@ function *(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    return parent(b)(n, d)
 end
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    n = numerator(a, false) + denominator(a, false)*b
    d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.FracElem, b::Union{Integer, Rational, AbstractFloat})
    n = numerator(a, false) - denominator(a, false)*b
    d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
-@doc Markdown.doc"""
-    +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
-
-Return $a + b$.
-"""
 +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem) = b + a
 
-@doc Markdown.doc"""
-    -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
-
-Return $a - b$.
-"""
 function -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.FracElem)
    n = a*denominator(b, false) - numerator(b, false)
    d = denominator(b, false)
    return parent(b)(n, deepcopy(d))
 end
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    n = numerator(a, false) + denominator(a, false)*b
    d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.FracElem{T}, b::T) where {T <: RingElem}
    n = numerator(a, false) - denominator(a, false)*b
    d = denominator(a, false)
    return parent(a)(n, deepcopy(d))
 end
 
-@doc Markdown.doc"""
-    +(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a + b$.
-"""
 +(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem} = b + a
 
-@doc Markdown.doc"""
-    -(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-
-Return $a - b$.
-"""
 function -(a::T, b::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
    n = a*denominator(b, false) - numerator(b, false)
    d = denominator(b, false)
@@ -719,11 +639,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    ^(a::AbstractAlgebra.FracElem, b::Int)
-
-Return $a^b$.
-"""
 function ^(a::AbstractAlgebra.FracElem{T}, b::Int) where {T <: RingElem}
    if b < 0
       a = inv(a)

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -496,11 +496,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::Generic.LaurentSeriesElem)
-
-Return $-a$.
-"""
 function -(a::LaurentSeriesElem)
    len = pol_length(a)
    z = parent(a)()
@@ -520,11 +515,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::Generic.LaurentSeriesElem{T}, b::Generic.LaurentSeriesElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -581,11 +571,6 @@ function +(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::Generic.LaurentSeriesElem{T}, b::Generic.LaurentSeriesElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -642,11 +627,6 @@ function -(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingEle
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Generic.LaurentSeriesElem{T}, b::Generic.LaurentSeriesElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::LaurentSeriesElem{T}, b::LaurentSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -712,11 +692,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::T, b::Generic.LaurentSeriesElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::T, b::LaurentSeriesElem{T}) where {T <: RingElem}
    len = pol_length(b)
    z = parent(b)()
@@ -733,11 +708,6 @@ function *(a::T, b::LaurentSeriesElem{T}) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::Generic.LaurentSeriesElem)
-
-Return $a\times b$.
-"""
 function *(a::Union{Integer, Rational, AbstractFloat}, b::LaurentSeriesElem)
    len = pol_length(b)
    z = parent(b)()
@@ -754,18 +724,8 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::LaurentSeriesElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Generic.LaurentSeriesElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::LaurentSeriesElem{T}, b::T) where {T <: RingElem} = b*a
 
-@doc Markdown.doc"""
-    *(a::Generic.LaurentSeriesElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::LaurentSeriesElem, b::Union{Integer, Rational, AbstractFloat}) = b*a
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -684,11 +684,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(x::Generic.MatrixElem)
-
-Return $-x$.
-"""
 function -(x::MatrixElem)
    z = similar(x)
    for i in 1:nrows(x)
@@ -705,11 +700,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(x::Generic.MatrixElem{T}, y::Generic.MatrixElem{T}) where {T <: RingElement}
-
-Return $x + y$.
-"""
 function +(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
    check_parent(x, y)
    r = similar(x)
@@ -721,11 +711,6 @@ function +(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
    return r
 end
 
-@doc Markdown.doc"""
-    -(x::Generic.MatrixElem{T}, y::Generic.MatrixElem{T}) where {T <: RingElement}
-
-Return $x - y$.
-"""
 function -(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
    check_parent(x, y)
    r = similar(x)
@@ -737,11 +722,6 @@ function -(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
    return r
 end
 
-@doc Markdown.doc"""
-    *(x::AbstractAlgebra.MatElem{T}, y::AbstractAlgebra.MatElem{T}) where {T <: RingElement}
-
-Return $x\times y$.
-"""
 function *(x::AbstractAlgebra.MatElem{T}, y::AbstractAlgebra.MatElem{T}) where {T <: RingElement}
    ncols(x) != nrows(y) && error("Incompatible matrix dimensions")
    A = similar(x, nrows(x), ncols(y))
@@ -764,11 +744,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(x::Union{Integer, Rational, AbstractFloat}, y::Generic.MatrixElem)
-
-Return $x\times y$.
-"""
 function *(x::Union{Integer, Rational, AbstractFloat}, y::MatrixElem)
    z = similar(y)
    for i = 1:nrows(y)
@@ -779,11 +754,6 @@ function *(x::Union{Integer, Rational, AbstractFloat}, y::MatrixElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(x::T, y::Generic.MatrixElem{T}) where {T <: RingElem}
-
-Return $x\times y$.
-"""
 function *(x::T, y::MatrixElem{T}) where {T <: RingElem}
    z = similar(y)
    for i = 1:nrows(y)
@@ -794,18 +764,8 @@ function *(x::T, y::MatrixElem{T}) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    *(x::Generic.MatrixElem, y::Union{Integer, Rational, AbstractFloat})
-
-Return $x\times y$.
-"""
 *(x::MatrixElem, y::Union{Integer, Rational, AbstractFloat}) = y*x
 
-@doc Markdown.doc"""
-    *(x::Generic.MatrixElem{T}, y::T) where {T <: RingElem}
-
-Return $x\times y$.
-"""
 *(x::MatrixElem{T}, y::T) where {T <: RingElem} = y*x
 
 @doc Markdown.doc"""

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -129,11 +129,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
    check_parent(a, b)
    lena = length(a)
@@ -158,11 +153,6 @@ function +(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) w
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.NCPolyElem{T}, b::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
    check_parent(a, b)
    lena = length(a)

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -374,11 +374,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::Generic.PolynomialElem)
-
-Return $-a$.
-"""
 function -(a::PolynomialElem)
    len = length(a)
    z = parent(a)()
@@ -396,11 +391,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = length(a)
@@ -425,11 +415,6 @@ function +(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = length(a)
@@ -605,11 +590,6 @@ function mul_classical(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyEl
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return mul_classical(a, b)
@@ -621,11 +601,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::T, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElem}
    len = length(b)
    z = parent(b)()
@@ -637,11 +612,6 @@ function *(a::T, b::AbstractAlgebra.PolyElem{T}) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::Generic.PolynomialElem)
-
-Return $a\times b$.
-"""
 function *(a::Union{Integer, Rational, AbstractFloat}, b::PolynomialElem)
    len = length(b)
    z = parent(b)()
@@ -653,18 +623,8 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::PolynomialElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.PolyElem{T}, b::T) where {T <: RingElem} = b*a
 
-@doc Markdown.doc"""
-    *(a::Generic.PolynomialElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::PolynomialElem, b::Union{Integer, Rational, AbstractFloat}) = b*a
 
 ###############################################################################

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -309,11 +309,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.RelSeriesElem)
-
-Return $-a$.
-"""
 function -(a::AbstractAlgebra.RelSeriesElem)
    len = pol_length(a)
    z = parent(a)()
@@ -332,11 +327,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -391,11 +381,6 @@ function +(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -450,11 +435,6 @@ function -(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.RelSeriesElem{T}, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    check_parent(a, b)
    lena = pol_length(a)
@@ -499,11 +479,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 function *(a::T, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElem}
    len = pol_length(b)
    z = parent(b)()
@@ -518,11 +493,6 @@ function *(a::T, b::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElem}
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.RelSeriesElem)
-
-Return $a\times b$.
-"""
 function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.RelSeriesElem)
    len = pol_length(b)
    z = parent(b)()
@@ -537,18 +507,8 @@ function *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.RelSer
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.RelSeriesElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.RelSeriesElem{T}, b::T) where {T <: RingElem} = b*a
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.RelSeriesElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.RelSeriesElem, b::Union{Integer, Rational, AbstractFloat}) = b*a
 
 ###############################################################################

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -194,11 +194,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResElem)
-
-Return $-a$.
-"""
 function -(a::AbstractAlgebra.ResElem)
    parent(a)(-data(a))
 end
@@ -209,31 +204,16 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) + data(b))
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) - data(b))
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) * data(b))
@@ -245,88 +225,28 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) * b)
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) * b)
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem)
-
-Return $a\times b$.
-"""
 *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem) = parent(b)(a * data(b))
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem} = parent(b)(a * data(b))
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a + b$.
-"""
 +(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) + b)
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem}
-
-Return $a + b$.
-"""
 +(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) + b)
 
-@doc Markdown.doc"""
-    +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem)
-
-Return $a + b$.
-"""
 +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem) = parent(b)(a + data(b))
 
-@doc Markdown.doc"""
-    +(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem}
-
-Return $a + b$.
-"""
 +(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem} = parent(b)(a + data(b))
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a - b$.
-"""
 -(a::AbstractAlgebra.ResElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) - b)
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem}
-
-Return $a - b$.
-"""
 -(a::AbstractAlgebra.ResElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) - b)
 
-@doc Markdown.doc"""
-    -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem)
-
-Return $a - b$.
-"""
 -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResElem) = parent(b)(a - data(b))
 
-@doc Markdown.doc"""
-    -(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem}
-
-Return $a - b$.
-"""
 -(a::T, b::AbstractAlgebra.ResElem{T}) where {T <: RingElem} = parent(b)(a - data(b))
 
 ###############################################################################
@@ -335,11 +255,6 @@ Return $a - b$.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    ^(a::AbstractAlgebra.ResElem, b::Int)
-
-Return $a^b$.
-"""
 function ^(a::AbstractAlgebra.ResElem, b::Int)
    parent(a)(powermod(data(a), b, modulus(a)))
 end

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -203,11 +203,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResFieldElem)
-
-Return $-a$.
-"""
 function -(a::AbstractAlgebra.ResFieldElem)
    parent(a)(-data(a))
 end
@@ -218,31 +213,16 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
-
-Return $a + b$.
-"""
 function +(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) + data(b))
 end
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
-
-Return $a - b$.
-"""
 function -(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) - data(b))
 end
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
-
-Return $a\times b$.
-"""
 function *(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
    check_parent(a, b)
    return parent(a)(data(a) * data(b))
@@ -254,88 +234,28 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) * b)
 
-@doc Markdown.doc"""
-    *(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) * b)
 
-@doc Markdown.doc"""
-    *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem)
-
-Return $a\times b$.
-"""
 *(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem) = parent(b)(a * data(b))
 
-@doc Markdown.doc"""
-    *(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem}
-
-Return $a\times b$.
-"""
 *(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem} = parent(b)(a * data(b))
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a + b$.
-"""
 +(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) + b)
 
-@doc Markdown.doc"""
-    +(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem}
-
-Return $a + b$.
-"""
 +(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) + b)
 
-@doc Markdown.doc"""
-    +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem)
-
-Return $a + b$.
-"""
 +(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem) = parent(b)(a + data(b))
 
-@doc Markdown.doc"""
-    +(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem}
-
-Return $a + b$.
-"""
 +(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem} = parent(b)(a + data(b))
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat})
-
-Return $a - b$.
-"""
 -(a::AbstractAlgebra.ResFieldElem, b::Union{Integer, Rational, AbstractFloat}) = parent(a)(data(a) - b)
 
-@doc Markdown.doc"""
-    -(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem}
-
-Return $a - b$.
-"""
 -(a::AbstractAlgebra.ResFieldElem{T}, b::T) where {T <: RingElem} = parent(a)(data(a) - b)
 
-@doc Markdown.doc"""
-    -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem)
-
-Return $a - b$.
-"""
 -(a::Union{Integer, Rational, AbstractFloat}, b::AbstractAlgebra.ResFieldElem) = parent(b)(a - data(b))
 
-@doc Markdown.doc"""
-    -(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem}
-
-Return $a - b$.
-"""
 -(a::T, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElem} = parent(b)(a - data(b))
 
 ###############################################################################
@@ -344,11 +264,6 @@ Return $a - b$.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    ^(a::AbstractAlgebra.ResFieldElem, b::Int)
-
-Return $a^b$.
-"""
 function ^(a::AbstractAlgebra.ResFieldElem, b::Integer)
    parent(a)(powermod(data(a), b, modulus(a)))
 end


### PR DESCRIPTION
This removes the docstrings looking like `"+(a,b): return a+b"`.
Related to #535.