### PR TITLE
Fix ad hoc divexact for polynomials over function fields

### DIFF
--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -1041,8 +1041,6 @@ function divexact(a::Rat{T},
    return a*inv(b)
 end
 
-divexact(a::RingElem, b::FunctionFieldElem; check::Bool=true) = a*inv(b)
-
 ###############################################################################
 #
 #   Norm

--- a/test/generic/FunctionField-test.jl
+++ b/test/generic/FunctionField-test.jl
@@ -854,5 +854,6 @@ end
       @test t * BigInt(1) == BigInt(1) * t
       @test t + one(R1) == one(R1) + t
       @test t * one(R1) == one(R1) * t
+      @test divexact(t, one(S)) == t
    end
 end


### PR DESCRIPTION
Remove an ad hoc method which is too general. Let the promotion
system do its job.