### PR TITLE
Implement similar and zero for absolute and relative series.

### DIFF
--- a/docs/src/series_rings.md
+++ b/docs/src/series_rings.md
@@ -124,6 +124,58 @@ julia> f = S(Rational{BigInt}[0, 2, 3, 1], 4, 6)
 
 ```
 
+It is also possible to create series directly without having to create the
+corresponding series ring.
+
+```julia
+abs_series(R::Ring, arr::Vector{T}, len::Int, prec::Int, var::AbstractString="x"; max_precision::Int=prec, cached::Bool=true) where T
+rel_series(R::Ring, arr::Vector{T}, len::Int, prec::Int, val::Int, var::AbstractString="x"; max_precision::Int=prec, cached::Bool=true) where T
+```
+
+Create the power series over the given base ring `R` with coefficients
+specified by `arr` with the given absolute precision `prec` and in the case
+of relative series with the given valuation `val`.
+
+Note that more coefficients may be specified than are actually used. Only
+the first `len` coefficients are made part of the series, the remainder being
+stored internally but ignored.
+
+In the case of absolute series one must have `prec >= len` and in the case of
+relative series one must have `prec >= len + val`.
+
+By default the series are created in a ring with variable `x` and
+`max_precision` equal to `prec`, however one may specify these directly to
+override the defaults. Note that series are only compatible if they have the
+same coefficient ring `R`, `max_precision` and variable string `var`.
+
+Also by default any parent ring created is cached. If this behaviour is not
+desired, set `cached=false`. However, this means that subsequent series created
+in the same way will not be compatible. Instead, one should use the parent
+object of the first series to create subsequent series instead of calling this
+function repeatedly with cached=false.
+
+**Examples**
+
+```jldoctest
+julia> f = abs_series(ZZ, [1, 2, 3], 3, 5, "y")
+1 + 2*y + 3*y^2 + O(y^5)
+
+julia> g = rel_series(ZZ, [1, 2, 3], 3, 7, 4)
+x^4 + 2*x^5 + 3*x^6 + O(x^7)
+
+julia> k = abs_series(ZZ, [1, 2, 3], 1, 6, cached=false)
+1 + O(x^6)
+
+julia> p = rel_series(ZZ, BigInt[], 0, 3, 1)
+O(x^3)
+
+julia> q = abs_series(ZZ, [], 0, 6)
+O(x^6)
+
+julia> s = abs_series(ZZ, [1, 2, 3], 3, 5; max_precision=10)
+1 + 2*x + 3*x^2 + O(x^5)
+```
+
 ### Data type and parent object methods
 
 ```julia

--- a/docs/src/series_rings.md
+++ b/docs/src/series_rings.md
@@ -309,3 +309,53 @@ julia> isgen(w)
 true
 
 ```
+
+## Optional functionality for series
+
+### Similar and zero
+
+The following functions are available for all absolute and relative series
+types. The functions `similar` and `zero` do the same thing, but are provided
+for uniformity with other parts of the interface.
+
+```julia
+similar(x::MySeries, R::Ring, max_prec::Int, var::Symbol=var(parent(x)); cached::Bool=true)
+zero(a::MySeries, R::Ring, max_prec::Int, var::Symbol=var(parent(a)); cached::Bool=true)
+```
+
+Construct the zero series with the given variable (if specified), coefficients
+in the specified coefficient ring and with relative/absolute precision cap on
+its parent ring as given by `max_prec`.
+
+```julia
+similar(x::MySeries, R::Ring, var::Symbol=var(parent(x)); cached::Bool=true)
+similar(x::MySeries, max_prec::Int, var::Symbol=var(parent(x)); cached::Bool=true)
+similar(x::MySeries, var::Symbol=var(parent(x)); cached::Bool=true)
+similar(x::MySeries, R::Ring, max_prec::Int, var::String; cached::Bool=true)
+similar(x::MySeries, R::Ring, var::String; cached::Bool=true)
+similar(x::MySeries, max_prec::Int, var::String; cached::Bool=true)
+similar(x::MySeries, var::String; cached::Bool=true)
+zero(x::MySeries, R::Ring, var::Symbol=var(parent(x)); cached::Bool=true)
+zero(x::MySeries, max_prec::Int, var::Symbol=var(parent(x)); cached::Bool=true)
+zero(x::MySeries, var::Symbol=var(parent(x)); cached::Bool=true)
+zero(x::MySeries, R::Ring, max_prec::Int, var::String; cached::Bool=true)
+zero(x::MySeries, R::Ring, var::String; cached::Bool=true)
+zero(x::MySeries, max_prec::Int, var::String; cached::Bool=true)
+zero(x::MySeries, var::String; cached::Bool=true)
+```
+
+As above, but use the precision cap of the parent ring of `x` and the
+`base_ring` of `x` if these are not specified.
+
+Custom series rings may choose which series type is best-suited to return for
+the given coefficient ring, precision cap and variable, however they should
+return a series with the same model as `x`, i.e. relative or series.
+
+If custom implementations don't specialise these function the default return
+type is a `Generic.AbsSeries` or `Generic.RelSeries`.
+
+The default implementation of zero calls out to similar, so it's generally
+sufficient to specialise only similar. For both similar and zero only the most
+general method has to be implemented as all other methods call out to this more
+general method.
+

--- a/docs/src/series_rings.md
+++ b/docs/src/series_rings.md
@@ -186,6 +186,19 @@ Return a `Symbol` representing the variable (generator) of the series ring. Note
 that this is a `Symbol` not a `String`, though its string value will usually be used
 when printing series.
 
+Custom series types over a given ring should define one of the following functions
+which return the type of an absolute or relative series object over that ring.
+
+```julia
+abs_series_type(::Type{T}) where T <: RingElement
+rel_series_type(::Type{T}) where T <: RingElement
+```
+
+Return the type of a series whose coefficients have the given type.
+
+This function is defined for generic series and only needs to be defined for
+custom series rings, e.g. ones defined by a C implementation.
+
 ```julia
 max_precision(S::MySeriesRing{T}) where T <: AbstractAlgebra.RingElem
 ```

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -410,7 +410,7 @@ include("Generic.jl")
 
 # Do not import div, divrem, exp, inv, log, sqrt, numerator and denominator
 # as we have our own
-import .Generic: abs_series, add!, addeq!, addmul!, 
+import .Generic: abs_series, abs_series_type, add!, addeq!, addmul!, 
                  add_column, add_column!, add_row,
                  add_row!, basis, cached, can_solve_left_reduced_triu,
                  can_solve, can_solve_with_solution,
@@ -475,7 +475,7 @@ import .Generic: abs_series, add!, addeq!, addmul!,
 		 prime, primpart, pseudodivrem,
                  pseudo_inv, pseudorem, push_term!, randmat_triu,
                  randmat_with_rank, rand_ordering, rank_profile_popov, remove,
-                 renormalize!, rel_series, rels,
+                 renormalize!, rel_series, rel_series_type, rels,
 		 rescale!, resultant, resultant_ducos,
                  resultant_euclidean, resultant_subresultant,
                  resultant_sylvester, resx, retraction_map, reverse,
@@ -501,7 +501,7 @@ import .Generic: abs_series, add!, addeq!, addmul!,
 		 power_sums_to_polynomial, roots, sturm_sequence
 
 # Do not export inv, div, divrem, exp, log, sqrt, numerator and denominator as we define our own
-export abs_series, add!, addeq!, addmul!,
+export abs_series, abs_series_type, add!, addeq!, addmul!,
                  addmul_delayed_reduction!, addmul!,
                  add_column, add_column!, add_row, add_row!, base_ring, cached,
                  canonical_unit, can_solve_left_reduced_triu,
@@ -569,7 +569,7 @@ export abs_series, add!, addeq!, addmul!,
 		 pseudo_inv, pseudodivrem, pseudorem,
                  push_term!, rank, randmat_triu, randmat_with_rank,
                  rand_ordering, rank_profile_popov, reduce!, remove,
-                 renormalize!, rel_series, rels,
+                 renormalize!, rel_series, rel_series_type, rels,
 		 resultant, resultant_ducos, rescale!,
                  resultant_euclidean, resultant_subresultant,
                  resultant_sylvester, resx, retraction_map, reverse,

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -410,7 +410,8 @@ include("Generic.jl")
 
 # Do not import div, divrem, exp, inv, log, sqrt, numerator and denominator
 # as we have our own
-import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row,
+import .Generic: abs_series, add!, addeq!, addmul!, 
+                 add_column, add_column!, add_row,
                  add_row!, basis, cached, can_solve_left_reduced_triu,
                  can_solve, can_solve_with_solution,
                  character, characteristic, charpoly, charpoly_danilevsky!,
@@ -474,7 +475,8 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row,
 		 prime, primpart, pseudodivrem,
                  pseudo_inv, pseudorem, push_term!, randmat_triu,
                  randmat_with_rank, rand_ordering, rank_profile_popov, remove,
-                 renormalize!, rels, rescale!, resultant, resultant_ducos,
+                 renormalize!, rel_series, rels,
+		 rescale!, resultant, resultant_ducos,
                  resultant_euclidean, resultant_subresultant,
                  resultant_sylvester, resx, retraction_map, reverse,
                  reverse_cols, reverse_cols!,
@@ -499,7 +501,9 @@ import .Generic: add!, addeq!, addmul!, add_column, add_column!, add_row,
 		 power_sums_to_polynomial, roots, sturm_sequence
 
 # Do not export inv, div, divrem, exp, log, sqrt, numerator and denominator as we define our own
-export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, add_column!, add_row, add_row!, base_ring, cached,
+export abs_series, add!, addeq!, addmul!,
+                 addmul_delayed_reduction!, addmul!,
+                 add_column, add_column!, add_row, add_row!, base_ring, cached,
                  canonical_unit, can_solve_left_reduced_triu,
                  can_solve, can_solve_with_solution,
                  change_base_ring, character,
@@ -565,7 +569,8 @@ export add!, addeq!, addmul!, addmul_delayed_reduction!, addmul!, add_column, ad
 		 pseudo_inv, pseudodivrem, pseudorem,
                  push_term!, rank, randmat_triu, randmat_with_rank,
                  rand_ordering, rank_profile_popov, reduce!, remove,
-                 renormalize!, rels, resultant, resultant_ducos, rescale!,
+                 renormalize!, rel_series, rels,
+		 resultant, resultant_ducos, rescale!,
                  resultant_euclidean, resultant_subresultant,
                  resultant_sylvester, resx, retraction_map, reverse,
                  reverse_rows!, reverse_cols, reverse_cols!,

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export O, valuation, precision, max_precision
+export O, valuation, precision, max_precision, abs_series
 
 ###############################################################################
 #
@@ -210,6 +210,22 @@ zero(a::AbsSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
 
 zero(a::AbsSeriesElem, var::String; cached::Bool=true) =
    zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+
+###############################################################################
+#
+#   abs_series constructor
+#
+###############################################################################
+
+function abs_series(R::Ring, arr::Vector{T}, len::Int, prec::Int, var::AbstractString="x"; max_precision::Int=prec, cached::Bool=true) where T
+   prec < len && error("Precision too small for given data")
+   TT = elem_type(R)
+   coeffs = T == Any && length(arr) == 0 ? elem_type(R)[] : map(R, arr)
+   p = AbsSeries{TT}(coeffs, len, prec)
+   # Default is supposed to return a Generic polynomial
+   p.parent = AbsSeriesRing{TT}(R, max_precision, Symbol(var), cached)
+   return p
+end
 
 ###############################################################################
 #

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export O, valuation, precision, max_precision, abs_series
+export O, valuation, precision, max_precision, abs_series, abs_series_type
 
 ###############################################################################
 #
@@ -30,6 +30,13 @@ end
 parent_type(::Type{AbsSeries{T}}) where {T <: RingElement} = AbsSeriesRing{T}
 
 elem_type(::Type{AbsSeriesRing{T}}) where {T <: RingElement} = AbsSeries{T}
+
+@doc Markdown.doc"""
+    abs_series_type(::Type{T}) where T <: RingElement
+
+Return the type of an absolute series whose coefficients have the given type.
+"""
+abs_series_type(::Type{T}) where T <: RingElement = Generic.AbsSeries{T}
 
 ###############################################################################
 #

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -130,6 +130,89 @@ end
 
 ###############################################################################
 #
+#   Similar and zero
+#
+###############################################################################
+
+function similar(x::AbsSeriesElem, R::Ring, max_prec::Int,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   TT = elem_type(R)
+   V = Vector{TT}(undef, 0)
+   p = AbsSeries{TT}(V, 0, max_prec)
+   # Default similar is supposed to return a Generic series
+   p.parent = AbsSeriesRing{TT}(R, max_prec, var, cached)
+   return p
+end
+
+function similar(x::AbsSeriesElem, R::Ring,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, R, max_precision(parent(x)), var; cached = cached)
+end
+
+function similar(x::AbsSeriesElem, max_prec::Int,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, base_ring(x), max_prec, var; cached=cached)
+end
+
+function similar(x::AbsSeriesElem,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, base_ring(x),
+                  max_precision(parent(x)), var; cached=cached)
+end
+
+function similar(x::AbsSeriesElem, R::Ring, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return similar(x, R, max_prec, Symbol(var); cached=cached)
+end
+
+function similar(x::AbsSeriesElem, R::Ring, var::String; cached::Bool=true)
+   return similar(x, R, max_precision(parent(x)), Symbol(var); cached=cached)
+end
+
+function similar(x::AbsSeriesElem, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return similar(x, base_ring(x), max_prec, Symbol(var); cached=cached)
+end
+
+function similar(x::AbsSeriesElem, var::String; cached::Bool=true)
+   return similar(x, base_ring(x),
+                  max_precision(parent(x)), Symbol(var); cached=cached)
+end
+
+function zero(a::AbsSeriesElem, R::Ring, max_prec::Int,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, R, max_prec, var; cached=cached)
+end
+
+function zero(a::AbsSeriesElem, R::Ring,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, R, max_precision(parent(x)), var; cached=cached)
+end
+
+function zero(a::AbsSeriesElem, max_prec::Int,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, base_ring(a), max_prec, var; cached=cached)
+end
+
+zero(a::AbsSeriesElem, var::Symbol=var(parent(a)); cached::Bool=true) =
+   similar(a, base_ring(a), max_precision(parent(x)), var; cached=cached)
+
+function zero(a::AbsSeriesElem, R::Ring, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return zero(a, R, max_prec, Symbol(var); cached=cached)
+end
+
+zero(a::AbsSeriesElem, R::Ring, var::String; cached::Bool=true) =
+   zero(a, R, max_precision(parent(x)), Symbol(var); cached=cached)
+
+zero(a::AbsSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
+   zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
+
+zero(a::AbsSeriesElem, var::String; cached::Bool=true) =
+   zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+
+###############################################################################
+#
 #   AbstractString I/O
 #
 ###############################################################################

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -215,6 +215,89 @@ end
 
 ###############################################################################
 #
+#   Similar and zero
+#
+###############################################################################
+
+function similar(x::RelSeriesElem, R::Ring, max_prec::Int,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   TT = elem_type(R)
+   V = Vector{TT}(undef, 0)
+   p = RelSeries{TT}(V, 0, max_prec, max_prec)
+   # Default similar is supposed to return a Generic series
+   p.parent = RelSeriesRing{TT}(R, max_prec, var, cached)
+   return p
+end
+
+function similar(x::RelSeriesElem, R::Ring,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, R, max_precision(parent(x)), var; cached = cached)
+end
+
+function similar(x::RelSeriesElem, max_prec::Int,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, base_ring(x), max_prec, var; cached=cached)
+end
+
+function similar(x::RelSeriesElem,
+                                 var::Symbol=var(parent(x)); cached::Bool=true)
+   return similar(x, base_ring(x),
+                  max_precision(parent(x)), var; cached=cached)
+end
+
+function similar(x::RelSeriesElem, R::Ring, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return similar(x, R, max_prec, Symbol(var); cached=cached)
+end
+
+function similar(x::RelSeriesElem, R::Ring, var::String; cached::Bool=true)
+   return similar(x, R, max_precision(parent(x)), Symbol(var); cached=cached)
+end
+
+function similar(x::RelSeriesElem, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return similar(x, base_ring(x), max_prec, Symbol(var); cached=cached)
+end
+
+function similar(x::RelSeriesElem, var::String; cached::Bool=true)
+   return similar(x, base_ring(x), max_precision(parent(x)),
+                  Symbol(var); cached=cached)
+end
+
+function zero(a::RelSeriesElem, R::Ring, max_prec::Int,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, R, max_prec, var; cached=cached)
+end
+
+function zero(a::RelSeriesElem, R::Ring,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, R, max_precision(parent(x)), var; cached=cached)
+end
+
+function zero(a::RelSeriesElem, max_prec::Int,
+                                 var::Symbol=var(parent(a)); cached::Bool=true)
+   return similar(a, base_ring(a), max_prec, var; cached=cached)
+end
+
+zero(a::RelSeriesElem, var::Symbol=var(parent(a)); cached::Bool=true) =
+   similar(a, base_ring(a), max_precision(parent(x)), var; cached=cached)
+
+function zero(a::RelSeriesElem, R::Ring, max_prec::Int,
+                                                var::String; cached::Bool=true)
+   return zero(a, R, max_prec, Symbol(var); cached=cached)
+end
+
+zero(a::RelSeriesElem, R::Ring, var::String; cached::Bool=true) =
+   zero(a, R, max_precision(parent(x)), Symbol(var); cached=cached)
+
+zero(a::RelSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
+   zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
+
+zero(a::RelSeriesElem, var::String; cached::Bool=true) =
+   zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+
+###############################################################################
+#
 #   AbstractString I/O
 #
 ###############################################################################

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -5,7 +5,8 @@
 ###############################################################################
 
 export PowerSeriesRing, O, valuation, precision, max_precision, set_precision!,
-       polcoeff, set_valuation!, pol_length, renormalize!, rel_series
+       polcoeff, set_valuation!, pol_length, renormalize!, rel_series,
+       rel_series_type
 
 ###############################################################################
 #
@@ -31,6 +32,13 @@ parent_type(::Type{RelSeries{T}}) where T <: RingElement = RelSeriesRing{T}
 parent(a::AbstractAlgebra.SeriesElem) = a.parent
 
 elem_type(::Type{RelSeriesRing{T}}) where T <: RingElement = RelSeries{T}
+
+@doc Markdown.doc"""
+    rel_series_type(::Type{T}) where T <: RingElement
+
+Return the type of a relative series whose coefficients have the given type.
+"""
+rel_series_type(::Type{T}) where T <: RingElement = Generic.RelSeries{T}
 
 base_ring(R::SeriesRing{T}) where T <: RingElement = R.base_ring::parent_type(T)
 

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 export PowerSeriesRing, O, valuation, precision, max_precision, set_precision!,
-       polcoeff, set_valuation!, pol_length, renormalize!
+       polcoeff, set_valuation!, pol_length, renormalize!, rel_series
 
 ###############################################################################
 #
@@ -295,6 +295,22 @@ zero(a::RelSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
 
 zero(a::RelSeriesElem, var::String; cached::Bool=true) =
    zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+
+###############################################################################
+#
+#   rel_series constructor
+#
+###############################################################################
+
+function rel_series(R::Ring, arr::Vector{T}, len::Int, prec::Int, val::Int, var::AbstractString="x"; max_precision::Int=prec, cached::Bool=true) where T
+   prec < len + val && error("Precision too small for given data")
+   TT = elem_type(R)
+   coeffs = T == Any && length(arr) == 0 ? elem_type(R)[] : map(R, arr)
+   p = RelSeries{TT}(coeffs, len, prec, val)
+   # Default is supposed to return a Generic polynomial
+   p.parent = RelSeriesRing{TT}(R, max_precision, Symbol(var), cached)
+   return p
+end
 
 ###############################################################################
 #

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -16,6 +16,11 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+@testset "Generic.AbsSeries.types" begin
+   @test abs_series_type(BigInt) == Generic.AbsSeries{BigInt}
+   @test abs_series_type(Rational{BigInt}) == Generic.AbsSeries{Rational{BigInt}}
+end
+
 @testset "Generic.AbsSeries.constructors" begin
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
 

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -128,6 +128,54 @@ end
    @test modulus(T) == 7
 end
 
+@testset "Generic.AbsSeries.similar" begin
+   R, x = PowerSeriesRing(ZZ, 10, "x"; model=:capped_absolute)
+
+   for iters = 1:10
+      f = rand(R, 0:10, -10:10)
+
+      g = similar(f, QQ, "y")
+      h = similar(f, "y")
+      k = similar(f)
+      m = similar(f, QQ, 5)
+      n = similar(f, 5)
+
+      @test isa(g, AbsSeriesElem)
+      @test isa(h, AbsSeriesElem)
+      @test isa(k, AbsSeriesElem)
+      @test isa(m, AbsSeriesElem)
+      @test isa(n, AbsSeriesElem)
+
+      @test base_ring(g) == QQ
+      @test base_ring(m) == QQ
+
+      @test parent(g).S == :y
+      @test parent(h).S == :y
+
+      @test iszero(g)
+      @test iszero(h)
+      @test iszero(k)
+      @test iszero(m)
+      @test iszero(n)
+
+      @test parent(g) != parent(f)
+      @test parent(h) != parent(f)
+      @test parent(k) == parent(f)
+      @test parent(m) != parent(f)
+      @test parent(n) != parent(f)
+
+      p = similar(f, cached=false)
+      q = similar(f, "z", cached=false)
+      r = similar(f, "z", cached=false)
+      s = similar(f)
+      t = similar(f)
+
+      @test parent(p) != parent(f)
+      @test parent(q) != parent(r)
+      @test parent(s) == parent(t)
+   end
+end
+
 @testset "Generic.AbsSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -176,6 +176,48 @@ end
    end
 end
 
+@testset "Generic.AbsSeries.abs_series" begin
+   f = abs_series(ZZ, [1, 2, 3], 3, 5, "y")
+
+   @test isa(f, AbsSeriesElem)
+   @test base_ring(f) == ZZ
+   @test coeff(f, 0) == 1
+   @test coeff(f, 2) == 3
+   @test parent(f).S == :y
+
+   g = abs_series(ZZ, [1, 2, 3], 3, 5)
+
+   @test isa(g, AbsSeriesElem)
+   @test base_ring(g) == ZZ
+   @test coeff(g, 0) == 1
+   @test coeff(g, 2) == 3
+   @test parent(g).S == :x
+
+   h = abs_series(ZZ, [1, 2, 3], 2, 5)
+   k = abs_series(ZZ, [1, 2, 3], 1, 6, cached=false)
+   m = abs_series(ZZ, [1, 2, 3], 3, 9, cached=false)
+
+   @test parent(h) == parent(g)
+   @test parent(k) != parent(m)
+
+   p = abs_series(ZZ, BigInt[], 0, 4)
+   q = abs_series(ZZ, [], 0, 6)
+
+   @test isa(p, AbsSeriesElem)
+   @test isa(q, AbsSeriesElem)
+
+   @test length(p) == 0
+   @test length(q) == 0
+
+   r = abs_series(QQ, BigInt[1, 2, 3], 3, 5)
+
+   @test isa(r, AbsSeriesElem)
+
+   s = abs_series(ZZ, [1, 2, 3], 3, 5; max_precision=10)
+   
+   @test max_precision(parent(s)) == 10
+end
+
 @testset "Generic.AbsSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x", model=:capped_absolute)

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -16,6 +16,11 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+@testset "Generic.RelSeries.types" begin
+   @test rel_series_type(BigInt) == Generic.RelSeries{BigInt}
+   @test rel_series_type(Rational{BigInt}) == Generic.RelSeries{Rational{BigInt}}
+end
+
 @testset "Generic.RelSeries.constructors" begin
    R, x = PowerSeriesRing(ZZ, 30, "x")
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -184,6 +184,48 @@ end
    end
 end
 
+@testset "Generic.RelSeries.rel_series" begin
+   f = rel_series(ZZ, [1, 2, 3], 3, 5, 2, "y")
+
+   @test isa(f, RelSeriesElem)
+   @test base_ring(f) == ZZ
+   @test coeff(f, 2) == 1
+   @test coeff(f, 4) == 3
+   @test parent(f).S == :y
+
+   g = rel_series(ZZ, [1, 2, 3], 3, 7, 4)
+
+   @test isa(g, RelSeriesElem)
+   @test base_ring(g) == ZZ
+   @test coeff(g, 4) == 1
+   @test coeff(g, 6) == 3
+   @test parent(g).S == :x
+
+   h = rel_series(ZZ, [1, 2, 3], 2, 7, 1)
+   k = rel_series(ZZ, [1, 2, 3], 1, 6, 0, cached=false)
+   m = rel_series(ZZ, [1, 2, 3], 3, 9, 5, cached=false)
+
+   @test parent(h) == parent(g)
+   @test parent(k) != parent(m)
+
+   p = rel_series(ZZ, BigInt[], 0, 3, 1)
+   q = rel_series(ZZ, [], 0, 3, 2)
+
+   @test isa(p, RelSeriesElem)
+   @test isa(q, RelSeriesElem)
+
+   @test pol_length(p) == 0
+   @test pol_length(q) == 0
+
+   r = rel_series(QQ, BigInt[1, 2, 3], 3, 11, 8)
+
+   @test isa(r, RelSeriesElem)
+
+   s = rel_series(ZZ, [1, 2, 3], 3, 5, 0; max_precision=10)
+   
+   @test max_precision(parent(s)) == 10
+end
+
 @testset "Generic.RelSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -136,6 +136,54 @@ end
    @test modulus(T) == 7
 end
 
+@testset "Generic.AbsSeries.similar" begin
+   R, x = PowerSeriesRing(ZZ, 10, "x")
+
+   for iters = 1:10
+      f = rand(R, 0:10, -10:10)
+
+      g = similar(f, QQ, "y")
+      h = similar(f, "y")
+      k = similar(f)
+      m = similar(f, QQ, 5)
+      n = similar(f, 5)
+
+      @test isa(g, RelSeriesElem)
+      @test isa(h, RelSeriesElem)
+      @test isa(k, RelSeriesElem)
+      @test isa(m, RelSeriesElem)
+      @test isa(n, RelSeriesElem)
+
+      @test base_ring(g) == QQ
+      @test base_ring(m) == QQ
+
+      @test parent(g).S == :y
+      @test parent(h).S == :y
+
+      @test iszero(g)
+      @test iszero(h)
+      @test iszero(k)
+      @test iszero(m)
+      @test iszero(n)
+
+      @test parent(g) != parent(f)
+      @test parent(h) != parent(f)
+      @test parent(k) == parent(f)
+      @test parent(m) != parent(f)
+      @test parent(n) != parent(f)
+
+      p = similar(f, cached=false)
+      q = similar(f, "z", cached=false)
+      r = similar(f, "z", cached=false)
+      s = similar(f)
+      t = similar(f)
+
+      @test parent(p) != parent(f)
+      @test parent(q) != parent(r)
+      @test parent(s) == parent(t)
+   end
+end
+
 @testset "Generic.RelSeries.unary_ops" begin
    #  Exact ring
    R, x = PowerSeriesRing(ZZ, 10, "x")


### PR DESCRIPTION
I had a lot of trouble deciding what precision and valuation the resulting series should have. As the series returned is going to be zero, I decided the precision should equal the valuation, so only one should be supplied.

But that still left two possibilities for this precision:

* set it to the max_precision of the parent of the input series
* set it to the precision of the input series

I decided to go with the former, as the other parameters (when specified) change some feature of the parent ring and otherwise use the values from the parent ring.

However, if this convention turns out to not be useful in practice, we can certainly revisit this.

I've also slipped constructors for abs_series and rel_series, without creating the parent ring, and abs_series_type and rel_series_type into this PR.