### PR TITLE
use (im)mutable rings consistently

### DIFF
--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -765,20 +765,17 @@ struct ConstPolyRing{T <: RingElement} <: Ring
    base_ring::Ring
 
    function ConstPolyRing{T}(R::Ring, cached::Bool) where T <: RingElement
-      return get_cached!(ConstPolyID, R, cached) do
-         new{T}(R)
-      end::ConstPolyRing{T}
+      cached == true || @warn "ring type is immutable"
+      new{T}(R)
    end
 end
 
-const ConstPolyID = AbstractAlgebra.CacheDictType{Ring, ConstPolyRing}()
-   
 mutable struct ConstPoly{T <: RingElement} <: RingElem
    c::T
    parent::ConstPolyRing{T}
 
    function ConstPoly{T}(c::T) where T <: RingElement
-      return new(c)
+      new{T}(c)
    end
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -716,17 +716,14 @@ const LaurentSeriesElem{T} = Union{LaurentSeriesRingElem{T}, LaurentSeriesFieldE
 #
 ###############################################################################
 
-mutable struct PuiseuxSeriesRing{T <: RingElement} <: AbstractAlgebra.Ring
+struct PuiseuxSeriesRing{T <: RingElement} <: AbstractAlgebra.Ring
    laurent_ring::Ring
 
    function PuiseuxSeriesRing{T}(R::LaurentSeriesRing{T}, cached::Bool = true) where T <: RingElement
-      return get_cached!(PuiseuxSeriesID, R, cached) do
-         new{T}(R)
-      end::PuiseuxSeriesRing{T}
+      cached == true || @warn "ring type is immutable"
+      new{T}(R)
    end
 end
-
-const PuiseuxSeriesID = CacheDictType{Ring, Ring}()
 
 mutable struct PuiseuxSeriesRingElem{T <: RingElement} <: AbstractAlgebra.RingElem
    data::LaurentSeriesRingElem{T}
@@ -744,17 +741,14 @@ end
 #
 ###############################################################################
 
-mutable struct PuiseuxSeriesField{T <: FieldElement} <: AbstractAlgebra.Field
+struct PuiseuxSeriesField{T <: FieldElement} <: AbstractAlgebra.Field
    laurent_ring::Field
 
    function PuiseuxSeriesField{T}(R::LaurentSeriesField{T}, cached::Bool = true) where T <: FieldElement
-      return get_cached!(PuiseuxSeriesFieldID, R, cached) do
-         new{T}(R)
-      end::PuiseuxSeriesField{T}
+      cached == true || @warn "ring type is immutable"
+      new{T}(R)
    end
 end
-
-const PuiseuxSeriesFieldID = CacheDictType{Ring, Field}()
 
 mutable struct PuiseuxSeriesFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
    data::LaurentSeriesFieldElem{T}
@@ -812,17 +806,14 @@ end
 #
 ###############################################################################
 
-mutable struct FracField{T <: RingElem} <: AbstractAlgebra.FracField{T}
+struct FracField{T <: RingElem} <: AbstractAlgebra.FracField{T}
    base_ring::Ring
 
    function FracField{T}(R::Ring, cached::Bool = true) where T <: RingElem
-      return get_cached!(FracDict, R, cached) do
-         new{T}(R)
-      end::FracField{T}
+      cached == true || @warn "ring type is immutable"
+      new{T}(R)
    end
 end
-
-const FracDict = CacheDictType{Ring, Ring}()
 
 mutable struct Frac{T <: RingElem} <: AbstractAlgebra.FracElem{T}
    num::T
@@ -838,7 +829,7 @@ end
 #
 ###############################################################################
 
-struct RationalFunctionField{T <: FieldElement} <: AbstractAlgebra.Field
+mutable struct RationalFunctionField{T <: FieldElement} <: AbstractAlgebra.Field
    S::Symbol
    fraction_field::FracField{<:PolyElem{T}}
    base_ring::Field

--- a/test/algorithms/GenericFunctions-test.jl
+++ b/test/algorithms/GenericFunctions-test.jl
@@ -21,20 +21,17 @@ struct ConstPolyRing{T <: RingElement} <: Ring
    base_ring::Ring
 
    function ConstPolyRing{T}(R::Ring, cached::Bool) where T <: RingElement
-      return get_cached!(ConstPolyID, R, cached) do
-         new{T}(R)
-      end::ConstPolyRing{T}
+      cached == true || @warn "ring type is immutable"
+      new{T}(R)
    end
 end
 
-const ConstPolyID = AbstractAlgebra.CacheDictType{Ring, ConstPolyRing}()
-   
 mutable struct ConstPoly{T <: RingElement} <: RingElem
    c::T
    parent::ConstPolyRing{T}
 
    function ConstPoly{T}(c::T) where T <: RingElement
-      return new(c)
+      new{T}(c)
    end
 end
 

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -3,7 +3,7 @@
    T = FractionField(S)
 
    @test FractionField(S, cached = true) === FractionField(S, cached = true)
-   @test FractionField(S, cached = false) !== FractionField(S, cached = true)
+   @test FractionField(S) === FractionField(S)
 
    @test elem_type(T) == Generic.Frac{elem_type(S)}
    @test elem_type(Generic.FracField{elem_type(S)}) == Generic.Frac{elem_type(S)}

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -23,7 +23,7 @@
    T, y = PuiseuxSeriesRing(S, 30, "y")
 
    @test PuiseuxSeriesRing(S, 30, "y", cached = true)[1] === PuiseuxSeriesRing(S, 30, "y", cached = true)[1]
-   @test PuiseuxSeriesRing(S, 30, "y", cached = false)[1] !== PuiseuxSeriesRing(S, 30, "y", cached = true)[1]
+   @test PuiseuxSeriesRing(S, 30, "y")[1] === PuiseuxSeriesRing(S, 30, "y")[1]
 
    U, z = PuiseuxSeriesField(QQ, 30, "z")
 


### PR DESCRIPTION
With the advent of `RationalFunctionField` and the dummy example `ConstPolyRing`, we saw immutable parent rings. I don't disagree with the idea of immutable structs for the parents, but since each element is walking around with its parent attached, it would be a good idea to keep the bloat down. I see two ways
1. Parent with one member can be immutable, and in such case, the caching dictionary is useless, and the constructor should warn the user that caching cannot be turned off. This limit of one on number of members will prevent the explosion in size of nested ring constructs. Or
2. We always have mutable parent ring structs and dictionary for caching them.

This pr takes path 1 and moves PuiseuxSeries{Ring|Field} FracField to the immutable world while moving RationalFunctionField to the mutable world (for size reasons).