### PR TITLE
update partitions

### DIFF
--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -23,21 +23,21 @@ Generic.Partition
 
 ### Array interface
 
-`Partition` is a concrete subtype of `AbstractVector{Int}` and implements the following standard Array interface:
+`Partition` is a concrete (immutable) subtype of `AbstractVector{Integer}` and implements the standard Array interface.
 
 ```@docs
 size(::Generic.Partition)
 getindex(::Generic.Partition, i::Integer)
-setindex!(::Generic.Partition, v::Integer, i::Integer)
 ```
 These functions work on the level of `p.part` vector.
-Additionally `setindex!` will try to prevent uses which result in non-valid (i.e. non-decreasing) partition vectors.
 
-One can easily iterate over all partitions of $n$ using the `AllParts` type:
+One can easily iterate over all partitions of $n$ using the `Generic.partitions` function.
 
 ```@docs
-Generic.AllParts
+Generic.partitions
 ```
+
+You may also have a look at [JuLie.jl](https://github.com/ulthiel/JuLie.jl) package for more utilities related to partitions.
 
 The number of all partitions can be computed by the hidden function `_numpart`.
 Much faster implementation is available in [Nemo.jl](https://nemocas.github.io/Nemo.jl/latest/arb.html#Nemo.numpart-Tuple{Int64,ArbField}).

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -14,9 +14,19 @@ end
 #
 ###############################################################################
 
+@doc Markdown.doc"""
+    elem_type(parent)
+    elem_type(parent_type)
+Given a parent object (or its type), return the type of its elements.
+"""
 elem_type(x)  = elem_type(typeof(x))
 elem_type(T::DataType) = throw(MethodError(elem_type, (T,)))
 
+@doc Markdown.doc"""
+    parent_type(element)
+    parent_type(element_type)
+Given an element (or its type), return the type of its parent object.
+"""
 parent_type(x) = parent_type(typeof(x))
 parent_type(T::DataType) = throw(MethodError(parent_type, (T,)))
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -179,8 +179,9 @@ end
 @doc Markdown.doc"""
     AllParts(n::Integer)
 
-Return an iterator over all integer `Partition`s of `n`.
-Partitions are produced in ascending order according to RuleAsc (Algorithm 3.1) from
+Return an iterator over all integer Partitions of `n`.
+
+Partitions are produced as `Vector{typeof(n)}` in ascending order according to RuleAsc (Algorithm 3.1) from
 
 > Jerome Kelleher and Barry O’Sullivan,
 > *Generating All Partitions: A Comparison Of Two Encodings*
@@ -188,20 +189,26 @@ Partitions are produced in ascending order according to RuleAsc (Algorithm 3.1) 
 
 See also `Combinatorics.partitions(1:n)`.
 
+Note: All returned partitions share memory, so advancing to the next one will change the previous. For persistent storage one should `copy` the result
+
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
 julia> ap = AllParts(5);
 
+julia> for p in ap; println(p) end
+[1, 1, 1, 1, 1]
+[2, 1, 1, 1]
+[3, 1, 1]
+[2, 2, 1]
+[4, 1]
+[3, 2]
+[5]
 
-julia> collect(ap)
-7-element Array{AbstractAlgebra.Generic.Partition{Int64},1}:
- 1₅
- 2₁1₃
- 3₁1₂
- 2₂1₁
- 4₁1₁
- 3₁2₁
- 5₁
+julia> unique(collect(ap))
+1-element Array{Array{Int64,1},1}:
+ [5]
+
+
 ```
 """
 struct AllParts{T<:Integer}

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -157,18 +157,22 @@ julia> p.n == sum(p.part)
 true
 ```
 """
-mutable struct Partition{T} <: AbstractVector{T}
+struct Partition{T} <: AbstractVector{T}
    n::Int
    part::Vector{T}
 
-   function Partition(part::AbstractVector{T}, check::Bool=true) where T<:Integer
+   Partition(part::AbstractVector{<:Integer}, check::Bool=true) =
+      Partition(sum(part), part, check)
+
+   function Partition(n::Integer, part::AbstractVector{T}, check::Bool=true) where T
       if check
-         all(diff(part) .<= 0) || sort!(part, rev=true)
+         all(i-> part[i] >= part[i-1], 2:length(part)) || sort!(part, rev=true)
          if length(part) > 0
-            part[end] >= 1 || throw(ArgumentError("Found non-positive entry in partition!"))
+            part[end] >= 1 || throw(ArgumentError("Found non-positive entry in partition: $(part[end])"))
          end
+         @assert n == sum(part)
       end
-      return new{T}(sum(part), part)
+      return new{T}(n, part)
    end
 end
 
@@ -201,10 +205,13 @@ julia> collect(ap)
 ```
 """
 struct AllParts{T<:Integer}
-    n::Int
-    part::Vector{T}
-    AllParts{T}(n::Integer) where T = new{T}(n, zeros(Int,n))
-    AllParts(n::T) where T<:Integer = AllParts{T}(n)
+   n::T
+   tmp::Vector{T}
+   part::Vector{T}
+
+   AllParts{T}(n::Integer) where T =
+      new{T}(n, ones(T, n), ones(T, n))
+   AllParts(n::T; copy=true) where T<:Integer = AllParts{T}(n)
 end
 
 ###############################################################################

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -788,6 +788,8 @@ end
 one(G::SymmetricGroup) = Perm(G.n)
 one(g::Perm) = one(parent(g))
 
+Base.isone(g::Perm) = all(i == g[i] for i in eachindex(g.d))
+
 function (G::SymmetricGroup{T})(a::AbstractVector{S}, check::Bool=true) where {S, T}
    if check
       G.n == length(a) || throw("Cannot coerce to $G: lengths differ")

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -4,18 +4,8 @@
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    parent_type(::Type{<:Perm})
-
-Return the type of the parent of a permutation.
-"""
 parent_type(::Type{Perm{T}}) where T = SymmetricGroup{T}
 
-@doc Markdown.doc"""
-    elem_type(::Type{<:SymmetricGroup})
-
-Return the type of elements of a permutation group.
-"""
 elem_type(::Type{SymmetricGroup{T}}) where T = Perm{T}
 
 @doc Markdown.doc"""

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -136,6 +136,11 @@ Base.eltype(::Type{AllParts{T}}) where T = Vector{T}
    return k
 end
 
+@doc Markdown.doc"""
+    partitions(n::Integer)
+Return the vector of all permutations of `n`. For an unsafe generator version
+see `partitions!`.
+"""
 partitions(n::Integer) = [Partition(n, copy(p), false) for p in AllParts(n)]
 partitions!(n::Integer) = (Partition(n, p, false) for p in AllParts(n))
 

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -101,14 +101,17 @@ end
 #    "Generating All Partitions: A Comparison Of Two Encodings"
 # by Jerome Kelleher and Barry O’Sullivan, ArXiv:0909.2331
 
-@inline Base.iterate(A::AllParts) = A.part, max(A.n, one(A.n))
+@inline function Base.iterate(A::AllParts)
+   resize!(A.part, A.n)
+   resize!(A.tmp, A.n)
+   A.tmp .= 1
+   A.part .= 1
+
+   return A.part, max(A.n, one(A.n))
+end
 
 @inline function Base.iterate(A::AllParts, k)
-   if isone(k)
-      A.tmp .= 1
-      A.part .= 1
-      return nothing
-   end
+   isone(k) && return nothing
    k = @inbounds nextpart_asc!(A.tmp, k)
 
    resize!(A.part, k)
@@ -140,6 +143,19 @@ end
     partitions(n::Integer)
 Return the vector of all permutations of `n`. For an unsafe generator version
 see `partitions!`.
+
+# Examples:
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> Generic.partitions(5)
+7-element Array{AbstractAlgebra.Generic.Partition{Int64},1}:
+ 1₅
+ 2₁1₃
+ 3₁1₂
+ 2₂1₁
+ 4₁1₁
+ 3₁2₁
+ 5₁
+
 """
 partitions(n::Integer) = [Partition(n, copy(p), false) for p in AllParts(n)]
 partitions!(n::Integer) = (Partition(n, p, false) for p in AllParts(n))

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -33,27 +33,6 @@ getindex(p::Partition, i::Integer) = p.part[i]
 
 Base.sum(p::Partition) = p.n
 
-@doc Markdown.doc"""
-    setindex!(p::Partition, v::Integer, i::Integer)
-
-Set the `i`-th part of partition `p` to `v`.
-`setindex!` will throw an error if the operation violates the non-increasing assumption.
-"""
-function setindex!(p::Partition, v::Integer, i::Integer)
-   prev = sum(p)
-   nex = 1
-   if i != 1
-      prev = p[i-1]
-   end
-   if i != length(p)
-      nex = p[i+1]
-   end
-   nex <= v <= prev || throw(ArgumentError("Partition must be positive and non-increasing"))
-   p.n += v - p.part[i]
-   p.part[i] = v
-   return p
-end
-
 ==(p::Partition, m::Partition) = sum(p) == sum(m) && p.part == m.part
 hash(p::Partition, h::UInt) = hash(p.part, hash(Partition, h))
 

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -156,7 +156,9 @@ end
    @test isone(a) && isone(b)
    @test !isone(c)
 
-   @test @allocated(isone(a)) == 0
+   if isbitstype(T)
+      @test @allocated(isone(a)) == 0
+   end
 
    @test parity(a) == 0
    @test parity(c) == 1

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -319,7 +319,7 @@ end
       N = T(7)
       G = SymmetricGroup(N)
 
-      @test all(character(p)(one(G)) == dim(YoungTableau(p)) for p in AllParts(N))
+      @test all(character(p)(one(G)) == dim(YoungTableau(p)) for p in Generic.partitions(N))
 
       N = T(3)
       G = SymmetricGroup(N)
@@ -352,7 +352,7 @@ end
    G = SymmetricGroup(N)
 
    ps = Partition.([[1,1,1,1], [2,1,1], [2,2], [3,1], [4]])
-   @test Set(AllParts(N)) == Set(ps)
+   @test Set(Generic.partitions(N)) == Set(ps)
 
    l = Partition([1,1,1,1])
 
@@ -372,7 +372,7 @@ end
    N = 5
    G = SymmetricGroup(N)
    ps = Partition.([[1,1,1,1,1], [2,1,1,1], [2,2,1], [3,1,1], [3,2], [4,1], [5]])
-   @test Set(AllParts(N)) == Set(ps)
+   @test Set(Generic.partitions(N)) == Set(ps)
 
    l = Partition([1,1,1,1,1])
    @test [character(l, m) for m in ps] == [   1,  -1,   1,   1,  -1,  -1,   1 ]

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -1,4 +1,4 @@
-IntTypes = [Int8, Int16, Int32, Int, UInt8, UInt16, UInt32, UInt, BigInt]
+IntTypes = [Int16, UInt32, Int, BigInt]
 
 @testset "Perm.abstract_types" begin
    @test Generic.Perm <: GroupElem
@@ -151,6 +151,12 @@ end
    c = G(T[2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
 
    @test a == b
+   @test a !== b
+
+   @test isone(a) && isone(b)
+   @test !isone(c)
+
+   @test @allocated(isone(a)) == 0
 
    @test parity(a) == 0
    @test parity(c) == 1

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -21,11 +21,11 @@ end
    @test Generic._numpart(100) == 190_569_292
    @test Generic._numpart(1000) == 24_061_467_864_032_622_473_692_149_727_991
 
-   @test collect(AllParts(5)) isa Vector{Generic.Partition{Int}}
-   @test collect(AllParts(Int8(5))) isa Vector{Generic.Partition{Int8}}
-   @test collect(AllParts(2)) == [Partition([1,1]), Partition([2])]
-   @test collect(AllParts(1)) == [Partition([1])]
-   @test collect(AllParts(0)) == [Partition(Int[])]
+   @test Generic.partitions(5) isa Vector{Generic.Partition{Int}}
+   @test Generic.partitions(Int8(5)) isa Vector{Generic.Partition{Int8}}
+   @test Generic.partitions(2) == [Partition([1,1]), Partition([2])]
+   @test Generic.partitions(1) == [Partition([1])]
+   @test Generic.partitions(0) == [Partition(Int[])]
 end
 
 @testset "youngtabs.youngtableau_type" begin

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -21,6 +21,8 @@ end
    @test Generic._numpart(100) == 190_569_292
    @test Generic._numpart(1000) == 24_061_467_864_032_622_473_692_149_727_991
 
+   @test eltype(Generic.AllParts(Int8(5))) == Vector{Int8}
+
    @test Generic.partitions(5) isa Vector{Generic.Partition{Int}}
    @test Generic.partitions(Int8(5)) isa Vector{Generic.Partition{Int8}}
    @test Generic.partitions(2) == [Partition([1,1]), Partition([2])]

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -14,21 +14,6 @@
    @test p[2] == 3
    @test p[3] == 1
    @test_throws BoundsError p[4]
-
-   @test_throws ArgumentError p[1] = 2
-   @test_throws ArgumentError p[2] = 5
-   @test_throws ArgumentError p[2] = 0
-
-   r = deepcopy(p)
-
-   p[3] = 2
-   @test p[3] == 2
-
-   @test sum(p) == 9
-   @test sum(r) == 8
-
-   @test p == Partition([4,3,2])
-   @test p != r
 end
 
 @testset "youngtabs.partition_iter" begin
@@ -55,7 +40,7 @@ end
    @test length(Y) == 12
    @test size(Y) == (3,4)
 
-   Y.part[2] = 2
+   Y = YoungTableau([4,2,1])
    @test Y != Z
 
    @test YoungTableau([1,3,4,1]) == YoungTableau([4,3,1,1])

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -26,6 +26,11 @@ end
    @test Generic.partitions(2) == [Partition([1,1]), Partition([2])]
    @test Generic.partitions(1) == [Partition([1])]
    @test Generic.partitions(0) == [Partition(Int[])]
+
+   # we actually iterate over all of them:
+   @test sum(first, Generic.partitions!(10)) == 192
+   # but they share memory:
+   @test length(unique(collect(Generic.partitions!(10)))) == 1
 end
 
 @testset "youngtabs.youngtableau_type" begin


### PR DESCRIPTION
This motivated by @ulthiel s JuLie package.

Changes:
* `isone(::Perm)` does not allocate anymore. 
* `Partition` is now a `struct` (reduces 32b allocation on construction), hence removal of `setindex!` (it was of dubious semantics anyway)
* Inlining/simplifying of `iterate`s helps with another allocation, so we're down to 1 allocation per `Partition` and two per `Perm` in iteration.
* added `Generic.partitions` and `Generic.partitions!` functions: first returns array of partitions, the second allows zero-allocation iteration over all partitions (of course the return partitions share memory, so you need to copy the ones you're interested in ;)   
(I don't intend to export them, not to clash with JuLie ones).
* The type returned by iteration over `AllParts` has changed (before: `Partition`, now: `Vector{<Integer}`), so **this pull is breaking**.
