### PR TITLE
Univariate polynomial residue rings

### DIFF
--- a/docs/src/residue_rings.md
+++ b/docs/src/residue_rings.md
@@ -7,9 +7,13 @@ end
 
 # Residue Ring Interface
 
-Residue rings (currently a quotient ring modulo a principal ideal) are supported in
-AbstractAlgebra.jl, at least for Euclidean base rings. In addition to the standard Ring
-interface, some additional functions are required to be present for residue rings.
+Residue rings (currently a quotient ring modulo a principal ideal) are
+supported in AbstractAlgebra.jl, at least for Euclidean base rings. There is
+also partial support for residue rings of polynomial rings where the modulus
+has invertible leading coefficient.
+
+In addition to the standard Ring interface, some additional functions are
+required to be present for residue rings.
 
 ## Types and parents
 

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -213,10 +213,10 @@ zero(a::AbsSeriesElem, R::Ring, var::String; cached::Bool=true) =
    zero(a, R, max_precision(parent(a)), Symbol(var); cached=cached)
 
 zero(a::AbsSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
+   zero(a, base_ring(a), max_prec, Symbol(var); cached=cached)
 
 zero(a::AbsSeriesElem, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_precision(parent(a)), Symbol(var); cached=cached)
+   zero(a, base_ring(a), max_precision(parent(a)), Symbol(var); cached=cached)
 
 ###############################################################################
 #

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -193,7 +193,7 @@ end
 
 function zero(a::AbsSeriesElem, R::Ring,
                                  var::Symbol=var(parent(a)); cached::Bool=true)
-   return similar(a, R, max_precision(parent(x)), var; cached=cached)
+   return similar(a, R, max_precision(parent(a)), var; cached=cached)
 end
 
 function zero(a::AbsSeriesElem, max_prec::Int,
@@ -202,7 +202,7 @@ function zero(a::AbsSeriesElem, max_prec::Int,
 end
 
 zero(a::AbsSeriesElem, var::Symbol=var(parent(a)); cached::Bool=true) =
-   similar(a, base_ring(a), max_precision(parent(x)), var; cached=cached)
+   similar(a, base_ring(a), max_precision(parent(a)), var; cached=cached)
 
 function zero(a::AbsSeriesElem, R::Ring, max_prec::Int,
                                                 var::String; cached::Bool=true)
@@ -210,13 +210,13 @@ function zero(a::AbsSeriesElem, R::Ring, max_prec::Int,
 end
 
 zero(a::AbsSeriesElem, R::Ring, var::String; cached::Bool=true) =
-   zero(a, R, max_precision(parent(x)), Symbol(var); cached=cached)
+   zero(a, R, max_precision(parent(a)), Symbol(var); cached=cached)
 
 zero(a::AbsSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
    zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
 
 zero(a::AbsSeriesElem, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+   zero(a, base_ring(p), max_precision(parent(a)), Symbol(var); cached=cached)
 
 ###############################################################################
 #

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1337,7 +1337,7 @@ end
 
 Return $a\times b \pmod{d}$.
 """
-function mulmod(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}, d::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function mulmod(a::AbstractAlgebra.PolyElem{T}, b::AbstractAlgebra.PolyElem{T}, d::AbstractAlgebra.PolyElem{T}) where T <: RingElement
    check_parent(a, b)
    check_parent(a, d)
    return mod(a*b, d)
@@ -1348,7 +1348,7 @@ end
 
 Return $a^b \pmod{d}$. There are no restrictions on $b$.
 """
-function powermod(a::AbstractAlgebra.PolyElem{T}, b::Int, d::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function powermod(a::AbstractAlgebra.PolyElem{T}, b::Int, d::AbstractAlgebra.PolyElem{T}) where T <: RingElement
    check_parent(a, d)
    if length(a) == 0
       z = zero(parent(a))
@@ -1467,7 +1467,7 @@ end
 
 Return $f \pmod{g}$.
 """
-function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
    check_parent(f, g)
    if length(g) == 0
       throw(DivideError())
@@ -1491,7 +1491,7 @@ function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) whe
    return f
 end
 
-function rem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function rem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where T <: RingElement
   return mod(f, g)
 end
 
@@ -1501,7 +1501,7 @@ end
 Return a tuple $(q, r)$ such that $f = qg + r$ where $q$ is the euclidean
 quotient of $f$ by $g$.
 """
-function Base.divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function Base.divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where T <: RingElement
    check_parent(f, g)
    if length(g) == 0
       throw(DivideError())
@@ -1536,7 +1536,7 @@ end
 
 Return the euclidean quotient of $f$ by $g$.
 """
-function Base.div(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where {T <: Union{AbstractAlgebra.ResElem, FieldElement}}
+function Base.div(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) where T <: RingElement
    q, r = divrem(f, g)
    return q
 end

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -279,7 +279,7 @@ end
 
 function zero(a::RelSeriesElem, R::Ring,
                                  var::Symbol=var(parent(a)); cached::Bool=true)
-   return similar(a, R, max_precision(parent(x)), var; cached=cached)
+   return similar(a, R, max_precision(parent(a)), var; cached=cached)
 end
 
 function zero(a::RelSeriesElem, max_prec::Int,
@@ -288,7 +288,7 @@ function zero(a::RelSeriesElem, max_prec::Int,
 end
 
 zero(a::RelSeriesElem, var::Symbol=var(parent(a)); cached::Bool=true) =
-   similar(a, base_ring(a), max_precision(parent(x)), var; cached=cached)
+   similar(a, base_ring(a), max_precision(parent(a)), var; cached=cached)
 
 function zero(a::RelSeriesElem, R::Ring, max_prec::Int,
                                                 var::String; cached::Bool=true)
@@ -296,13 +296,13 @@ function zero(a::RelSeriesElem, R::Ring, max_prec::Int,
 end
 
 zero(a::RelSeriesElem, R::Ring, var::String; cached::Bool=true) =
-   zero(a, R, max_precision(parent(x)), Symbol(var); cached=cached)
+   zero(a, R, max_precision(parent(a)), Symbol(var); cached=cached)
 
 zero(a::RelSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
    zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
 
 zero(a::RelSeriesElem, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_precision(parent(x)), Symbol(var); cached=cached)
+   zero(a, base_ring(p), max_precision(parent(a)), Symbol(var); cached=cached)
 
 ###############################################################################
 #

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -299,10 +299,10 @@ zero(a::RelSeriesElem, R::Ring, var::String; cached::Bool=true) =
    zero(a, R, max_precision(parent(a)), Symbol(var); cached=cached)
 
 zero(a::RelSeriesElem, max_prec::Int, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_prec, Symbol(var); cached=cached)
+   zero(a, base_ring(a), max_prec, Symbol(var); cached=cached)
 
 zero(a::RelSeriesElem, var::String; cached::Bool=true) =
-   zero(a, base_ring(p), max_precision(parent(a)), Symbol(var); cached=cached)
+   zero(a, base_ring(a), max_precision(parent(a)), Symbol(var); cached=cached)
 
 ###############################################################################
 #

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -492,3 +492,11 @@ function ResidueRing(R::AbstractAlgebra.Ring, a::RingElement; cached::Bool = tru
 
    return ResRing{T}(R(a), cached)
 end
+
+function ResidueRing(R::AbstractAlgebra.PolyRing, a::RingElement; cached::Bool = true)
+   iszero(a) && throw(DomainError(a, "Modulus must be nonzero"))
+   !isunit(leading_coefficient(a)) && throw(DomainError(a, "Non-invertible leading coefficient"))
+   T = elem_type(R)
+
+   return ResRing{T}(R(a), cached)
+end

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -43,6 +43,28 @@
 
    @test isa(g, Generic.Res)
 
+   # Poly modulus, invertible lc 
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test isa(T, Generic.ResRing)
+
+   f = T(x^4)
+
+   @test isa(f, Generic.Res)
+
+   g = T(f)
+
+   @test isa(g, Generic.Res)
+
+   h = T()
+
+   @test isa(h, Generic.Res)
+
+   k = T(1)
+
+   @test isa(k, Generic.Res)
+
    S = Generic.ResidueRing(B, 164538890)
    x = R(1)
    y = S(1)
@@ -97,6 +119,16 @@ end
    @test deepcopy(h) == h
 
    @test characteristic(R) == 16453889
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test isone(one(T))
+   @test iszero(zero(T))
+   @test isunit(T(x))
+   @test canonical_unit(T(x)) == T(x)
+   @test modulus(T) == x^2 + 1
 end
 
 @testset "Generic.Res.unary_ops" begin
@@ -108,6 +140,12 @@ end
    T = ResidueRing(S, x^3 + 3x + 1)
 
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test -T(x + 1) == T(-x - 1)
 end
 
 @testset "Generic.Res.binary_ops" begin
@@ -134,6 +172,19 @@ end
    @test n - p == T(5x^2 + 3)
 
    @test n*p == T(3x^2 + 4x + 4)
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   n = T(x^5 + 1)
+   p = T(x^2 + 2x + 1)
+
+   @test n + p == T(3x + 1)
+
+   @test n - p == T(-x + 1)
+
+   @test n*p == T(2x - 2)
 end
 
 @testset "Generic.Res.gcd" begin
@@ -152,6 +203,16 @@ end
    p = T(x^2 + 2x + 1)
 
    @test gcd(n, p) == 1
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 2x + 1)
+   
+   @test gcd(T(x + 1), T(x + 1)) == T(x + 1)
+
+   T = ResidueRing(S, x^2 + 1)
+
+   @test gcd(T(x + 1), T(x + 1)) == T(1)
 end
 
 @testset "Generic.Res.adhoc_binary" begin
@@ -175,6 +236,18 @@ end
    @test 4 - f == T(x^2+5*x)
 
    @test f*5 == T(2*x^2+3*x+6)
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 2x + 1)
+
+   f = T(x + 1)
+
+   @test f + 4 == T(x + 5)
+
+   @test 4 - f == T(-x + 3)
+
+   @test f*5 == T(5x + 5)
 end
 
 @testset "Generic.Res.comparison" begin
@@ -201,6 +274,13 @@ end
    @test h != g
 
    @test isequal(f, g)
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test T(x + 1) == T(x + 1)
+   @test isequal(T(x + 2), T(x + 2))
 end
 
 @testset "Generic.Res.adhoc_comparison" begin
@@ -217,6 +297,13 @@ end
    f = T(x^5 + 1)
 
    @test f != 5
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test T(2) == 2
+   @test T(x) != 2
 end
 
 @testset "Generic.Res.powering" begin
@@ -232,6 +319,15 @@ end
    f = T(x^5 + 1)
 
    @test f^100 == T(x^2 + 2x + 1)
+
+   # Poly modulus, invertible lc
+   S, x = PolynomialRing(ZZ, "x")
+   T = ResidueRing(S, x^2 + 1)
+
+   @test T(x + 1)^0 == T(1)
+   @test T(x + 1)^1 == T(x + 1)
+   @test T(x + 1)^2 == T(2x)
+   @test T(x + 1)^3 == T(2x - 2)
 end
 
 @testset "Generic.Res.inversion" begin


### PR DESCRIPTION
Fixes #629 

This could be controversial. Let me know if you want this. If so, I'll also add mod, rem, div, divrem, mulmod and powmod for Flint poly rings in Nemo so that this works with Nemo.

I've made this work simply by lifting the restriction to a field as the coefficient ring of mod, rem, divrem, div, mulmod and powmod for univariate polynomials. I didn't lift the restriction for invmod, gcdinv, gcdx, as this of course leads to incorrect results as it is not a Euclidean domain. This also means divexact is not available for residue rings of polynomial rings when not over a field (I'm not sure what it could actually do generically if I did implement that). This is the case even though divexact is part of our ring interface. (I could have it raise a not implemented error, but Julia will just as quickly tell you this.)

See what everyone thinks. If we decide we don't like this, we don't have to merge it.

I left the restriction to a field as coefficient ring in docstrings for the poly functions above so that people don't get too excited. Technically I could factor each of the functions out and have them check the leading coefficient is invertible whenever working over a ring, but I already only allow modulus with invertible leading coeff in the residue ring constructor, so it's not likely to cause too much of a problem and the code is cleaner. As far as I can tell the code won't return wrong answers in other cases. It will just raise an exception of some kind or another (e.g. inv not available over the coefficient ring).

