### PR TITLE
Improve find_name

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -238,15 +238,10 @@ macro show_name(io, O)
 end
 
 function find_name(A, M = Main)
-  for a = names(Main)
+  for a = names(M)
     a === :ans && continue
-    d = Meta.parse("$M.$a")
-    try
-      z = eval(d);
-      if z === A
+    if isdefined(M, a) && getfield(M, a) === A
         return a
-      end
-    catch e
     end
   end
 end


### PR DESCRIPTION
First, actually honor the argument `M` instead of hardcoding `Main`.

Next, avoid `Meta.parse` and exception handling. Before this PR:

    julia> @time AbstractAlgebra.find_name(R)
      0.000165 seconds (44 allocations: 2.031 KiB)

Afterwards:

    julia> @time AbstractAlgebra.find_name(R)
      0.000011 seconds (4 allocations: 288 bytes)
