### PR TITLE
Remove wrong ad hoc methods

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -27,6 +27,16 @@ end
 
 promote_rule(::Type{T}, ::Type{T}) where T <: RingElement = T
 
+function promote_rule_sym(::Type{T}, ::Type{S}) where {T, S}
+   U = promote_rule(T, S)
+   if U !== Union{}
+      return U
+   else
+      UU = promote_rule(S, T)
+      return UU
+   end
+end
+
 ###############################################################################
 #
 #   Generic catchall functions
@@ -34,10 +44,13 @@ promote_rule(::Type{T}, ::Type{T}) where T <: RingElement = T
 ###############################################################################
 
 function +(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   if S == promote_rule(S, T)
+   U = promote_rule_sym(S, T)
+   if S === U
       +(x, parent(x)(y))
-   else
+   elseif T === U
       +(parent(y)(x), y)
+   else
+      error("Cannot promote to common type")
    end
 end
 
@@ -46,10 +59,13 @@ end
 +(x::RingElement, y::RingElem) = parent(y)(x) + y
 
 function -(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   if S == promote_rule(S, T)
+   U = promote_rule_sym(S, T)
+   if S === U
       -(x, parent(x)(y))
-   else
+   elseif T === U
       -(parent(y)(x), y)
+   else
+      error("Cannot promote to common type")
    end
 end
 
@@ -58,10 +74,13 @@ end
 -(x::RingElement, y::RingElem) = parent(y)(x) - y
 
 function *(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   if S == promote_rule(S, T)
+   U = promote_rule_sym(S, T)
+   if S === U
       *(x, parent(x)(y))
-   else
+   elseif T === U
       *(parent(y)(x), y)
+   else
+      error("Cannot promote to common type")
    end
 end
 
@@ -81,10 +100,13 @@ If no exact division is possible, an exception is raised.
 function divexact end
 
 function divexact(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   if S == promote_rule(S, T)
+   U = promote_rule_sym(S, T)
+   if S === U
       divexact(x, parent(x)(y))
-   else
+   elseif T === U
       divexact(parent(y)(x), y)
+   else
+      error("Cannot promote to common type")
    end
 end
 
@@ -107,10 +129,10 @@ function divides(x::T, y::T) where {T <: RingElem}
 end
 
 function ==(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   R = promote_rule(S, T)
-   if S == R
+   U = promote_rule_sym(S, T)
+   if S === U
       ==(x, parent(x)(y))
-   elseif T == R
+   elseif T === U
       ==(parent(y)(x), y)
    else
       false

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -855,10 +855,6 @@ end
 
 *(a::Rat{T}, b::FunctionFieldElem{T}) where T <: FieldElement = b*a
 
-*(a::FunctionFieldElem, b::RingElem) = a*base_ring(a)(b)
-
-*(a::RingElem, b::FunctionFieldElem) = b*a
-
 function +(a::FunctionFieldElem{T}, b::Rat{T}) where T <: FieldElement
    parent(b) != base_ring(a) && error("Unable to coerce element")
    return a + parent(a)(b)
@@ -869,10 +865,6 @@ end
 +(a::FunctionFieldElem, b::Union{Integer, Rational}) = a + base_ring(a)(b)
 
 +(a::Union{Integer, Rational}, b::FunctionFieldElem) = b + a
-
-+(a::FunctionFieldElem, b::RingElem) = a + base_ring(a)(b)
-
-+(a::RingElem, b::FunctionFieldElem) = b + a
 
 function -(a::FunctionFieldElem{T}, b::Rat{T}) where T <: FieldElement
    parent(b) != base_ring(a) && error("Unable to coerce element")
@@ -887,10 +879,6 @@ end
 -(a::FunctionFieldElem, b::Union{Integer, Rational}) = a - base_ring(a)(b)
 
 -(a::Union{Integer, Rational}, b::FunctionFieldElem) = base_ring(b)(a) - b
-
--(a::FunctionFieldElem, b::RingElem) = a - base_ring(a)(b)
-
--(a::RingElem, b::FunctionFieldElem) = base_ring(b)(a) - b
 
 ###############################################################################
 #
@@ -969,10 +957,6 @@ end
 ==(a::FunctionFieldElem, b::Union{Integer, Rational}) = a == base_ring(a)(b)
 
 ==(a::Union{Integer, Rational}, b::FunctionFieldElem) = b == a
-
-==(a::FunctionFieldElem, b::RingElem) = a == base_ring(a)(b)
-
-==(a::RingElem, b::FunctionFieldElem) = b == a
 
 ###############################################################################
 #
@@ -1240,8 +1224,10 @@ rand(K::FunctionField, v...) = rand(Random.GLOBAL_RNG, K, v...)
 
 promote_rule(::Type{FunctionFieldElem{T}}, ::Type{FunctionFieldElem{T}}) where T <: FieldElement = FunctionFieldElem{T}
 
-function promote_rule(::Type{FunctionFieldElem{T}}, ::Type{U}) where {T <: FieldElem, U <: RingElem}
-   promote_rule(T, U) == T ? FunctionFieldElem{T} : Union{}
+function promote_rule(::Type{FunctionFieldElem{T}}, ::Type{U}) where
+      {T <: FieldElement, U <: RingElem}
+   # The base ring element type of FunctionFieldElem{T} is Rat{T}, not T
+   promote_rule(Rat{T}, U) == Rat{T} ? FunctionFieldElem{T} : Union{}
 end
 
 ###############################################################################

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -846,7 +846,7 @@ end
 
 const FunctionFieldDict = CacheDictType{Tuple{Poly, PolyElem, Symbol}, Field}()
 
-mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.Field
+mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
    num::Poly{<:PolyElem{T}}
    den::PolyElem{T}
    parent::FunctionField{T}

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -321,11 +321,9 @@ rand(S::LaurentPolyWrapRing, degrees_range, v...) =
 
 promote_rule(::Type{L}, ::Type{L}) where {L <: LaurentPolyWrap} = L
 
-function promote_rule(::Type{L}, ::Type{U}) where
-       {T<:RingElement, L <: LaurentPolyWrap{T}, U <: RingElement}
-   promote_rule(T, U) == T ? L : Union{}
+function promote_rule(::Type{LaurentPolyWrap{S, T}}, ::Type{U}) where {S, T, U}
+   promote_rule(T, U) == T ? LaurentPolyWrap{S, T} : Union{}
 end
-
 
 ################################################################################
 #

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -217,8 +217,6 @@ function promote_rule(::Type{Poly{T}}, ::Type{U}) where {T <: RingElement, U <: 
    promote_rule(T, U) == T ? Poly{T} : Union{}
 end
 
-
-
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -499,10 +499,11 @@ rand(S::RationalFunctionField, v...) = rand(GLOBAL_RNG, S, v...)
 ###############################################################################
 
 promote_rule(::Type{Rat{T}}, ::Type{Rat{T}}) where T <: FieldElement = Rat{T}
+
 promote_rule(::Type{Rat{T}}, ::Type{Rat{T}}) where T <: FieldElem = Rat{T}
 
 function promote_rule(::Type{Rat{T}}, ::Type{U}) where {T <: FieldElement, U <: RingElem}
-   promote_rule(T, U) == T ? Rat{T} : Union{}
+   promote_rule(Frac{dense_poly_type(T)}, U) === Frac{dense_poly_type(T)} ? Rat{T} : Union{}
 end
 
 ###############################################################################

--- a/test/generic/FunctionField-test.jl
+++ b/test/generic/FunctionField-test.jl
@@ -25,6 +25,7 @@ P2 = [(x2 + 1)*z2 + (x2 + 2), z2 + (x2 + 1)//(x2 + 2), z2^2 + 3z2 + 1,
       @test typeof(S) <: Generic.FunctionField
 
       @test isa(y, Generic.FunctionFieldElem)
+      @test y isa FieldElem
 
       a = S()
 
@@ -839,3 +840,19 @@ end
       end
    end  
 end      
+
+@testset "Generic.FunctionField.polynomial_ring" begin
+   for i = 1:length(P1)
+      S, y = FunctionField(P1[i], "y")
+
+      St, t = PolynomialRing(S, "t", cached = false)
+      @test t + y == y + t
+      @test t * y == y * t
+      @test t + 1 == 1 + t
+      @test t * 1 == 1 * t
+      @test t + BigInt(1) == BigInt(1) + t
+      @test t * BigInt(1) == BigInt(1) * t
+      @test t + one(R1) == one(R1) + t
+      @test t * one(R1) == one(R1) * t
+   end
+end

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -195,7 +195,10 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
       f = LaurentPolyWrap(x^3 + 2x^2 - 1)
       @test f == f
       @test f == LaurentPolyWrap(x^3 + 2x^2 - 1)
+      @test f == x^3 + 2x^2 - 1
+      @test x^3 + 2x^2 - 1 == f
       @test f != x
+      @test x != f
       @test f != LaurentPolyWrap(x^3 + 2x^2 - 1, -2)
    end
 

--- a/test/generic/RationalFunctionField-test.jl
+++ b/test/generic/RationalFunctionField-test.jl
@@ -111,6 +111,9 @@ end
    @test b*(x + 1) == (-x-1)//(x-1)
 
    @test (x + 1)*b == (-x-1)//(x-1)
+
+   @test denominator(a) * a == a * denominator(a)
+   @test denominator(a) + a == a + denominator(a)
 end
 
 @testset "Generic.RationalFunctionField.comparison" begin


### PR DESCRIPTION
Before
```julia
julia> using Revise, AbstractAlgebra                                                                                                                

julia> Qt, t = RationalFunctionField(QQ, "t");

julia> Qtx, x = PolynomialRing(Qt, "x");

julia> F, a = FunctionField(x^6+27*t^2+108*t+108, "a");

julia> FT, T = PolynomialRing(F, "T");

julia> T + a
ERROR: MethodError: no method matching Rational{BigInt}(::AbstractAlgebra.Generic.Poly{AbstractAlgebra.Generic.FunctionFieldElem{Rational{BigInt}}})
Closest candidates are:
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number at twiceprecision.jl:243
  (::Type{T})(::Complex) where T<:Real at complex.jl:37
```

The problem is that the method `+(a::FunctionFieldElem, b::RingElem) = a + base_ring(a)(b)` gets called, which is the wrong one. We already have the promote rules in place, so by removing these ad hoc methods we fall back to the right method.

CC: @fieker 