### PR TITLE
Add an option to disable latex output in jupyter

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,7 +53,8 @@ makedocs(
              "Maps" => [ "map.md",
                          "functional_map.md",
                          "map_cache.md",
-                         "map_with_inverse.md"]
+                         "map_with_inverse.md"],
+             "Miscellaneous" => ["misc.md"],
          ]
 )
 

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -1,0 +1,12 @@
+# Miscellaneous
+
+## Printing options
+
+AbstractAlgebra supports printing to LaTeX using the MIME type "text/latex". To
+enable LaTeX rendering in Jupyter notebooks and query for the current state,
+use the following functions:
+
+```@docs
+AbstractAlgebra.set_html_as_latex
+AbstractAlgebra.get_html_as_latex
+```

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -43,10 +43,35 @@ function show_obj(io::IO, mi::MIME, obj)
    finish(S)
 end
 
+global _html_as_latex = Ref(false)
+
+@doc doc"""
+    get_html_as_latex()
+
+Returns whether MIME type `text/html` is printed as `text/latex`.
+"""
+get_html_as_latex() = _html_as_latex[]
+
+@doc doc"""
+    set_html_as_latex(fl::Bool)
+
+Toggles whether MIME type `text/html` should be printed as `text/latex`. Note
+that this is a global option. The return value is the old value.
+"""
+function set_html_as_latex(fl::Bool)
+  old = get_html_as_latex()
+  _html_as_latex[] = fl
+  return old
+end
+
 function show_obj(io::IO, mi::MIME"text/html", obj)
-   print(io, "\$")
-   show_obj(io, MIME("text/latex"), obj)
-   print(io, "\$")
+   if _html_as_latex[]
+      print(io, "\$")
+      show_obj(io, MIME("text/latex"), obj)
+      print(io, "\$")
+   else
+      show_obj(io, MIME("text/plain"), obj)
+   end
 end
 
 ################################################################################

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -150,5 +150,14 @@
    @test sprint(show, p) == "a + b^2 + c^3"
    @test sprint(show, p, context = :compact => true) == "a + b^2 + c^3"
    @test sprint(show, p, context = :terse => true) == "a+b^2+c^3"
+
+   Qx, x = QQ["x"]
+   AbstractAlgebra.set_html_as_latex(true)
+   @test AbstractAlgebra.get_html_as_latex() == true
+   @test sprint(show, "text/html", x^12) == "\$x^{12}\$"
+   fl = AbstractAlgebra.set_html_as_latex(false)
+   @assert fl == true
+   @test AbstractAlgebra.get_html_as_latex() == false
+   @test sprint(show, "text/html", x^12) == "x^12"
 end
 


### PR DESCRIPTION
This was requested on the mailing list and something I also needed a few times. With the printer refactoring this is now very easy:

![toggle](https://user-images.githubusercontent.com/11231648/111284130-231c0580-8640-11eb-88df-7f2bbe41f28b.png)

- [x] Is the name OK? 
- [ ] Export it so that `Nemo.html_as_latex()` works.
- [x] Documentation. Any idea where it should go in the online documentation?