### PR TITLE
fix some deepcopy_internals: they need to call

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -84,14 +84,14 @@ function deepcopy_internal(d::MatSpaceElem{T}, dict::IdDict) where T <: RingElem
    z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
-         z[i, j] = deepcopy(d[i, j])
+         z[i, j] = deepcopy_internal(d[i, j], dict)
       end
    end
    return z
 end
 
 function deepcopy_internal(d::MatSpaceView{T}, dict::IdDict) where T <: RingElement
-   return MatSpaceView(deepcopy(d.entries), d.base_ring)
+   return MatSpaceView(deepcopy_internal(d.entries, dict), d.base_ring)
 end
 
 ###############################################################################

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -109,9 +109,9 @@ isone(a::Rat) = isone(data(a))
 
 isunit(a::Rat) = isunit(data(a))
 
-function deepcopy_internal(a::Rat, dic::IdDict)
+function deepcopy_internal(a::Rat, dict::IdDict)
    R = parent(a)
-   return R(deepcopy(data(a)))
+   return R(deepcopy_internal(data(a), dict))
 end
 
 ###############################################################################


### PR DESCRIPTION
deepcopy_internal using the same dict in the recursion,
they really should not call deepcopy directly. It will break
identities...
So far, we used rarely deeply nested types in serious applications,
hence did not notice.