### PR TITLE
Make Generic.Poly similar and zero steal parents if appropriate.

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -299,7 +299,7 @@ function similar(x::PolyElem, R::Ring, s::Symbol=var(parent(x)); cached::Bool=tr
    V = Vector{TT}(undef, 0)
    p = Generic.Poly{TT}(V)
    # Default similar is supposed to return a polynomial
-   if base_ring(x) == R && s == var(parent(x)) && typeof(x) == Generic.Poly{TT}
+   if base_ring(x) === R && s == var(parent(x)) && typeof(x) == Generic.Poly{TT}
       # steal parent in case it is not cached
       p.parent = parent(x)
    else

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -299,7 +299,7 @@ function similar(x::PolyElem, R::Ring, s::Symbol=var(parent(x)); cached::Bool=tr
    V = Vector{TT}(undef, 0)
    p = Generic.Poly{TT}(V)
    # Default similar is supposed to return a polynomial
-   if base_ring(x) === R && s == var(parent(x)) && typeof(x) == Generic.Poly{TT}
+   if base_ring(x) === R && s == var(parent(x)) && typeof(x) === Generic.Poly{TT}
       # steal parent in case it is not cached
       p.parent = parent(x)
    else

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -294,12 +294,17 @@ end
 #
 ###############################################################################
 
-function similar(x::PolyElem, R::Ring, var::Symbol=var(parent(x)); cached::Bool=true)
+function similar(x::PolyElem, R::Ring, s::Symbol=var(parent(x)); cached::Bool=true)
    TT = elem_type(R)
    V = Vector{TT}(undef, 0)
    p = Generic.Poly{TT}(V)
    # Default similar is supposed to return a polynomial
-   p.parent = Generic.PolyRing{TT}(R, var, cached)
+   if base_ring(x) == R && s == var(parent(x)) && typeof(x) == Generic.Poly{TT}
+      # steal parent in case it is not cached
+      p.parent = parent(x)
+   else
+      p.parent = Generic.PolyRing{TT}(R, s, cached)
+   end
    p = set_length!(p, 0)
    return p
 end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -192,7 +192,7 @@ end
       s = similar(f)
       t = similar(f)
 
-      @test parent(p) != parent(f)
+      @test parent(p) == parent(f)
       @test parent(q) != parent(r)
       @test parent(s) == parent(t)
    end
@@ -264,7 +264,7 @@ end
    s = zero(f)
    t = zero(f)
 
-   @test parent(p) != parent(f)
+   @test parent(p) == parent(f)
    @test parent(q) != parent(r)
    @test parent(s) == parent(t)
 end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -173,7 +173,7 @@ end
       @test isa(h, PolyElem)
       @test isa(k, PolyElem)
 
-      @test base_ring(g) == QQ
+      @test base_ring(g) === QQ
 
       @test parent(g).S == :y
       @test parent(h).S == :y
@@ -182,9 +182,9 @@ end
       @test length(h) == 0
       @test length(k) == 0
 
-      @test parent(g) != parent(f)
-      @test parent(h) != parent(f)
-      @test parent(k) == parent(f)
+      @test parent(g) !== parent(f)
+      @test parent(h) !== parent(f)
+      @test parent(k) === parent(f)
 
       p = similar(f, cached=false)
       q = similar(f, "z", cached=false)
@@ -192,9 +192,9 @@ end
       s = similar(f)
       t = similar(f)
 
-      @test parent(p) == parent(f)
-      @test parent(q) != parent(r)
-      @test parent(s) == parent(t)
+      @test parent(p) === parent(f)
+      @test parent(q) !== parent(r)
+      @test parent(s) === parent(t)
    end
 end
 
@@ -202,7 +202,7 @@ end
    f = polynomial(ZZ, [1, 2, 3], "y")
 
    @test isa(f, PolyElem)
-   @test base_ring(f) == ZZ
+   @test base_ring(f) === ZZ
    @test coeff(f, 0) == 1
    @test coeff(f, 2) == 3
    @test parent(f).S == :y
@@ -210,7 +210,7 @@ end
    g = polynomial(ZZ, [1, 2, 3])
 
    @test isa(g, PolyElem)
-   @test base_ring(g) == ZZ
+   @test base_ring(g) === ZZ
    @test coeff(g, 0) == 1
    @test coeff(g, 2) == 3
    @test parent(g).S == :x
@@ -219,8 +219,8 @@ end
    k = polynomial(ZZ, [1, 2, 3], cached=false)
    m = polynomial(ZZ, [1, 2, 3], cached=false)
 
-   @test parent(h) == parent(g)
-   @test parent(k) != parent(m)
+   @test parent(h) === parent(g)
+   @test parent(k) !== parent(m)
 
    p = polynomial(ZZ, BigInt[])
    q = polynomial(ZZ, [])
@@ -249,14 +249,14 @@ end
    @test length(h) == 0
    @test length(k) == 0
 
-   @test base_ring(g) == QQ
+   @test base_ring(g) === QQ
 
    @test parent(g).S == :y
    @test parent(h).S == :y
 
-   @test parent(g) != parent(f)
-   @test parent(h) != parent(f)
-   @test parent(k) == parent(f)
+   @test parent(g) !== parent(f)
+   @test parent(h) !== parent(f)
+   @test parent(k) === parent(f)
 
    p = zero(f, cached=false)
    q = zero(f, "z", cached=false)
@@ -264,9 +264,9 @@ end
    s = zero(f)
    t = zero(f)
 
-   @test parent(p) == parent(f)
-   @test parent(q) != parent(r)
-   @test parent(s) == parent(t)
+   @test parent(p) === parent(f)
+   @test parent(q) !== parent(r)
+   @test parent(s) === parent(t)
 end
 
 @testset "Generic.Poly.manipulation" begin


### PR DESCRIPTION
Fixes #897 

Note that there is a corresponding Nemo fix required for this to pass.

This is the most conservative fix I can come up with which fixes 897 and does what we all agree on.

If this is accepted I will do the same thing for power series.

The system is still inconsistent, but we all agree the current functionality is not useful. The principle here is:

* If the polynomial being created would have lived in the exact same (AbstractAlgebra/Nemo) ring (if parents had been cached), then "zero" and "similar" steal the parent from the original polynomial rather than create a new one.

At least this fix is not inconsistent with matrices, given that parents are not stored in the objects anyway. We probably should use @rfourquet's parent comparison idea there instead.

I should point out that I actually don't see a way to have zero and similar return a polynomial with exactly the same parent as the one that is being copied in all cases. Yes, one could steal or deepcopy and modify the parent in other cases too, but then there is no way to know if the stolen parent actually matches the polynomial we are creating, as one has no idea how that original polynomial was constructed.

It's worse for power series, since one might want exactly the same kind of parent, just with a different max_precision or something like that. This problem already occurs for polynomials if you change the variable (not that either of these cases would have been compatible with the original polynomial in the first place).

The only thing you can guarantee is that if the original polynomial was created with an optimal parent for the current package, the new one will have the same parent if it is meant to be compatible with the original.

I believe the current code does at least do that.