### PR TITLE
CI: test against Julia 1.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,42 +15,27 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.0'
-          - '1.1'
-          - '1.2'
+          - '1.0'  # current LTS
+          #- '1.1'
+          #- '1.2'
           - '1.3'
           - '1.4'
           - '1.5'
           - '1.6'
+          - '~1.7.0-0'
           - 'nightly'
-        julia-arch:
-          - x64
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        exclude:
-          # Reduce the number of macOS jobs, as fewer can be run in parallel
+        include:
+          # Add a few windows and macOS jobs (not too many, the number we can run in parallel is limited)
           - os: macOS-latest
-            julia-version: '1.1'
+            julia-version: '1.0'
           - os: macOS-latest
-            julia-version: '1.2'
-          - os: macOS-latest
-            julia-version: '1.3'
-          - os: macOS-latest
-            julia-version: '1.4'
-          - os: macOS-latest
-            julia-version: '1.5'
+            julia-version: '1.6'
           - os: windows-latest
-            julia-version: '1.1'
+            julia-version: '1.0'
           - os: windows-latest
-            julia-version: '1.2'
-          - os: windows-latest
-            julia-version: '1.3'
-          - os: windows-latest
-            julia-version: '1.4'
-          - os: windows-latest
-            julia-version: '1.5'
+            julia-version: '1.6'
 
     steps:
       - uses: actions/checkout@v2
@@ -62,7 +47,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
       - name: Cache artifacts
         uses: actions/cache@v1
         env:


### PR DESCRIPTION
Also instead of excluding most mac/Windows jobs, just explicitly
write down those we want.

Also drop testing on 1.1 and 1.2 (it's unlikely a regression only
occurs there, and even if, it is unlikely anybody still is using those)
