### PR TITLE
Move implementation of inv for series over fields to generic, add tests.

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -690,6 +690,34 @@ function Base.inv(a::AbstractAlgebra.AbsSeriesElem)
    return ainv
 end
 
+function Base.inv(a::AbsSeriesElem{T}) where T <: FieldElement
+    prec = precision(a)
+    @assert valuation(a) == 0
+    @assert prec != 0
+    R = parent(a)
+    x = R(inv(coeff(a, 0)))
+    set_precision!(x, 1)
+    la = [prec]
+    while la[end] > 1
+        push!(la, div(la[end] + 1, 2))
+    end 
+    two = R(2)
+    two = set_precision!(two, prec)
+    n = length(la) - 1
+    y = R()
+    minus_a = -a
+    while n > 0
+        # x -> x*(2 - xa) is the lifting recursion
+        x = set_precision!(x, la[n])
+        y = set_precision!(y, la[n])
+        y = mul!(y, minus_a, x)
+        y = addeq!(y, two)
+        x = mul!(x, x, y)
+        n -= 1 
+    end
+    return x
+end
+
 ###############################################################################
 #
 #   Square root

--- a/src/generic/Misc/Series.jl
+++ b/src/generic/Misc/Series.jl
@@ -1,40 +1,5 @@
 ###############################################################################
 #
-#  Inversion
-#
-###############################################################################
-
-function Base.inv(a::RelSeriesElem{T}) where T <: FieldElement
-    @assert valuation(a) == 0
-    # x -> x*(2-xa) is the lifting recursion
-    x = parent(a)(inv(coeff(a, 0)))
-    set_precision!(x, 1)
-    p = precision(a)
-    la = [p]
-    while la[end] > 1
-        push!(la, div(la[end] + 1, 2))
-    end
-  
-    two = parent(a)(base_ring(a)(2))
-    set_precision!(two, p)
-  
-    n = length(la) - 1
-    y = parent(a)()
-    while n > 0
-        set_precision!(x, la[n])
-        set_precision!(y, la[n])
-        #    y = mul!(y, a, x)
-        #    y = two-y #sub! is missing...
-        #    x = mul!(x, x, y)
-        #    then why not negate a before the loop?
-        x = x*(two - x*a)
-        n -= 1 
-    end
-    return x
-end
-
-###############################################################################
-#
 #  Transcendental functions
 #
 ###############################################################################

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -927,6 +927,34 @@ function Base.inv(a::AbstractAlgebra.RelSeriesElem)
    return ainv
 end
 
+function Base.inv(a::RelSeriesElem{T}) where T <: FieldElement
+    prec = precision(a)
+    @assert valuation(a) == 0
+    @assert prec != 0
+    R = parent(a)
+    x = R(inv(coeff(a, 0)))
+    set_precision!(x, 1)
+    la = [prec]
+    while la[end] > 1
+        push!(la, div(la[end] + 1, 2))
+    end 
+    two = R(2)
+    two = set_precision!(two, prec)
+    n = length(la) - 1
+    y = R()
+    minus_a = -a
+    while n > 0
+        # x -> x*(2 - xa) is the lifting recursion
+        x = set_precision!(x, la[n])
+        y = set_precision!(y, la[n])
+        y = mul!(y, minus_a, x)
+        y = addeq!(y, two)
+        x = mul!(x, x, y)
+        n -= 1 
+    end
+    return x
+end
+
 ###############################################################################
 #
 #   Square root

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -628,6 +628,19 @@ end
        @test f*inv(f) == 1
     end
 
+    # Exact field
+    for prec = 1:10
+       R, x = PowerSeriesRing(QQ, prec, "x"; model=:capped_absolute)
+       for iter = 1:30
+          f = R()
+          while valuation(f) != 0
+             f = rand(R, 0:0, -10:10)
+          end
+
+          @test f*inv(f) == 1
+       end
+    end
+
     # Inexact field
     R, x = PowerSeriesRing(RealField, 10, "x", model=:capped_absolute)
     for iter = 1:300

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -641,6 +641,19 @@ end
        @test f*inv(f) == 1
     end
 
+    # Exact field
+    for prec = 1:10
+       R, x = PowerSeriesRing(QQ, prec, "x")
+       for iter = 1:30
+          f = R()
+          while valuation(f) != 0
+             f = rand(R, 0:0, -10:10)
+          end
+
+          @test f*inv(f) == 1
+       end
+    end
+
     # Inexact field
     R, x = PowerSeriesRing(RealField, 10, "x")
     for iter = 1:300


### PR DESCRIPTION
Nemo passes with these changes.

Running Hecke tests now. @thofma @fieker the Hecke tests currently take about half an hour to run on my poor laptop. Some individual tests take 5 or 10 minutes to run. Are these testing functionality not tested by the shorter tests, or are they mainly there to keep an eye on performance regressions?

If the latter, is there any possibility of wrapping them in a test for HECKE_TESTLONG or so in ENV? Only you guys actually know what timings to look out for, I presume, as these would be machine specific.