### PR TITLE
Update doc links, add link to stable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AbstractAlgebra
 
-[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://nemocas.github.io/AbstractAlgebra.jl/latest)
+[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://nemocas.github.io/AbstractAlgebra.jl/dev)
+[![Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://nemocas.github.io/AbstractAlgebra.jl/stable)
 [![Build status](https://ci.appveyor.com/api/projects/status/1w9ninmoidxkxshp/branch/master?svg=true)](https://ci.appveyor.com/project/thofma/abstractalgebra-jl/branch/master)
 [![Build Status](https://github.com/Nemocas/AbstractAlgebra.jl/workflows/Run%20tests/badge.svg)](https://github.com/Nemocas/AbstractAlgebra.jl/actions?query=workflow%3A%22Run%20tests%22+branch%3Amaster)
 [![Codecov](https://codecov.io/github/Nemocas/AbstractAlgebra.jl/coverage.svg?branch=master&token=)](https://codecov.io/gh/Nemocas/AbstractAlgebra.jl)
@@ -17,11 +18,10 @@ AbstractAlgebra currently provides:
 
 Documentation can be found at the following link:
 
-* <https://nemocas.github.io/AbstractAlgebra.jl/latest/index.html>
+* <https://nemocas.github.io/AbstractAlgebra.jl/dev/index.html>
 
 Projects that depend on AbstractAlgebra include:
 
 * Nemo.jl <https://nemocas.org/> (optimised implementations of specific rings provided by the Flint, Arb and Antic C libraries)
 * Hecke.jl <https://github.com/thofma/Hecke.jl> (algebraic number theory)
 * Singular.jl <https://github.com/oscar-system/Singular.jl> (polynomial rings and ideals, Groebner bases and computer algebra provided by the Singular C++ library)
-

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -40,7 +40,7 @@ Generic.partitions
 You may also have a look at [JuLie.jl](https://github.com/ulthiel/JuLie.jl) package for more utilities related to partitions.
 
 The number of all partitions can be computed by the hidden function `_numpart`.
-Much faster implementation is available in [Nemo.jl](https://nemocas.github.io/Nemo.jl/latest/arb.html#Nemo.numpart-Tuple{Int64,ArbField}).
+Much faster implementation is available in [Nemo.jl](https://nemocas.github.io/Nemo.jl/dev/arb.html#Nemo.numpart-Tuple{Int64,ArbField}).
 
 ```@docs
 Generic._numpart


### PR DESCRIPTION
In doc URLs, `latest` changed to `dev` some time ago.
