### PR TITLE
Add support for `rand(QQ, -big(5):big(5))`

### DIFF
--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -606,7 +606,7 @@ RandomExtensions.maketype(R::AbstractAlgebra.Integers{T}, _) where {T} = T
 
 # define rand(make(ZZ, n:m))
 rand(rng::AbstractRNG,
-     sp::SamplerTrivial{<:Make2{T, Integers{T}, UnitRange{Int}}}
+     sp::SamplerTrivial{<:Make2{T, Integers{T}, <:AbstractArray{<:Integer}}}
      ) where {T} =
         sp[][1](rand(rng, sp[][2]))
 

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -308,7 +308,7 @@ end
 RandomExtensions.maketype(R::Rationals{T}, _) where {T} = Rational{T}
 
 function rand(rng::AbstractRNG,
-              sp::SamplerTrivial{<:Make2{Rational{T}, Rationals{T}, UnitRange{Int}}}
+              sp::SamplerTrivial{<:Make2{Rational{T}, Rationals{T}, <:AbstractArray{<:Integer}}}
               ) where {T}
    R, n = sp[][1:end]
    d = T(0)


### PR DESCRIPTION
This is also part of PR #995, but that PR produces failures in CI that I can't reproduce. So let's see if this commit on its own causes issues or not, that might help narrow it down.