### PR TITLE
Improve combinations

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1937,7 +1937,7 @@ function combinations(v::AbstractVector{T}, k::Int) where T
 end
 function _combinations_dfs!(ans::Vector{Vector{T}}, comb::Vector{T}, v::AbstractVector{T}, n::Int, k::Int) where T
    k < 1 && (pushfirst!(ans, comb[:]); return)
-   for m in n:-1:1
+   for m in n:-1:k
       comb[k] = v[m]
       _combinations_dfs!(ans, comb, v, m - 1, k - 1)
    end

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1923,7 +1923,7 @@ end
 Return an array consisting of k-combinations of {1,...,n} (or a given vector v)
 as arrays.
 """
-function combinations(n::Int, k::Int) combinations(1:n, k) end
+combinations(n::Int, k::Int) = combinations(1:n, k)
 function combinations(v::AbstractVector{T}, k::Int) where T
    n = length(v)
    ans = Vector{T}[]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1917,21 +1917,22 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    combinations(n::Int,k::Int)
+    combinations(n::Int, k::Int)
 
 Return an array consisting of k-combinations of {1,...,n} as arrays.
 """
-function combinations(n, k)
-   if (k == 0)
-      r = Array{Array{Int, 1}, 1}(undef, 1)
-      r[1] = []
-      return r
-   elseif k > n
-      return Array{Array{Int, 1 }, 1}(undef, 0)
-   elseif k == n
-      return [collect(1:k)]
-   else
-      return vcat(combinations(n - 1, k), [append!(l, [n]) for l in combinations(n - 1, k - 1)])
+function combinations(n::Int, k::Int)
+   ans = Vector{Int}[]
+   k > n && return ans
+   _combinations_dfs!(ans, Vector{Int}(undef, k), n, k)
+   return ans
+end
+
+function _combinations_dfs!(ans::Vector{Vector{Int}}, comb::Vector{Int}, n::Int, k::Int)
+   k < 1 && (pushfirst!(ans, comb[:]); return)
+   for m in n:-1:1
+      comb[k] = m
+      _combinations_dfs!(ans, comb, m - 1, k - 1)
    end
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1918,12 +1918,16 @@ end
 
 @doc Markdown.doc"""
     combinations(n::Int, k::Int)
-    combinations(v::AbstractVector, k::Int)
 
-Return an array consisting of k-combinations of {1,...,n} (or a given vector v)
-as arrays.
+Return an array consisting of k-combinations of {1,...,n} as arrays.
 """
 combinations(n::Int, k::Int) = combinations(1:n, k)
+
+@doc Markdown.doc"""
+    combinations(v::AbstractVector, k::Int)
+
+Return an array consisting of k-combinations of a given vector v as arrays.
+"""
 function combinations(v::AbstractVector{T}, k::Int) where T
    n = length(v)
    ans = Vector{T}[]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1918,21 +1918,24 @@ end
 
 @doc Markdown.doc"""
     combinations(n::Int, k::Int)
+    combinations(v::AbstractVector, k::Int)
 
-Return an array consisting of k-combinations of {1,...,n} as arrays.
+Return an array consisting of k-combinations of {1,...,n} (or a given vector v)
+as arrays.
 """
-function combinations(n::Int, k::Int)
-   ans = Vector{Int}[]
+function combinations(n::Int, k::Int) combinations(1:n, k) end
+function combinations(v::AbstractVector{T}, k::Int) where T
+   n = length(v)
+   ans = Vector{T}[]
    k > n && return ans
-   _combinations_dfs!(ans, Vector{Int}(undef, k), n, k)
+   _combinations_dfs!(ans, Vector{T}(undef, k), v, n, k)
    return ans
 end
-
-function _combinations_dfs!(ans::Vector{Vector{Int}}, comb::Vector{Int}, n::Int, k::Int)
+function _combinations_dfs!(ans::Vector{Vector{T}}, comb::Vector{T}, v::AbstractVector{T}, n::Int, k::Int) where T
    k < 1 && (pushfirst!(ans, comb[:]); return)
    for m in n:-1:1
-      comb[k] = m
-      _combinations_dfs!(ans, comb, m - 1, k - 1)
+      comb[k] = v[m]
+      _combinations_dfs!(ans, comb, v, m - 1, k - 1)
    end
 end
 


### PR DESCRIPTION
The `combinations` function was very slow...
```julia
julia> @btime AbstractAlgebra.combinations(10, 3); # before
  32.587 μs (996 allocations: 92.59 KiB)

julia> @btime AbstractAlgebra.combinations(10, 3); # after
  5.971 μs (129 allocations: 15.47 KiB)

julia> @btime collect(Combinatorics.combinations(1:10, 3));
  5.783 μs (242 allocations: 18.05 KiB)
```
The output order of the combinations is same as before.
