### PR TITLE
Fix conformance test for divrem

### DIFF
--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -265,7 +265,7 @@ function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 20)
          m = one(R)
       end
 
-      @test (div(f, m), mod(f, m)) == divrem(f, m)
+      @test (div(f, m), rem(f, m)) == divrem(f, m)
       @test divides(mulmod(f, g, m) - mod(f*g, m), m)[1]
       @test divides(powermod(f, 3, m) - mod(f^3, m), m)[1]
 


### PR DESCRIPTION
The AA documentation is *not* clear on what exactly the second return value of `divrem` is, but the Julia documentation is crystal clear. So I am hoping the conformance test was simply wrong (hence this PR).

CC @tthsqe12 