### PR TITLE
Add trailing_coefficient for MPoly.

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -427,21 +427,21 @@ julia> evaluate(f, [M1, M2, M3])
 
 ### Leading and constant coefficients, leading monomials and leading terms
 
-The leading coefficient, constant coefficient, leading monomial and leading
-term of a polynomial p are returned by the following functions:
+The leading and trailing coefficient, constant coefficient, leading monomial
+and leading term of a polynomial p are returned by the following functions:
 
 ```@docs
 leading_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+trailing_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+constant_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+```
+
 ```
 ```@docs
 leading_monomial(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
 ```
 ```@docs
 leading_term(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
-```
-
-```@docs
-constant_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
 ```
 
 **Examples**

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -863,6 +863,28 @@ function leading_coefficient(p::MPolyElem{T}) where T <: RingElement
 end
 
 @doc Markdown.doc"""
+    trailing_coefficient(p::MPolyElem)
+
+Return the trailing coefficient of the polynomial $p$, i.e. the coefficient of
+the last nonzero term, or zero if the polynomial is zero.
+"""
+function trailing_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+   coeff = zero(base_ring(p))
+   for c in coefficients(p)
+      coeff = c
+   end
+   return coeff
+end
+
+function trailing_coefficient(p::MPoly{T}) where T <: RingElement
+   if iszero(p)
+      return zero(base_ring(p))
+   else
+      return coeff(p, length(p))
+   end
+end
+
+@doc Markdown.doc"""
     constant_coefficient(p::MPolyElem)
 
 Return the constant coefficient of the polynomial $p$ or zero if it doesn't

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -369,6 +369,11 @@ end
    @test constant_coefficient(2x + 1) == 1
    @test constant_coefficient(2x) == 0
    @test constant_coefficient(2x^2 + 3y^3 + 4) == 4
+
+   @test trailing_coefficient(x^2*y + 7x*y + 3x + 2y + 5) == 5
+   @test trailing_coefficient(x^2*y + 7x*y + 3x + 2y) == 2
+   @test trailing_coefficient(R(2)) == 2
+   @test trailing_coefficient(R()) == 0
 end
 
 @testset "Generic.MPoly.total_degree" begin


### PR DESCRIPTION
This should work for Nemo (and Singular.jl once imported/exported). As it has to do it the generic way using iterators it will be slow for Nemo, but I will write a faster version over there.

In the meantime, this should be ok as is, I believe.

Fixes #822 (tail was dealt with in the relevant PR)