### PR TITLE
Add all functions with special local versions to import/export lists

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -18,7 +18,8 @@ using Test # for "interface-conformance" functions
 import_exclude = [:import_exclude, :QQ, :ZZ,
                   :RealField, :NumberField,
                   :AbstractAlgebra,
-                  :exp, :sqrt, :div, :divrem, :numerator, :denominator,
+                  :inv, :log, :exp, :sqrt, :div, :divrem,
+                  :numerator, :denominator,
                   :promote_rule,
                   :Set, :Module, :Ring, :Group, :Field]
 
@@ -53,7 +54,7 @@ import LinearAlgebra: lu, lu!, tr
 ################################################################################
 
 # This is the list of functions for which we locally have a different behavior.
-const Base_import_exclude = [:exp, :log, :sqrt, :div, :divrem, :numerator,
+const Base_import_exclude = [:exp, :log, :sqrt, :inv, :div, :divrem, :numerator,
 		             :denominator]
 
 ################################################################################


### PR DESCRIPTION
Functions such as inv, sqrt, log, exp, etc. have special local versions which we use internally, which conflict with the Base definition.

This PR adds those to the relevant import/export exclude lists.

Fixes https://github.com/Nemocas/Nemo.jl/issues/1038
