### PR TITLE
start using NotInvertibleError

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -132,7 +132,7 @@ export ZZ, QQ, zz, qq, RealField, RDF
 export create_accessors, get_handle, package_handle, zeros,
        Array, sig_exists
 
-export error_dim_negative, ErrorConstrDimMismatch
+export ImpossibleInverse, error_dim_negative, ErrorConstrDimMismatch
 
 export crt, factor, factor_squarefree
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -132,7 +132,7 @@ export ZZ, QQ, zz, qq, RealField, RDF
 export create_accessors, get_handle, package_handle, zeros,
        Array, sig_exists
 
-export ImpossibleInverse, error_dim_negative, ErrorConstrDimMismatch
+export NotInvertibleError, error_dim_negative, ErrorConstrDimMismatch
 
 export crt, factor, factor_squarefree
 

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -211,7 +211,12 @@ end
 ###############################################################################
 
 function ^(a::ResElem, b::Int)
-   parent(a)(powermod(data(a), b, modulus(a)))
+   if b < 0
+      # powermod throws a DivideError when it should throw an ImpossibleInverse
+      parent(a)(powermod(data(inv(a)), -b, modulus(a)))
+   else
+      parent(a)(powermod(data(a), b, modulus(a)))
+   end
 end
 
 ###############################################################################
@@ -307,9 +312,7 @@ inverse is encountered, an exception is raised.
 """
 function Base.inv(a::ResElem)
    g, ainv = gcdinv(data(a), modulus(a))
-   if g != 1
-      error("Impossible inverse in inv")
-   end
+   isone(g) || throw(ImpossibleInverse(a))
    return parent(a)(ainv)
 end
 

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -312,7 +312,7 @@ inverse is encountered, an exception is raised.
 """
 function Base.inv(a::ResElem)
    g, ainv = gcdinv(data(a), modulus(a))
-   isone(g) || throw(ImpossibleInverse(a))
+   isone(g) || throw(NotInvertibleError(a))
    return parent(a)(ainv)
 end
 

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -212,7 +212,7 @@ end
 
 function ^(a::ResElem, b::Int)
    if b < 0
-      # powermod throws a DivideError when it should throw an ImpossibleInverse
+      # powermod throws a DivideError when it should throw an NotInvertibleError
       parent(a)(powermod(data(inv(a)), -b, modulus(a)))
    else
       parent(a)(powermod(data(a), b, modulus(a)))

--- a/src/error.jl
+++ b/src/error.jl
@@ -4,30 +4,26 @@
 #
 ###############################################################################
 
-mutable struct ImpossibleInverse{T, S} <: Exception
+mutable struct NotInvertibleError{T, S} <: Exception
   data::T   # element that could not be inverted
   mod::S    # ring or modulus with respect to which it could not be inverted
 end
 
-function ImpossibleInverse(x::T, y::S) where {T <: RingElement, S}
-  if iszero(x)
-    throw(DivideError())
-  else
-    throw(ImpossibleInverse{T, S}(x, y))
-  end
+function NotInvertibleError(x::T, y::S) where {T <: RingElement, S}
+  return NotInvertibleError{T, S}(x, y)
 end
 
-function ImpossibleInverse(x::RingElement)
-  return ImpossibleInverse(x, parent(x))
+function NotInvertibleError(x::RingElement)
+  return NotInvertibleError(x, parent(x))
 end
 
-function Base.showerror(io::IO, e::ImpossibleInverse{T, S}) where {T, S <: Ring}
+function Base.showerror(io::IO, e::NotInvertibleError{T, S}) where {T, S <: Ring}
   print(io, e.data)
   print(io, " is not invertible in ")
   print(io, e.mod)
 end
 
-function Base.showerror(io::IO, e::ImpossibleInverse)
+function Base.showerror(io::IO, e::NotInvertibleError)
   print(io, e.data)
   print(io, " is not invertible modulo ")
   print(io, e.mod)

--- a/src/error.jl
+++ b/src/error.jl
@@ -4,6 +4,36 @@
 #
 ###############################################################################
 
+mutable struct ImpossibleInverse{T, S} <: Exception
+  data::T   # element that could not be inverted
+  mod::S    # ring or modulus with respect to which it could not be inverted
+end
+
+function ImpossibleInverse(x::T, y::S) where {T <: RingElement, S}
+  if iszero(x)
+    throw(DivideError())
+  else
+    throw(ImpossibleInverse{T, S}(x, y))
+  end
+end
+
+function ImpossibleInverse(x::RingElement)
+  return ImpossibleInverse(x, parent(x))
+end
+
+function Base.showerror(io::IO, e::ImpossibleInverse{T, S}) where {T, S <: Ring}
+  print(io, e.data)
+  print(io, " is not invertible in ")
+  print(io, e.mod)
+end
+
+function Base.showerror(io::IO, e::ImpossibleInverse)
+  print(io, e.data)
+  print(io, " is not invertible modulo ")
+  print(io, e.mod)
+end
+
+
 mutable struct ErrorConstrDimMismatch <: Exception
   expect_r::Int
   expect_c::Int

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -337,32 +337,32 @@ end
 
 
    R = ResidueRing(ZZ, ZZ(4))
-   @test_throws DivideError R(4)^-1
-   @test_throws ImpossibleInverse R(2)^-1
+   @test_throws NotInvertibleError R(4)^-1
+   @test_throws NotInvertibleError R(2)^-1
    try
       R(2)^-1
    catch e
-      @test e isa ImpossibleInverse
+      @test e isa NotInvertibleError
       @test e.data == 2
       @test modulus(e.mod) == 4
    end
 
    R = ResidueRing(ZZ, 4)
-   @test_throws DivideError R(4)^-1
-   @test_throws ImpossibleInverse R(2)^-1
+   @test_throws NotInvertibleError R(4)^-1
+   @test_throws NotInvertibleError R(2)^-1
    try
       R(2)^-1
    catch e
-      @test e isa ImpossibleInverse
+      @test e isa NotInvertibleError
       @test e.data == 2
       @test modulus(e.mod) == 4
    end
 
    R = ResidueRing(ZZ, ZZ(5))
-   @test_throws DivideError R(5)^-1
+   @test_throws NotInvertibleError R(5)^-1
 
    R = ResidueRing(ZZ, 5)
-   @test_throws DivideError R(5)^-1
+   @test_throws NotInvertibleError R(5)^-1
 end
 
 @testset "Generic.Res.inversion" begin

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -334,6 +334,35 @@ end
    @test T(x + 1)^1 == T(x + 1)
    @test T(x + 1)^2 == T(2x)
    @test T(x + 1)^3 == T(2x - 2)
+
+
+   R = ResidueRing(ZZ, ZZ(4))
+   @test_throws DivideError R(4)^-1
+   @test_throws ImpossibleInverse R(2)^-1
+   try
+      R(2)^-1
+   catch e
+      @test e isa ImpossibleInverse
+      @test e.data == 2
+      @test modulus(e.mod) == 4
+   end
+
+   R = ResidueRing(ZZ, 4)
+   @test_throws DivideError R(4)^-1
+   @test_throws ImpossibleInverse R(2)^-1
+   try
+      R(2)^-1
+   catch e
+      @test e isa ImpossibleInverse
+      @test e.data == 2
+      @test modulus(e.mod) == 4
+   end
+
+   R = ResidueRing(ZZ, ZZ(5))
+   @test_throws DivideError R(5)^-1
+
+   R = ResidueRing(ZZ, 5)
+   @test_throws DivideError R(5)^-1
 end
 
 @testset "Generic.Res.inversion" begin


### PR DESCRIPTION
If it were up to me, I would get rid of the non-informative `DivideError` and throw an `ImpossibleInverse` instead. Suppose you are doing polynomial arithmetic. Would you want to see
```julia
julia> ZZx,x = ZZ["x"]; x//(x-x)
ERROR: DivideError: integer division error
```
? It doesn't make much sense to me, but here we are.