### PR TITLE
Document constructing polynomials from empty vectors

### DIFF
--- a/docs/src/poly_interface.md
+++ b/docs/src/poly_interface.md
@@ -89,22 +89,13 @@ coefficients, must be available.
 
 ```julia
 (S::MyPolyRing{T})(A::Vector{T}) where T <: RingElem
-```
-
-Create the polynomial in the given ring whose degree $i$ coefficient is given by `A[1 + i]`.
-
-```julia
 (S::MyPolyRing{T})(A::Vector{U}) where T <: RingElem, U <: RingElem
-```
-
-Create the polynomial in the given ring whose degree $i$ coefficient is given by `A[1 + i]`.
-The elements of the array are assumed to be able to be coerced into the base ring `R`.
-
-```julia
 (S::MyPolyRing{T})(A::Vector{U}) where T <: RingElem, U <: Integer
 ```
 
 Create the polynomial in the given ring whose degree $i$ coefficient is given by `A[1 + i]`.
+The elements of the array are assumed to be able to be coerced into the base ring `R`.
+If the argument is an empty vector, the zero polynomial shall be returned.
 
 It may be desirable to have a additional version of the function that accepts an array
 of Julia `Int` values  if this can be done more efficiently.

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -296,6 +296,7 @@ function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
             end
             @test a == Rx(collect(coefficients(a)))
          end
+         @test Rx(Int[]) == zero(Rx)
          @test Rx([0, 1, 2]) == x + 2*x^2
          @test Rx([big(0), big(1), big(2)]) == x + 2*x^2
          @test Rx(map(R, [0, 1, 2])) == x + 2*x^2


### PR DESCRIPTION
The ring conformance tests added by @tthsqe12 some time ago already tested for this in a randomized fashion. When I tried to use the conformance tests in Nemo, I found that not all polynomial implementations support this. But I think they should. So, as a first step, this PR documents the expected behavior. I will submit further PRs to adjust implementations in Nemo and possibly elsewhere to conform to this.