### PR TITLE
Use derivative to cut down number of allocations.

### DIFF
--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -842,11 +842,14 @@ function Base.exp(a::AbstractAlgebra.AbsSeriesElem{T}) where T <: RingElement
    z = set_precision!(z, precision(a))
    z = setcoeff!(z, 0, exp(coeff(a, 0)))
    len = length(a)
+   C = base_ring(a)()
+   d = derivative(a)
    for k = 1 : precision(a) - 1
       s = zero(base_ring(a))
       for j = 1 : min(k + 1, len) - 1
-         s += j * coeff(a, j) * coeff(z, k - j)
+         s = addmul_delayed_reduction!(s, coeff(d, j - 1), coeff(z, k - j), C)
       end
+      s = reduce!(s)
       !isunit(base_ring(a)(k)) && error("Unable to divide in exp")
       z = setcoeff!(z, k, divexact(s, k))
    end

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1137,7 +1137,7 @@ function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    for k = 1 : preca - 1
       s = R()
       for j = 1 : min(k + 1, len) - 1
-         c = j >= vala ? polcoeff(d, j - vald) : R()
+         c = j > vald ? polcoeff(d, j - vald - 1) : R()
          s = addmul_delayed_reduction!(s, c, polcoeff(z, k - j), C)
       end
       s = reduce!(s)

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1131,12 +1131,16 @@ function Base.exp(a::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
    c = vala == 0 ? polcoeff(a, 0) : R()
    z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala
+   C = R()
+   d = derivative(a)
+   vald = valuation(d)
    for k = 1 : preca - 1
       s = R()
       for j = 1 : min(k + 1, len) - 1
-         c = j >= vala ? polcoeff(a, j - vala) : R()
-         s += j * c * polcoeff(z, k - j)
+         c = j >= vala ? polcoeff(d, j - vald) : R()
+         s = addmul_delayed_reduction!(s, c, polcoeff(z, k - j), C)
       end
+      s = reduce!(s)
       !isunit(R(k)) && error("Unable to divide in exp")
       z = setcoeff!(z, k, divexact(s, k))
    end

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -868,6 +868,16 @@ end
       @test isequal(exp(log(f)), f)
    end
 
+   # Exact Ring
+
+   R, t = PolynomialRing(QQ, "t")
+   S, x = PowerSeriesRing(R, 10, "x")
+
+   c = exp(x + O(x^10))
+
+   @test isequal(c, 1 + x + 1//2*x^2 + 1//6*x^3 + 1//24*x^4 + 1//120*x^5 +
+             1//720*x^6 + 1//5040*x^7 + 1//40320*x^8 + 1//362880*x^9 + O(x^10))
+
    # Inexact field
    S, x = PowerSeriesRing(RealField, 10, "x")
 


### PR DESCRIPTION
Speeds up relative and absolute series generic exp over rings by:

* computing derivative once to avoid allocations
* using delayed reduction (where available)

Note that this may be breaking, as fit! is not available for Nemo polynomial rings and derivative uses it. I will make a PR to fix this soon.