### PR TITLE
Make 0^0=1

### DIFF
--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -209,12 +209,12 @@ function ^(a::NCPolyElem{T}, b::Int) where T <: NCRingElem
       end
       z = set_length!(z, b + 1)
       return z
+   elseif b == 0
+      return one(R)
    elseif length(a) == 0
       return zero(R)
    elseif length(a) == 1
       return R(coeff(a, 0)^b)
-   elseif b == 0
-      return one(R)
    elseif b == 1
       return deepcopy(a)
    else

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1292,12 +1292,12 @@ Return $a^b \pmod{d}$. There are no restrictions on $b$.
 """
 function powermod(a::PolyElem{T}, b::Int, d::PolyElem{T}) where T <: RingElement
    check_parent(a, d)
-   if length(a) == 0
+   if b == 0
+      z = one(parent(a))
+   elseif length(a) == 0
       z = zero(parent(a))
    elseif length(a) == 1
       z = parent(a)(coeff(a, 0)^b)
-   elseif b == 0
-      z = one(parent(a))
    else
       if b < 0
          a = invmod(a, d)

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -407,7 +407,9 @@ end
 
 function isequal(x::AbsMSeries{T}, y::AbsMSeries{T}) where T <: RingElement
     check_parent(x, y)
-    return precision(x) == precision(y) && poly(x) == poly(y)
+    prec = precision(x)
+    prec == precision(y) || return false
+    return truncate_poly(poly(x), prec) == truncate_poly(poly(y), prec)
 end
 
 ###############################################################################

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -206,6 +206,7 @@ function ^(x::GFElem{T}, y::Integer) where T <: Integer
    R = parent(x)
    p = R.p::T
    if x.d == 0
+      y == 0 && return one(R)
       return deepcopy(x)
    end
    if y < 0

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -207,6 +207,7 @@ function ^(x::GFElem{T}, y::Integer) where T <: Integer
    p = R.p::T
    if x.d == 0
       y == 0 && return one(R)
+      y < 0 && throw(DivideError())
       return deepcopy(x)
    end
    if y < 0

--- a/test/generic/AbsMSeries-test.jl
+++ b/test/generic/AbsMSeries-test.jl
@@ -230,7 +230,7 @@ end
          for expn = 0:10
             r1 = f^expn
 
-            @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+            @test isequal(r1, r2)
 
             r2 *= f
          end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -565,7 +565,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end
@@ -581,7 +581,7 @@ end
       for expn = 0:4 # cannot set high power here
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isapprox(r1, r2)
+         @test isapprox(r1, r2)
 
          r2 *= f
       end
@@ -600,7 +600,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end

--- a/test/generic/FunctionField-test.jl
+++ b/test/generic/FunctionField-test.jl
@@ -513,7 +513,7 @@ end
          for expn = 0:2
             r1 = f^expn
 
-            @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+            @test r1 == r2
 
             r2 *= f
          end
@@ -528,7 +528,7 @@ end
          for expn = 0:5
             r1 = f^expn
 
-            @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+            @test r1 == r2
 
             r2 *= f
          end

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -550,7 +550,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end
@@ -566,7 +566,7 @@ end
       for expn = 0:4 # cannot set high power here
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isapprox(r1, r2)
+         @test isapprox(r1, r2)
 
          r2 *= f
       end
@@ -585,7 +585,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -553,7 +553,7 @@ end
             r *= f
          end
 
-         @test (f == 0 && expn == 0 && f^expn == 0) || f^expn == r
+         @test f^expn == r
       end
 
       @test_throws DomainError rand(varlist)^-1

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -298,7 +298,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+         @test r1 == r2
 
          r2 *= f
       end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -1019,7 +1019,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+         @test r1 == r2
 
          r2 *= f
       end
@@ -1044,7 +1044,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+         @test r1 == r2
 
          r2 *= f
       end
@@ -1066,7 +1066,7 @@ end
       for expn = 0:4 # cannot set high power here
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isapprox(r1, r2)
+         @test isapprox(r1, r2)
 
          r2 *= f
       end
@@ -1091,7 +1091,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || r1 == r2
+         @test r1 == r2
 
          r2 *= f
       end
@@ -1138,7 +1138,7 @@ if false
          for expn = 0:5
             r = powermod(f, expn, g)
 
-            @test (f == 0 && expn == 0 && r == 0) || r == p
+            @test r == p
 
             p = mulmod(p, f, g)
          end
@@ -1178,7 +1178,7 @@ if false
          for expn = 0:5
             r = powermod(f, expn, g)
 
-            @test (f == 0 && expn == 0 && r == 0) || r == p
+            @test r == p
 
             p = mulmod(p, f, g)
          end
@@ -1215,7 +1215,7 @@ if false
          for expn = 0:5
             r = powermod(f, expn, g)
 
-            @test (f == 0 && expn == 0 && r == 0) || isapprox(r, p)
+            @test isapprox(r, p)
 
             p = mulmod(p, f, g)
          end
@@ -1253,7 +1253,7 @@ if false
          for expn = 0:5
             r = powermod(f, expn, g)
 
-            @test (f == 0 && expn == 0 && r == 0) || r == p
+            @test r == p
 
             p = mulmod(p, f, g)
          end

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -512,7 +512,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end
@@ -528,7 +528,7 @@ end
       for expn = 0:4 # cannot set high power here
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isapprox(r1, r2)
+         @test isapprox(r1, r2)
 
          r2 *= f
       end
@@ -547,7 +547,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -567,7 +567,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end
@@ -587,7 +587,7 @@ end
       for expn = 0:4 # cannot set high power here
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isapprox(r1, r2)
+         @test isapprox(r1, r2)
 
          r2 *= f
       end
@@ -610,7 +610,7 @@ end
       for expn = 0:10
          r1 = f^expn
 
-         @test (f == 0 && expn == 0 && r1 == 0) || isequal(r1, r2)
+         @test isequal(r1, r2)
 
          r2 *= f
       end

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -201,8 +201,8 @@ end
       s = rand(S)
 
       for n = 0:20
-         @test r == 0 || a == r^n
-         @test s == 0 || b == s^n
+         @test a == r^n
+         @test b == s^n
 
          a *= r
          b *= s
@@ -220,8 +220,8 @@ end
       sinv = s == 0 ? S(0) : inv(s)
 
       for n = 0:20
-         @test r == 0 || a == r^(-n)
-         @test s == 0 || b == s^(-n)
+         @test a == r^(-n)
+         @test b == s^(-n)
 
          a *= rinv
          b *= sinv

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -209,7 +209,11 @@ end
       end
    end
 
+   @test_throws DivideError R(0)^(-1)
+   @test_throws DivideError S(0)^(-1)
+
    for iter = 1:100
+
       a = R(1)
       b = S(1)
 
@@ -220,8 +224,8 @@ end
       sinv = s == 0 ? S(0) : inv(s)
 
       for n = 0:20
-         @test a == r^(-n)
-         @test b == s^(-n)
+         @test r == 0 || a == r^(-n)
+         @test s == 0 || b == s^(-n)
 
          a *= rinv
          b *= sinv


### PR DESCRIPTION
I think the convention in julia is to treat 0^0 as 1, which is not the case for the following
```julia
julia> GF(3)()^0
0

julia> PolynomialRing(MatrixAlgebra(QQ, 2), "y")[1]()^0
0

julia> R, x = QQ["x"]; ResidueField(R, x^2+1)()^0
0
```
This PR fixes these cases, and also removes all the senseless checks in the test files.

(For `AbsMSeries`, the `isequal` function checks using `poly(x) == poly(y)`, which might not be truncated to the given precision and will cause the tests to fail.)