### PR TITLE
Remove outdated versioninfo()

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -355,32 +355,6 @@ const MatrixElem{T} = Union{MatElem{T}, MatAlgElem{T}}
 
 ###############################################################################
 #
-#  Version information
-#
-################################################################################
-
-function versioninfo()
-  print("AbstractAlgebra version 0.3.0\n")
-  abstractalgebrarepo = dirname(dirname(@__FILE__))
-
-  print("AbstractAlgebra: ")
-  prepo = Base.LibGit2.GitRepo(abstractalgebrarepo)
-  Base.LibGit2.with(LibGit2.head(prepo)) do phead
-    print("commit: ")
-    print(string(LibGit2.Oid(phead))[1:8])
-    print(" date: ")
-    commit = Base.LibGit2.get(Base.LibGit2.GitCommit, prepo, LibGit2.Oid(phead))
-    print(Base.Dates.unix2datetime(Base.LibGit2.author(commit).time))
-    print(")\n")
-  end
-
-  finalize(prepo)
-
-  return nothing
-end
-
-###############################################################################
-#
 #   Julia types
 #
 ###############################################################################


### PR DESCRIPTION
Alternatively, one try to fix it; to get the package version, one could adapt this code from Oscar.jl:
```
# pkgdir was added in Julia 1.4
if VERSION < v"1.4"
   pkgdir(m::Core.Module) = abspath(Base.pathof(Base.moduleroot(m)), "..", "..")
end
pkgproject(m::Core.Module) = Pkg.Operations.read_project(Pkg.Types.projectfile_path(pkgdir(m)))
pkgversion(m::Core.Module) = pkgproject(m).version
const VERSION_NUMBER = pkgversion(@__MODULE__)
```
But then it'll still die because fail with `UndefVarError: LibGit2 not defined`, but of course that, too, could be fixed.

CC @thofma