### PR TITLE
Cut down the number of CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,12 @@
 name: Run tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - 'master'
+      - 'release-'
+    tags: '*'
+  pull_request:
 
 jobs:
   test:
@@ -17,6 +21,7 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          - '1.6-nightly'
           - 'nightly'
         julia-arch:
           - x64
@@ -26,13 +31,21 @@ jobs:
           - windows-latest
         exclude:
           # Reduce the number of macOS jobs, as fewer can be run in parallel
-          - os: macos-latest
+          - os: macOS-latest
             julia-version: '1.1'
-          - os: macos-latest
+          - os: macOS-latest
             julia-version: '1.2'
-          - os: macos-latest
+          - os: macOS-latest
             julia-version: '1.3'
-          - os: macos-latest
+          - os: macOS-latest
+            julia-version: '1.4'
+          - os: windows-latest
+            julia-version: '1.1'
+          - os: windows-latest
+            julia-version: '1.2'
+          - os: windows-latest
+            julia-version: '1.3'
+          - os: windows-latest
             julia-version: '1.4'
 
     steps:


### PR DESCRIPTION
Test all versions on linux. Test 1.0, 1.5, 1.6-nightly and nightly on macOS and Windows. This is in preparation for the upcoming downstream testing.﻿
