### PR TITLE
Fix documentation and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.20.1"
+version = "0.21.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
Not sure why, but documentation build was failing here: https://github.com/Nemocas/AbstractAlgebra.jl/runs/3201646567?check_suite_focus=true

This seems to fix it.