### PR TITLE
Make randmat_with_rank apply to other matrix types, e.g. Nemo matrices.

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -5854,7 +5854,7 @@ end
 
 randmat_triu(S::AbstractAlgebra.MatSpace, v...) = randmat_triu(Random.GLOBAL_RNG, S, v...)
 
-function randmat_with_rank(rng::AbstractRNG, S::Generic.MatSpace{T}, rank::Int, v...) where {T <: AbstractAlgebra.RingElement}
+function randmat_with_rank(rng::AbstractRNG, S::AbstractAlgebra.MatSpace{T}, rank::Int, v...) where {T <: AbstractAlgebra.RingElement}
    if !isdomain_type(T) && !(T <: ResElem)
       error("Not implemented")
    end
@@ -5892,7 +5892,7 @@ function randmat_with_rank(rng::AbstractRNG, S::Generic.MatSpace{T}, rank::Int, 
    return M
 end
 
-randmat_with_rank(S::Generic.MatSpace{T}, rank::Int, v...) where {T <: AbstractAlgebra.RingElement} =
+randmat_with_rank(S::AbstractAlgebra.MatSpace{T}, rank::Int, v...) where {T <: AbstractAlgebra.RingElement} =
    randmat_with_rank(Random.GLOBAL_RNG, S, rank, v...)
 
 ###############################################################################


### PR DESCRIPTION
Fixes #664 

I tested by hand that it works fine for Nemo matrices over GF(7) as per the ticket. I can't really test that here, but the change is not exactly complex.