### PR TITLE
OscarCI: update workflow, use global axis to reduce combinations

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -22,13 +22,13 @@ jobs:
       if: github.repository == 'oscar-system/OscarDevTools.jl'
       run: |
         julia --project=oscar-dev -e "using Pkg;
-                                      Pkg.add(path=\".\");
+                                      Pkg.develop(PackageSpec(path=\".\"));
                                       Pkg.instantiate();"
     - name: fetch OscarDevTools
       if: github.repository != 'oscar-system/OscarDevTools.jl'
       run: |
         julia --project=oscar-dev -e "using Pkg;
-                                      Pkg.add(\"OscarDevTools\");
+                                      Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
                                       Pkg.instantiate();"
     - id: set-matrix
       run: |
@@ -61,13 +61,13 @@ jobs:
         if: github.repository == 'oscar-system/OscarDevTools.jl'
         run: |
           julia --project=oscar-dev -e "using Pkg;
-                                        Pkg.add(path=\".\");
+                                        Pkg.develop(PackageSpec(path=\".\"));
                                         Pkg.instantiate();"
       - name: fetch OscarDevTools
         if: github.repository != 'oscar-system/OscarDevTools.jl'
         run: |
           julia --project=oscar-dev -e "using Pkg;
-                                        Pkg.add(url=\"https://github.com/oscar-system/OscarDevTools.jl\");
+                                        Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
                                         Pkg.instantiate();"
       - name: "Set up Oscar-dev configuration"
         env:

--- a/OscarCI.toml
+++ b/OscarCI.toml
@@ -1,25 +1,20 @@
 title = "metadata for oscar CI run"
 
-# keep it small to prevent job-explosion
 [env]
-os = [ "ubuntu-latest" ]
-julia-version = [ "~1.6.0-0" ]
+# os = [ "ubuntu-latest" ]
+# julia-version = [ "~1.6.0-0" ]
+# branches = [ "<matching>", "release" ]
 
-# packages not listed here will use the latest release
 [pkgs]
   [pkgs.Oscar]
-  branches = [ "master", "release" ]
   test = true
 
   [pkgs.Nemo]
-  branches = [ "master", "release" ]
   test = true
 
   [pkgs.Singular]
-  branches = [ "master", "release" ]
   test = true
 
   [pkgs.Hecke]
-  branches = [ "master", "release" ]
   test = true
   testoptions = [ "short" ]


### PR DESCRIPTION
This should run just two jobs (and will not create a separate axis per package):
- `<matching>`: for each of the repos look up a corresponding branch and use master otherwise
- `release`: run with the latest released version of the packages (version as chosen by Pkg.jl)

We could add some explicit extra combinations via `[include]`.