### PR TITLE
add conformance tests

### DIFF
--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -81,7 +81,7 @@ one(R::ResRing) = R(1)
 
 iszero(a::ResElem) = iszero(data(a))
 
-isone(a::ResElem) = isone(data(a))
+isone(a::ResElem) = isone(data(a)) || a == one(parent(a))
 
 function isunit(a::ResElem)
    g = gcd(data(a), modulus(a))

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -24,6 +24,8 @@ parent(a::MatAlgElem{T}, cached::Bool = true) where T <: RingElement =
 
 isexact_type(::Type{MatAlgElem{T}}) where T <: RingElement = isexact_type(T)
 
+isdomain_type(::Type{MatAlgElem{T}}) where T <: RingElement = false
+
 ###############################################################################
 #
 #   Transpose

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -216,7 +216,7 @@ function (a::Floats{T})(b::AbstractFloat) where T <: AbstractFloat
    return T(b)
 end
 
-function (a::Floats{T})(b::Union{Signed, Unsigned}) where T <: AbstractFloat
+function (a::Floats{T})(b::Integer) where T <: AbstractFloat
    return T(b)
 end
 

--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -1,4 +1,3 @@
-include("Rings-conformance-tests.jl")
 include("WeakValueDict-test.jl")
 include("Groups-test.jl")
 include("NCRings-test.jl")

--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -1,3 +1,4 @@
+include("Rings-conformance-tests.jl")
 include("WeakValueDict-test.jl")
 include("Groups-test.jl")
 include("NCRings-test.jl")

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -192,7 +192,7 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
             else
                try
                   t = divexact(b*a, b)
-                  @test equaltiy(t*b, a*b)
+                  @test equality(t*b, a*b)
                catch
                end
             end

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -441,27 +441,3 @@ function test_Field_interface_recursive(R::AbstractAlgebra.Field; reps = 50)
    test_Ring_interface_recursive(R, reps = reps)
    test_Field_interface(R, reps = reps)
 end
-
-####
-
-function test_elem(R::AbstractAlgebra.Integers{BigInt})
-   n = big(2)^rand(1:100)
-   return ZZ(rand((-n):n))
-end
-test_Ring_interface_recursive(ZZ)
-
-
-function test_elem(R::AbstractAlgebra.Rationals{BigInt})
-   n = big(2)^rand(1:100)
-   return QQ(rand((-n):n)//rand(1:n))
-end
-test_Field_interface_recursive(QQ)
-
-
-function test_elem(R::AbstractAlgebra.GFField)
-   return R(rand(0:characteristic(R)))
-end
-test_Field_interface_recursive(GF(3))
-test_Field_interface_recursive(GF(13))
-test_Field_interface_recursive(GF(big(13)))
-test_Field_interface_recursive(GF(big(10)^20 + 39))

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -1,0 +1,53 @@
+# TODO: instead of 'example_element' provide a function which allows sampling any number
+# of elements
+function test_Ring_interface(R::AbstractAlgebra.Ring, ExpectedElemType, ExpectedParentType, example_elements = [])
+   @testset "Ring interface for $(R) / $(ExpectedElemType) / $(ExpectedParentType)" begin
+      @test R isa ExpectedParentType
+      example_elements = R.(example_elements)
+
+      @testset "test ring conformance" begin
+         @test elem_type(R) == ExpectedElemType
+         @test elem_type(ExpectedParentType) == ExpectedElemType
+         @test elem_type(typeof(R)) == ExpectedElemType
+
+         @test iszero(zero(R))
+         @test isone(one(R))
+
+         @test iszero(R())
+         @test iszero(R(0))
+         @test isone(R(1))
+
+         @test !isunit(R())
+         @test isunit(R(1))
+
+         @test iszero(R(characteristic(R)))
+         @test iszero(characteristic(R) * one(R))
+         @test iszero(one(R) * characteristic(R))
+      end
+
+      elems = [ zero(R), one(R), R(R(2)), example_elements... ]
+      @testset "test element conformance" for x in elems
+         @test x isa ExpectedElemType
+         @test parent_type(x) == ExpectedParentType
+         @test parent_type(typeof(x)) == ExpectedParentType
+      end
+   end
+end
+
+test_Ring_interface(zz, Int, AbstractAlgebra.Integers{Int}, [11])
+test_Ring_interface(ZZ, BigInt, AbstractAlgebra.Integers{BigInt}, [11])
+
+test_Ring_interface(qq, Rational{Int}, AbstractAlgebra.Rationals{Int}, [11])
+test_Ring_interface(QQ, Rational{BigInt}, AbstractAlgebra.Rationals{BigInt}, [11])
+
+test_Ring_interface(RDF, Float64, AbstractAlgebra.Floats{Float64},
+        [11, 11//3, 1.2])
+test_Ring_interface(RealField, BigFloat, AbstractAlgebra.Floats{BigFloat},
+        [11, 11/3, 1.2, big(11), big(11)//big(3), big(1.2), Rational{BigInt}(11)])
+
+test_Ring_interface(GF(3), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}, [2])
+test_Ring_interface(GF(13), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}, [11])
+test_Ring_interface(GF(big(13)), AbstractAlgebra.GFElem{BigInt}, AbstractAlgebra.GFField{BigInt}, [11, big(11)])
+
+
+test_Ring_interface(ZZ["x"][1], Generic.Poly{BigInt}, Generic.PolyRing{BigInt})

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -188,11 +188,11 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
             @test a*b == b*a
             # documentation is not clear on divexact
             if isdomain_type(T)
-               @test iszero(b) || divexact(b*a, b) == a
+               @test iszero(b) || equality(divexact(b*a, b), a)
             else
                try
                   t = divexact(b*a, b)
-                  @test t*b == a*b
+                  @test equaltiy(t*b, a*b)
                catch
                end
             end

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -389,16 +389,6 @@ function test_MatAlgebra_interface(S::MatAlgebra; reps = 20)
          end
       end
 
-      if nrows(S) > 0
-         @testset "Views" begin
-            a = test_elem(S)::ST
-            b = test_elem(S)::ST
-            N1 = @view a[1:1, 1:1]
-            N2 = @view b[1:1, 1:1]
-            @test N1*N2 == matrix(R, 1, 1, a[1, 1]*b[1, 1])
-         end
-      end
-
       @testset "Basic manipulation of matrices" begin
          for k in 1:reps
             a = test_elem(S)::ST

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -1,53 +1,222 @@
-# TODO: instead of 'example_element' provide a function which allows sampling any number
-# of elements
-function test_Ring_interface(R::AbstractAlgebra.Ring, ExpectedElemType, ExpectedParentType, example_elements = [])
-   @testset "Ring interface for $(R) / $(ExpectedElemType) / $(ExpectedParentType)" begin
-      @test R isa ExpectedParentType
-      example_elements = R.(example_elements)
+import AbstractAlgebra: NCRingElem, NCRingElement
 
-      @testset "test ring conformance" begin
-         @test elem_type(R) == ExpectedElemType
-         @test elem_type(ExpectedParentType) == ExpectedElemType
-         @test elem_type(typeof(R)) == ExpectedElemType
+const reps = 50
 
-         @test iszero(zero(R))
-         @test isone(one(R))
+function equality(a::T, b::T) where T <: NCRingElement
+   if isexact_type(T)
+      return a == b
+   else
+      return isapprox(a, b)
+   end
+end
 
-         @test iszero(R())
-         @test iszero(R(0))
-         @test isone(R(1))
+function test_NCRing_interface(
+   R::AbstractAlgebra.NCRing,
+   example_elements::Vector{T}
+) where T <: NCRingElement
 
-         @test !isunit(R())
-         @test isunit(R(1))
+   @testset "NCRing interface for $(R)" begin
 
+      @testset "Functions for types and parents of rings" begin
+         @test elem_type(R) == T
+         @test elem_type(typeof(R)) == T
+         @test parent_type(T) == typeof(R)
+         for x in example_elements
+            @test parent(x) == R
+         end
+         @test isdomain_type(T) isa Bool
+         @test isexact_type(T) isa Bool
          @test iszero(R(characteristic(R)))
          @test iszero(characteristic(R) * one(R))
          @test iszero(one(R) * characteristic(R))
       end
 
-      elems = [ zero(R), one(R), R(R(2)), example_elements... ]
-      @testset "test element conformance" for x in elems
-         @test x isa ExpectedElemType
-         @test parent_type(x) == ExpectedParentType
-         @test parent_type(typeof(x)) == ExpectedParentType
+      @testset "Constructors" begin
+         @test R() isa T
+         @test R(true) isa T
+         @test R(false) isa T
+         @test R(0) isa T
+         @test R(1) isa T
+         @test R(-2) isa T
+         @test R(BigInt(0)) isa T
+         @test R(BigInt(1)) isa T
+         @test R(BigInt(-2)) isa T
+         @test R(BigInt(3)^100) isa T
+         for x in example_elements
+            @test R(x) isa T
+         end
+      end
+
+      elems = deepcopy(example_elements)
+      append!(elems, T[R(0), R(1), R(-2), R(BigInt(0)), R(BigInt(1)),
+                       R(BigInt(-2))#=, R(BigInt(3)^100)=#])
+
+      @testset "Basic functions" begin
+         @test iszero(R())       # R() is supposed to construct 0 ?
+         @test iszero(zero(R))
+         @test isone(one(R))
+         @test iszero(R(0))
+         @test isone(R(1))
+         @test isone(R(0)) || !isunit(R(0))
+         @test isunit(R(1))
+         for x in example_elements
+            @test hash(x) isa UInt
+            @test sprint(show, "text/plain", x) isa String
+         end
+         @test sprint(show, "text/plain", R) isa String
+
+         for i in 1:reps
+            a = rand(elems)
+            b = rand(elems)
+            c = rand(elems)
+            A = deepcopy(a)
+            B = deepcopy(b)
+            C = deepcopy(c)
+            @test equality((a + b) + c, a + (b + c))
+            @test equality(a + b, b + a)
+            @test equality(a - c, a + (-c))
+            @test equality(a + zero(R), a)
+            @test equality(a + (-a), zero(R))
+            @test equality((a*b)*c, a*(b*c))
+            @test equality(a*one(R), a)
+            @test equality(one(R)*a, a)
+            @test equality(a*(b + c), a*b + a*c)
+            @test equality((a + b)*c, a*c + b*c)
+            @test iszero(a*zero(R))
+            @test iszero(zero(R)*a)
+            @test A == a
+            @test B == b
+            @test C == c
+         end
+      end
+
+      if !(R isa AbstractAlgebra.Ring) && !iszero(one(R)) && isdomain_type(T)
+         @testset "Basic functionality for noncommutative rings only" begin
+            for i in 1:reps
+               a = rand(elems)
+               b = rand(elems)
+               A = deepcopy(a)
+               B = deepcopy(b)
+               @test iszero(b) || equality(divexact_left(b*a, b), a)
+               @test iszero(b) || equality(divexact_right(a*b, b), a)
+               @test A == a
+               @test B == b
+            end
+         end
+      end
+
+      @testset "Unsafe ring operators" begin
+         for i in 1:reps
+            a = rand(elems)
+            b = rand(elems)
+            c = rand(elems)
+            A = deepcopy(a)
+            B = deepcopy(b)
+            C = deepcopy(c)
+
+            x = deepcopy(a)
+            @test iszero(zero!(x))
+
+            ab = a*b
+            x = R()
+            @test mul!(x, a, b) == ab
+            x = deepcopy(b)
+            @test mul!(x, a, b) == ab
+            x = deepcopy(a)
+            @test mul!(x, x, b) == ab
+            x = deepcopy(b)
+            @test mul!(x, a, x) == ab
+
+            ab = a+b
+            x = R()
+            @test add!(x, a, b) == ab
+            x = deepcopy(b)
+            @test add!(x, a, b) == ab
+            x = deepcopy(a)
+            @test add!(x, x, b) == ab
+            x = deepcopy(b)
+            @test add!(x, a, x) == ab
+            x = deepcopy(a)
+            @test addeq!(x, b) == ab
+
+            # hmmm, doc says three args but describes four args 
+            # BigFloat may fuse, so isapprox
+            t = R()
+            x = deepcopy(a)
+            @test equality(addmul!(x, b, c, t), a+b*c)
+            x = deepcopy(a)
+            @test equality(addmul!(x, x, c, t), a+a*c)
+            x = deepcopy(a)
+            @test equality(addmul!(x, b, x, t), a+b*a)
+            x = deepcopy(a)
+            @test equality(addmul!(x, x, x, t), a+a*a)
+
+            @test A == a
+            @test B == b
+            @test C == c
+         end         
       end
    end
 end
 
-test_Ring_interface(zz, Int, AbstractAlgebra.Integers{Int}, [11])
-test_Ring_interface(ZZ, BigInt, AbstractAlgebra.Integers{BigInt}, [11])
 
-test_Ring_interface(qq, Rational{Int}, AbstractAlgebra.Rationals{Int}, [11])
-test_Ring_interface(QQ, Rational{BigInt}, AbstractAlgebra.Rationals{BigInt}, [11])
+function test_Ring_interface(
+   R::AbstractAlgebra.Ring,
+   example_elements::Vector{T}
+) where T <: NCRingElement
 
-test_Ring_interface(RDF, Float64, AbstractAlgebra.Floats{Float64},
-        [11, 11//3, 1.2])
-test_Ring_interface(RealField, BigFloat, AbstractAlgebra.Floats{BigFloat},
-        [11, 11/3, 1.2, big(11), big(11)//big(3), big(1.2), Rational{BigInt}(11)])
-
-test_Ring_interface(GF(3), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}, [2])
-test_Ring_interface(GF(13), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}, [11])
-test_Ring_interface(GF(big(13)), AbstractAlgebra.GFElem{BigInt}, AbstractAlgebra.GFField{BigInt}, [11, big(11)])
+   test_NCRing_interface(R, example_elements)
 
 
-test_Ring_interface(ZZ["x"][1], Generic.Poly{BigInt}, Generic.PolyRing{BigInt})
+   elems = deepcopy(example_elements)
+   append!(elems, T[R(0), R(1), R(-2), R(BigInt(0)), R(BigInt(1)),
+                    R(BigInt(-2))#=, R(BigInt(3)^100)=#])
+
+   if !iszero(one(R)) && isdomain_type(T)
+      @testset "Basic functionality for commutative rings only" begin
+         for i in 1:reps
+            a = rand(elems)
+            b = rand(elems)
+            A = deepcopy(a)
+            B = deepcopy(b)
+            @test isone(inv(one(R)))
+            @test a*b == b*a
+            @test iszero(b) || divexact(b*a, b) == a
+            @test A == a
+            @test B == b
+         end
+      end
+   end
+end
+
+
+#InexactError on R(BigInt(3) ^ 100)
+#failure on iszero(b) || divexact(b * a, b) == a
+#test_Ring_interface(zz, Int[11, 2^30, 2^40])
+
+test_Ring_interface(ZZ, BigInt[11])
+
+test_Ring_interface(QQ, Rational{BigInt}[11//5])
+
+#no method matching (::AbstractAlgebra.Floats{Float64})(::Bool)
+#test_Ring_interface(RDF, Float64[11, 11//3, 1.2])
+
+#no method matching (::AbstractAlgebra.Floats{BigFloat})(::Bool)
+#test_Ring_interface(RealField, BigFloat[11, 11/3, 1.2, big(11), big(11)//big(3), big(1.2), Rational{BigInt}(11)])
+
+R = GF(3)
+test_Ring_interface(R, AbstractAlgebra.GFElem{Int}[R(2)])
+
+#R = ResidueRing(ZZ, 1)
+#falure on isone(one(R))
+#test_Ring_interface(R, AbstractAlgebra.Generic.Res{BigInt}[R(2)])
+
+R = GF(13)
+test_Ring_interface(R, AbstractAlgebra.GFElem{Int}[R(11)])
+
+R = GF(big(13))
+test_Ring_interface(R, AbstractAlgebra.GFElem{BigInt}[R(11), R(big(11))])
+
+R, x = ZZ["x"]
+test_Ring_interface(R, Generic.Poly{BigInt}[x, x^2-big(2)^100, x^5])
+

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -94,12 +94,20 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
                A = deepcopy(a)
                B = deepcopy(b)
                # documentation is not clear on divexact
-               if (isdomain_type(T))
+               if isdomain_type(T)
                   @test iszero(b) || equality(divexact_left(b*a, b), a)
                   @test iszero(b) || equality(divexact_right(a*b, b), a)
                else
-                  @test iszero(b) || equality(b*divexact_left(b*a, b), b*a)
-                  @test iszero(b) || equality(divexact_right(a*b, b)*b, a*b)
+                  try
+                     t = divexact_left(b*a, b)
+                     @test equality(b*t, b*a)
+                  catch
+                  end
+                  try
+                     t = divexact_right(a*b, b)
+                     @test equality(t*b, a*b)
+                  catch
+                  end
                end
                @test A == a
                @test B == b
@@ -170,24 +178,26 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
 
       test_NCRing_interface(R)
 
-      if !iszero(one(R))
-         @testset "Basic functionality for commutative rings only" begin
-            for i in 1:reps
-               a = test_elem(R)::T
-               b = test_elem(R)::T
-               A = deepcopy(a)
-               B = deepcopy(b)
-               @test isone(inv(one(R)))
-               @test a*b == b*a
-               # documentation is not clear on divexact
-               if (isdomain_type(T))
-                  @test iszero(b) || divexact(b*a, b) == a
-               else
-                  @test iszero(b) || divexact(b*a, b)*b == a*b
+      @testset "Basic functionality for commutative rings only" begin
+         for i in 1:reps
+            a = test_elem(R)::T
+            b = test_elem(R)::T
+            A = deepcopy(a)
+            B = deepcopy(b)
+            @test isone(inv(one(R)))
+            @test a*b == b*a
+            # documentation is not clear on divexact
+            if isdomain_type(T)
+               @test iszero(b) || divexact(b*a, b) == a
+            else
+               try
+                  t = divexact(b*a, b)
+                  @test t*b == a*b
+               catch
                end
-               @test A == a
-               @test B == b
             end
+            @test A == a
+            @test B == b
          end
       end
    end

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -31,4 +31,26 @@ end
 
 include("julia/Integers-test.jl")
 
+# very generic testing: just define test_elem(R) and call test_Ring_interface(R)
+
 include("Rings-conformance-tests.jl")
+
+function test_elem(R::AbstractAlgebra.Integers{BigInt})
+   n = big(2)^rand(1:100)
+   return ZZ(rand((-n):n))
+end
+test_Ring_interface_recursive(ZZ)
+
+function test_elem(R::AbstractAlgebra.Rationals{BigInt})
+   n = big(2)^rand(1:100)
+   return QQ(rand((-n):n)//rand(1:n))
+end
+test_Field_interface_recursive(QQ)
+
+function test_elem(R::AbstractAlgebra.GFField)
+   return R(rand(0:characteristic(R)))
+end
+test_Field_interface_recursive(GF(3))
+test_Field_interface_recursive(GF(13))
+test_Field_interface_recursive(GF(big(13)))
+test_Field_interface_recursive(GF(big(10)^20 + 39))

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -51,6 +51,12 @@ function test_elem(R::AbstractAlgebra.Integers{BigInt})
 end
 test_Ring_interface_recursive(ZZ)
 
+function test_elem(R::AbstractAlgebra.Generic.ResRing{BigInt})
+   return R(rand(0:characteristic(R)))
+end
+test_Ring_interface(ResidueRing(ZZ, 1))   # isgen fails on polys
+test_Ring_interface_recursive(ResidueRing(ZZ, -4))
+
 function test_elem(R::AbstractAlgebra.Rationals{BigInt})
    n = big(2)^rand(1:100)
    return QQ(rand(-n:n)//rand(1:n))

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -35,15 +35,25 @@ include("julia/Integers-test.jl")
 
 include("Rings-conformance-tests.jl")
 
+function test_elem(R::AbstractAlgebra.Floats{Float64})
+   return rand(Float64)*rand(-100:100)
+end
+test_Ring_interface(RDF)
+
+function test_elem(R::AbstractAlgebra.Floats{BigFloat})
+   return rand(BigFloat)*rand(-100:100)
+end
+test_Ring_interface(RealField)
+
 function test_elem(R::AbstractAlgebra.Integers{BigInt})
    n = big(2)^rand(1:100)
-   return ZZ(rand((-n):n))
+   return ZZ(rand(-n:n))
 end
 test_Ring_interface_recursive(ZZ)
 
 function test_elem(R::AbstractAlgebra.Rationals{BigInt})
    n = big(2)^rand(1:100)
-   return QQ(rand((-n):n)//rand(1:n))
+   return QQ(rand(-n:n)//rand(1:n))
 end
 test_Field_interface_recursive(QQ)
 

--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -21,15 +21,6 @@ include("algorithms/DensePoly-test.jl")
 end
 
 @testset "Generic.Rings.elem/parent_type" begin
-   for (R, el, par) in [(GF(3), AbstractAlgebra.GFElem{Int}, AbstractAlgebra.GFField{Int}),
-                        (ZZ["x"][1], Generic.Poly{BigInt}, Generic.PolyRing{BigInt})]
-      x = R(2)
-      @test elem_type(R) == el
-      @test elem_type(typeof(R)) == el
-      @test parent_type(x) == par
-      @test parent_type(typeof(x)) == par
-   end
-
    @test_throws MethodError parent_type('c')
    @test_throws MethodError parent_type(Char)
    @test parent_type(big(1)) == AbstractAlgebra.Integers{BigInt}
@@ -37,3 +28,7 @@ end
    @test_throws MethodError elem_type('c')
    @test_throws MethodError elem_type(Char)
 end
+
+include("julia/Integers-test.jl")
+
+include("Rings-conformance-tests.jl")

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -1,37 +1,3 @@
-@testset "Julia.Floats.constructors" begin
-   R = RDF
-   S = RealField
-
-   @test elem_type(R) == Float64
-   @test elem_type(S) == BigFloat
-   @test elem_type(AbstractAlgebra.Floats{Float64}) == Float64
-   @test elem_type(AbstractAlgebra.Floats{BigFloat}) == BigFloat
-   @test parent_type(Float64) == AbstractAlgebra.Floats{Float64}
-   @test parent_type(BigFloat) == AbstractAlgebra.Floats{BigFloat}
-
-   @test isa(R, AbstractAlgebra.Floats)
-   @test isa(S, AbstractAlgebra.Floats)
-
-   @test isa(R(), Float64)
-   @test isa(S(), BigFloat)
-
-   @test isa(R(11), Float64)
-   @test isa(R(11//3), Float64)
-   @test isa(R(1.2), Float64)
-   @test isa(S(BigInt(11)), BigFloat)
-   @test isa(S(1.2), BigFloat)
-   @test isa(S(BigFloat(1.2)), BigFloat)
-   @test isa(S(BigInt(11)//BigInt(3)), BigFloat)
-   @test isa(S(Rational{BigInt}(11)), BigFloat)
-   @test isa(S(11), BigFloat)
-
-   a = R(11)
-   b = S(11)
-
-   @test isa(R(a), Float64)
-   @test isa(S(b), BigFloat)
-end
-
 @testset "Julia.Floats.printing" begin
    R, x = PolynomialRing(RealField, "x")
 
@@ -51,14 +17,6 @@ end
    R = RDF
    S = RealField
 
-   @test iszero(zero(R))
-   @test iszero(zero(S))
-
-   @test isone(one(R))
-   @test isone(one(S))
-
-   @test !isunit(R())
-   @test !isunit(S())
    @test isunit(R(3))
    @test isunit(S(3))
 end

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -1,31 +1,4 @@
 @testset "Julia.GFElem.constructors" begin
-   R = GF(13)
-   S = GF(BigInt(13))
-
-   @test elem_type(R) == AbstractAlgebra.GFElem{Int}
-   @test elem_type(S) == AbstractAlgebra.GFElem{BigInt}
-   @test elem_type(AbstractAlgebra.GFField{Int}) == AbstractAlgebra.GFElem{Int}
-   @test elem_type(AbstractAlgebra.GFField{BigInt}) == AbstractAlgebra.GFElem{BigInt}
-   @test parent_type(AbstractAlgebra.GFElem{Int}) == AbstractAlgebra.GFField{Int}
-   @test parent_type(AbstractAlgebra.GFElem{BigInt}) == AbstractAlgebra.GFField{BigInt}
-
-   @test isa(R, AbstractAlgebra.GFField)
-   @test isa(S, AbstractAlgebra.GFField)
-
-   @test isa(R(), AbstractAlgebra.GFElem)
-   @test isa(S(), AbstractAlgebra.GFElem)
-
-   @test isa(R(11), AbstractAlgebra.GFElem)
-   @test isa(S(BigInt(11)), AbstractAlgebra.GFElem)
-   @test isa(S(11), AbstractAlgebra.GFElem)
-   @test isa(S(BigInt(11)), AbstractAlgebra.GFElem)
-
-   a = R(11)
-   b = S(11)
-
-   @test isa(R(a), AbstractAlgebra.GFElem)
-   @test isa(S(b), AbstractAlgebra.GFElem)
-
    @test_throws DomainError GF(4)
    @test_throws DomainError GF(4, check=true)
    F = GF(4, check=false)
@@ -50,12 +23,6 @@ end
 @testset "Julia.GFElem.manipulation" begin
    R = GF(13)
    S = GF(BigInt(13))
-
-   @test iszero(zero(R))
-   @test iszero(zero(S))
-
-   @test isone(one(R))
-   @test isone(one(S))
 
    @test characteristic(R) == 13
    @test characteristic(S) == 13

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -1,47 +1,9 @@
-@testset "Julia.Integers.constructors" begin
-   R = zz
-   S = ZZ
-
-   @test elem_type(R) == Int
-   @test elem_type(S) == BigInt
-   @test elem_type(AbstractAlgebra.Integers{Int}) == Int
-   @test elem_type(AbstractAlgebra.Integers{BigInt}) == BigInt
-   @test parent_type(Int) == AbstractAlgebra.Integers{Int}
-   @test parent_type(BigInt) == AbstractAlgebra.Integers{BigInt}
-
-   @test isa(R, AbstractAlgebra.Integers)
-   @test isa(S, AbstractAlgebra.Integers)
-
-   @test isa(R(), Int)
-   @test isa(S(), BigInt)
-
-   @test isa(R(11), Int)
-   @test isa(S(BigInt(11)), BigInt)
-   @test isa(S(11), BigInt)
-
-   a = R(11)
-   b = S(11)
-
-   @test isa(R(a), Int)
-   @test isa(S(b), BigInt)
-end
-
 @testset "Julia.Integers.manipulation" begin
    R = zz
    S = ZZ
 
-   @test iszero(zero(R))
-   @test iszero(zero(S))
-
-   @test isone(one(R))
-   @test isone(one(S))
-
-   @test !isunit(R())
-   @test !isunit(S())
    @test !isunit(R(3))
    @test !isunit(S(3))
-   @test isunit(R(1))
-   @test isunit(S(1))
    @test isunit(R(-1))
    @test isunit(S(-1))
 

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -5,29 +5,6 @@
    @test R == FractionField(zz)
    @test S == FractionField(ZZ)
 
-   @test elem_type(R) == Rational{Int}
-   @test elem_type(S) == Rational{BigInt}
-   @test elem_type(AbstractAlgebra.Rationals{Int}) == Rational{Int}
-   @test elem_type(AbstractAlgebra.Rationals{BigInt}) == Rational{BigInt}
-   @test parent_type(Rational{Int}) == AbstractAlgebra.Rationals{Int}
-   @test parent_type(Rational{BigInt}) == AbstractAlgebra.Rationals{BigInt}
-
-   @test isa(R, AbstractAlgebra.Rationals)
-   @test isa(S, AbstractAlgebra.Rationals)
-
-   @test isa(R(), Rational{Int})
-   @test isa(S(), Rational{BigInt})
-
-   @test isa(R(11), Rational{Int})
-   @test isa(R(11//3), Rational{Int})
-   @test isa(R(11, 3), Rational{Int})
-   @test isa(S(BigInt(11)), Rational{BigInt})
-   @test isa(S(BigInt(11)//BigInt(3)), Rational{BigInt})
-   @test isa(S(Rational{BigInt}(11)), Rational{BigInt})
-   @test isa(S(11), Rational{BigInt})
-   @test isa(S(11, 3), Rational{BigInt})
-   @test isa(S(BigInt(11), BigInt(3)), Rational{BigInt})
-
    a = R(11)
    b = S(11)
 
@@ -46,14 +23,6 @@ end
    R = qq
    S = QQ
 
-   @test iszero(zero(R))
-   @test iszero(zero(S))
-
-   @test isone(one(R))
-   @test isone(one(S))
-
-   @test !isunit(R())
-   @test !isunit(S())
    @test isunit(R(3))
    @test isunit(S(3))
 end


### PR DESCRIPTION
Just looking for comments. @fingolfin @wbhart
~~I like the approach of the user providing explicit elements, which can hit coner cases, and also gives you the elem_type.~~
It uses functions now.
Will work on matrix, and poly tests soon.

Currently these rings do not pass, but the other ones work well.
```
zz
RDF
RealField
ResidueRing(ZZ, 1)
```