### PR TITLE
Allow use of reverse(PolyCoeffs) and take(reverse(PolyCoeffs)) and make use of this in polynomial_to_power_sums.

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -361,6 +361,16 @@ function Base.iterate(PC::PolyCoeffs{<:PolyElem}, st::Int = -1)
        return coeff(PC.f, st), st
    end
 end
+
+function Base.iterate(PCR::Iterators.Reverse{<:PolyCoeffs{<:PolyElem}},
+                                                   st::Int = degree(PCR.itr.f) + 1)
+   st -= 1
+   if st < 0
+      return nothing
+   else
+      return coeff(PCR.itr.f, st), st
+   end
+end
  
 Base.IteratorEltype(M::PolyElem) = Base.HasEltype()
 
@@ -368,6 +378,12 @@ Base.eltype(M::PolyElem{T}) where {T} = T
 
 Base.eltype(M::PolyCoeffs) = Base.eltype(M.f)
  
+Base.eltype(M::Iterators.Reverse{<:PolyCoeffs}) = Base.eltype(M.itr.f)
+
+Base.eltype(M::Iterators.Take{<:PolyCoeffs}) = Base.eltype(M.xs.f)
+
+Base.eltype(M::Iterators.Take{<:Iterators.Reverse{<:PolyCoeffs}}) = Base.eltype(M.xs.itr.f)
+
 Base.IteratorSize(M::PolyCoeffs{<:PolyElem}) = Base.HasLength()
 
 Base.length(M::PolyCoeffs{<:PolyElem}) = length(M.f)
@@ -378,6 +394,10 @@ end
  
 function Base.getindex(a::PolyCoeffs{<:PolyElem}, i::Int)
    return coeff(a.f, i)
+end
+
+function Base.getindex(a::Iterators.Reverse{<:PolyCoeffs{<:PolyElem}}, i::Int)
+   return coeff(a.itr.f, degree(a.itr.f) - i)
 end
 
 ###############################################################################

--- a/src/generic/Misc/Poly.jl
+++ b/src/generic/Misc/Poly.jl
@@ -30,10 +30,10 @@ function polynomial_to_power_sums(f::PolyElem{T}, n::Int=degree(f)) where T <: F
     d = degree(f)
     R = base_ring(f)
     # Beware: converting to power series and derivative do not commute
-    dfc = collect(Base.Iterators.take(reverse!(collect(coefficients(derivative(f)))), n + 1))
+    dfc = collect(Iterators.take(Iterators.reverse(coefficients(derivative(f))), n + 1))
     A = abs_series(R, dfc, length(dfc), n + 1; cached=false)
     S = parent(A)
-    fc = collect(Base.Iterators.take(reverse!(collect(coefficients(f))), n + 1))
+    fc = collect(Iterators.take(Iterators.reverse(coefficients(f)), n + 1))
     B = S(fc, length(fc), n + 1)
     L = A*inv(B)
     s = T[coeff(L, i) for i = 1:n]


### PR DESCRIPTION
Fixes #886 

This was barely worth doing. It gets rid of the extra allocations due to collect (though there may still be an allocation for Take and Reverse, I'm not sure), but it's clear that supporting Julia iterators in general is not worth it. They are just not a useful construct in the language due to the lack of multiple inheritance and due to iterators themselves being very, very limited.