### PR TITLE
add WeakValueCache and fix WeakValueDict

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -325,9 +325,7 @@ include("WeakValueDict.jl")
 ###############################################################################
 
 @static if VERSION >= v"1.6"
-#  const CacheDictType = Dict
-  const CacheDictType = WeakValueCache
-#  const CacheDictType = WeakValueDict
+  const CacheDictType = WeakValueDict
 else
   const CacheDictType = Dict
 end

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -324,8 +324,10 @@ include("WeakValueDict.jl")
 #
 ###############################################################################
 
-@static if false # VERSION >= v"1.6"
-  const CacheDictType = WeakValueDict
+@static if VERSION >= v"1.6"
+#  const CacheDictType = Dict
+  const CacheDictType = WeakValueCache
+#  const CacheDictType = WeakValueDict
 else
   const CacheDictType = Dict
 end

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -324,13 +324,13 @@ include("WeakValueDict.jl")
 #
 ###############################################################################
 
-@static if false #VERSION >= v"1.6"
-  const CacheDictType = WeakValueDict
+@static if VERSION >= v"1.6"
+  const CacheDictType = WeakValueCache
 else
   const CacheDictType = Dict
 end
 
-function get_cached!(default::Base.Callable, dict::AbstractDict,
+function get_cached!(default::Base.Callable, dict,
                                              key,
                                              use_cache::Bool)
    return use_cache ? Base.get!(default, dict, key) : default()

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -324,8 +324,8 @@ include("WeakValueDict.jl")
 #
 ###############################################################################
 
-@static if VERSION >= v"1.6"
-  const CacheDictType = WeakValueCache
+@static if false # VERSION >= v"1.6"
+  const CacheDictType = WeakValueDict
 else
   const CacheDictType = Dict
 end

--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -322,7 +322,8 @@ function Base.get!(default, h::WeakValueCache{K, V}, key::K) where {K, V}
       index = -index
    end
    age0 = h.age
-   x = convert(V, default())
+   # the WeakRef makes value conversion essentially useless
+   x = default()::V
    if h.age == age0
       _setindex!(h, WeakRef(x), key, index)
    else
@@ -340,7 +341,6 @@ function setindex!(h::WeakValueCache{K, V}, v0, key0) where {K, V}
    setindex!(h, v0, key)
 end
 
-# the WeakRef makes key conversion essentially useless
 function setindex!(h::WeakValueCache{K, V}, v0, key::K) where {K, V}
    x = convert(V, v0)
    index = ht_keyindex2!(h, key)

--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -604,8 +604,6 @@ function Base.empty!(wkh::WeakValueDict)
     return wkh
 end
 
-#### the rest of these look dodgy
-
 function Base.haskey(wkh::WeakValueDict{K}, key) where {K}
     lock(wkh) do
         return haskey(wkh.ht, key)
@@ -613,11 +611,16 @@ function Base.haskey(wkh::WeakValueDict{K}, key) where {K}
 end
 function Base.getindex(wkh::WeakValueDict{K}, key) where {K}
     lock(wkh) do
-        return getindex(wkh.ht, key).value
+        x = getindex(wkh.ht, key).value
+        if x !== nothing
+            return x
+        end
+        throw(KeyError(key))
     end
 end
 
 Base.isempty(wkh::WeakValueDict) = length(wkh) == 0
+
 function Base.length(t::WeakValueDict)
     lock(t) do
         _cleanup_locked(t)

--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -1,63 +1,408 @@
 # Weak value containers
 
 import Base: isempty, setindex!, getkey, length, iterate, empty, delete!, pop!,
-       get, sizehint!, copy
+       get, sizehint!, copy, empty!, haskey, getindex
 
 ################################################################################
 #
 # WeakValueCache
+# This section is a modification of base/dict.jl from the Julia project to
+# support disappearing entries. It might work if isfinalized can be implemented.
 #
 ################################################################################
+
+#=
+The weak value containers cannot be useful without special modifications to the
+value types. Julia's original sin is that the WeakRef type is broken by design
+(https://github.com/JuliaLang/julia/issues/35169). A typical mutable object
+may have a life like
+
+   A. born
+   B. in use and modified by program
+   C. declared dead
+   D. some finalizers may be called on the object (or one of its members)
+   E. actually dead: object's memory is collected
+
+The problem is that .value of a WeakRef can be an object between D and E. Since
+the finalizers generally put the object into an invalid state, this is useless
+(the stated rationale for this terrible behaviour is that finalizers are capable
+of resurrecting objects from the dead, so state D -> B is possible).
+
+To have a somewhat working WeakValue dictionary or cache, it is necessary to
+know if the object has transitioned past D. For this, we make the assumption
+the finalizers attached do not resurrect objects from the dead, and the
+assumption that the validity of the objects can be determined by a method such
+as `isfinalized`. Examples:
+
+   1. NmodRing: here we have
+
+         mutable struct NmodRing <: Ring
+            n::UInt
+            ninv::UInt
+         end
+
+      and this is fine
+
+         isfinalized(x::NmodRing) = false
+
+   2. FmpzModRing: already things get bad because here we have
+
+         mutable struct FmpzModRing <: Ring
+            n::fmpz
+            ninv::fmpz_mod_ctx_struct
+            isfinalized::Bool          # possible addition to the struct
+         end
+
+      and the fictitious
+
+         isfinalized(x::FmpzModRing) = x.isfinalized
+
+      When this is declared dead, the object itself and the two members can be
+      finalized in any order. We could try not attaching a finalizer to the
+      .ninv, and have the finalizer for the FmpzModRing clean up the
+      .ninv member and set the .isfinalized member to true, but there is no way
+      to know if the finalizer on the .n has run or not, and thus the validity
+      of the FmpzModRing object cannot be determined without special treatment
+      of the .n member
+
+   3. For the arbitrarily nested rings in AA, one would have to essentially
+      reimplement the GC, which is not going to happen.
+=#
+
+# is x an invalid object? i.e. have finalizers on x or any part of x run?
+function isfinalized(x)
+   # v0.22 tests might pass with isfinalized(x) = false and
+   # CacheDictType = WeakValueCache, but this only by luck.
+   error("not implemented")
+   return false
+end
+
+# for the .value member of a WeakRef
+function isdead(x)
+   return x == nothing || isfinalized(x)
+end
+
 
 """
 `WeakValueCache()` constructs a hash table whose values may be collected at
 anytime and behave as if they have disappeared from the table once collected.
 Putting something into a weak value cache `d[k] = v` and not modifying the
 entry only necessarily means that `d[k] == v` at a later point in time if `v`
-is loosely _in use_ in between.
+is loosely _in use_ in between. `WeakValueCache` does not work unless the
+predicate `isfinalized` is properly implemented for the type of the values.
 """
 mutable struct WeakValueCache{K, V}
-   data::Dict{K, WeakRef}
-   gen::UInt32
+   slots::Vector{UInt8}
+   keys::Vector{K}
+   vals::Vector{WeakRef}
+   nmissing::Int
+   nfilled::Int
+   maxprobe::Int
+   age::UInt64
 
-   function WeakValueCache{K, V}() where {K, V}
-      return new{K, V}(Dict{K, WeakRef}(), 0)
+   function WeakValueCache{K, V}() where V where K
+      n = 16
+      new(zeros(UInt8,n), Vector{K}(undef, n), Vector{WeakRef}(undef, n), 0, 0, 0, 0)
    end
 end
 
-function _clean!(d::WeakValueCache)
-   iszero((d.gen += 1) % 256) || return
-   # It is not clear what this does, but it is supposed to at least try to
-   # cleanup some 'empty' entries, that is, entries whose .value member
-   # has become nothing. It doesn't have to cleanup everything, it would just
-   # be nice if it kept the number of empty entries from running away.
-   i = Base.skip_deleted_floor!(d.data)
-   while i != 0
-      if d.data.vals[i].value === nothing
-         Base._delete!(d.data, i)
+function Base.show(io::IO, h::WeakValueCache)
+   print(io, "\n")
+   for i in 1:max(length(h.slots), length(h.keys), length(h.vals))
+      show(io, i); print(io,": ");
+      isassigned(h.slots, i) ? show(io,h.slots[i]) : print(io, Base.undef_ref_str); print(io, ", ")
+      isassigned(h.keys, i) ? show(io, h.keys[i]) : print(io, Base.undef_ref_str); print(io, ", ")
+      if isassigned(h.vals, i)
+         show(io, h.vals[i])
+         x = h.vals[i].value
+         if !isdead(x) && !isimmutable(x)
+            print(io, " @ ")
+            show(io, pointer_from_objref(x))
+         end
+      else
+         print(io, Base.undef_ref_str)
       end
-      i = Base.skip_deleted(d.data, i + 1)
+      print(io, ", ")
+      print(io, "\n")
    end
+   print(io," nfilled: "); show(io, h.nfilled); print(io, "\n")
+   print(io,"nmissing: "); show(io, h.nmissing); print(io, "\n")
+   print(io,"maxprobe: "); show(io, h.maxprobe); print(io, "\n")
+   print(io,"age: "); show(io, h.age); print(io, "\n")
 end
 
-function Base.get!(default::Base.Callable, d::WeakValueCache, key)
-   if haskey(d.data, key)
-      x = d.data[key].value
-      x == nothing || return x
+_tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
+
+hashindex(key, sz) = (((hash(key)::UInt % Int) & (sz-1)) + 1)::Int
+
+isslotempty(h::WeakValueCache, i::Int) = h.slots[i] == 0x0
+isslotfilled(h::WeakValueCache, i::Int) = h.slots[i] == 0x1
+isslotmissing(h::WeakValueCache, i::Int) = h.slots[i] == 0x2
+
+function _isconsistent(h::WeakValueCache)
+   nfilled = nmissing = 0
+   for i in 1:length(h.slots)
+      nfilled += isslotfilled(h, i)
+      nmissing += isslotmissing(h, i)
    end
-   x = default()
-   Base.setindex!(d.data, WeakRef(x), key)
-   _clean!(d)
+   return nfilled == h.nfilled && nmissing == h.nmissing
+end
+
+# missing or filled or empty -> filled
+function _setindex!(h::WeakValueCache, v, key, index)
+   @assert _isconsistent(h)
+   h.keys[index] = key
+   h.vals[index] = v
+   if isslotfilled(h, index)
+      return h
+   elseif isslotmissing(h, index)
+      h.nmissing -= 1
+   end
+   h.nfilled += 1
+   h.slots[index] = 0x1
+   h.age += 1
+   sz = length(h.keys)
+   if h.nmissing*4 > sz*3 || h.nfilled*3 > sz*2
+      rehash!(h, h.nfilled > 64000 ? h.nfilled*2 : h.nfilled*4)
+   end
+   return h
+end
+
+# filled -> missing
+function _deleteindex!(h::WeakValueCache, index) where {K,V}
+   @assert _isconsistent(h)
+   @assert isslotfilled(h, index)
+   h.nfilled -= 1
+   h.nmissing += 1
+   h.slots[index] = 0x2
+   h.age += 1
+   Base._unsetindex!(h.keys, index)
+   Base._unsetindex!(h.vals, index)
+   return h
+end
+
+function rehash!(h::WeakValueCache{K,V}, newsz = length(h.keys)) where V where K
+   olds = h.slots
+   oldk = h.keys
+   oldv = h.vals
+   sz = length(olds)
+   newsz = _tablesz(newsz)
+   h.age += 1
+   if h.nfilled == 0
+      resize!(h.slots, newsz)
+      fill!(h.slots, 0x0)
+      resize!(h.keys, newsz)
+      resize!(h.vals, newsz)
+      h.nmissing = 0
+      return h
+   end
+   slots = zeros(UInt8, newsz)
+   keys = Vector{K}(undef, newsz)
+   vals = Vector{WeakRef}(undef, newsz)
+   count = 0
+   maxprobe = 0
+   for i = 1:sz
+      if olds[i] == 0x1
+         k = oldk[i]
+         v = oldv[i]
+         if !isdead(v.value)
+            index0 = index = hashindex(k, newsz)
+            while slots[index] != 0x0
+               index = (index & (newsz-1)) + 1
+            end
+            probe = (index - index0) & (newsz-1)
+            maxprobe = max(maxprobe, probe)
+            slots[index] = 0x1
+            keys[index] = k
+            vals[index] = v
+            count += 1
+         end
+      end
+   end
+   h.slots = slots
+   h.keys = keys
+   h.vals = vals
+   h.nfilled = count
+   h.nmissing = 0
+   h.maxprobe = maxprobe
+   return h
+end
+
+function empty!(h::WeakValueCache{K,V}) where V where K
+   fill!(h.slots, 0x0)
+   sz = length(h.slots)
+   empty!(h.keys)
+   empty!(h.vals)
+   resize!(h.keys, sz)
+   resize!(h.vals, sz)
+   h.nmissing = 0
+   h.nfilled = 0
+   h.age += 1
+   return h
+end
+
+# get the index where a key is stored, or -1 if not present
+function ht_keyindex(h::WeakValueCache{K,V}, key) where V where K
+   sz = length(h.keys)
+   iter = 0
+   index = hashindex(key, sz)
+   while iter <= h.maxprobe
+      if isslotempty(h, index)
+         break
+      elseif isslotfilled(h, index)
+         x = h.vals[index].value
+         if isdead(x)
+            # filled -> missing
+            _deleteindex!(h, index)
+         elseif key === h.keys[index] || isequal(key, h.keys[index])
+            return index
+         end
+      end
+      index = (index & (sz-1)) + 1
+      iter += 1
+   end
+   return -1
+end
+
+# get the index where a key is stored, or -pos if not present
+# and the key would be inserted at pos
+# This version is for use by setindex! and get!
+function ht_keyindex2!(h::WeakValueCache{K,V}, key) where V where K
+   sz = length(h.keys)
+   iter = 0
+   index = hashindex(key, sz)
+   avail = 0
+   while iter <= h.maxprobe
+      if isslotempty(h, index)
+         return avail < 0 ? avail : -index
+      elseif isslotmissing(h, index)
+         if avail == 0
+            # found an available slot, but need to keep scanning
+            # in case "key" already exists in a later collided slot.
+            avail = -index
+         end
+      else
+         x = h.vals[index].value
+         if isdead(x)
+            # filled -> missing
+            _deleteindex!(h, index)
+            if avail == 0
+               # ditto
+               avail = -index
+            end
+         elseif key === h.keys[index] || isequal(key, h.keys[index])
+            return index
+         end
+      end
+      index = (index & (sz-1)) + 1
+      iter += 1
+   end
+   avail < 0 && return avail
+   # Check if key is not present, may need to keep searching to find slot
+   while iter <= max(16, sz>>6)
+      if isslotfilled(h,index)
+         x = h.vals[index].value
+         if isdead(x)
+            h.maxprobe = iter
+            return -index
+         end
+      else
+         h.maxprobe = iter
+         return -index
+      end
+      index = (index & (sz-1)) + 1
+      iter += 1
+   end
+   rehash!(h, h.nfilled > 64000 ? sz*2 : sz*4)
+   return ht_keyindex2!(h, key)
+end
+
+### delete! ####
+
+function delete!(h::WeakValueCache, key)
+   index = ht_keyindex(h, key)
+   if index > 0
+      _deleteindex!(h, index)
+   end
+   return h
+end
+
+### getindex / haskey ####
+
+function haskey(h::WeakValueCache, key)
+   index = ht_keyindex(h, key)
+   return index > 0 && !isdead(h.vals[index].value)
+end
+
+function getindex(h::WeakValueCache{K, V}, key) where {K, V}
+   index = ht_keyindex(h, key)
+   if index > 0
+      x = h.vals[index].value
+      if !isdead(x)
+         return x::V
+      end
+   end
+   throw(KeyError(key))
+end
+
+### get! ####
+
+function Base.get!(default::Base.Callable, h::WeakValueCache{K, V}, key0) where {K, V}
+   key = convert(K, key0)
+   isequal(key, key0) || throw(ArgumentError("$key0 is not a valid key for type $K"))
+   return get!(default, h, key)
+end
+
+function Base.get!(default::Base.Callable, h::WeakValueCache{K, V}, key::K) where {K, V}
+   index = ht_keyindex2!(h, key)
+   if index > 0
+      x = h.vals[index].value
+      if !isdead(x)
+         return x::V
+      end
+   else
+      index = -index
+   end
+   age0 = h.age
+   x = convert(V, default())
+   if h.age == age0
+      _setindex!(h, WeakRef(x), key, index)
+   else
+      # the call to default could have changed the internals of h
+      setindex!(h, x, key)
+   end
    return x
+end
+
+### setindex! ####
+
+function setindex!(h::WeakValueCache{K, V}, v0, key0) where {K, V}
+   key = convert(K, key0)
+   isequal(key, key0) || throw(ArgumentError("$key0 is not a valid key for type $K"))
+   setindex!(h, v0, key)
+end
+
+function setindex!(h::WeakValueCache{K, V}, v0, key::K) where V where K
+   x = convert(V, v0)
+   index = ht_keyindex2!(h, key)
+   _setindex!(h, WeakRef(x), key, abs(index))
+   return h
 end
 
 
 ################################################################################
 #
 # WeakValueDict
-# This section is a modification of base/weakkeydict.jl from the Julia project.
+# This section is a modification of base/weakkeydict.jl from the Julia project,
+#  and cannot be made to work without substantial changes.
 #
 ################################################################################
+
+#=
+This WeakValueDict is broken because it does not attempt to recognize invalid
+objects. The locks here are used to prevent finalizers from running while the
+internal ht is being modified/inspected, but this neither useful nor necessary.
+=#
 
 """
     WeakValueDict([itr])

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -97,11 +97,22 @@ function test_weak_cache(T, kreps, ireps)
    GC.@preserve x y begin
       ddef[1] = x
       ddef[2] = y
+
       # test get! where default modifies d
       get!(d, 2) do; d[1] = x; return y; end
       @test d[1] == x
       @test d[2] == y
       @test length(string(d)) > 3
+
+      @test_throws KeyError d[3]
+   end
+
+   d[3] = BigInt(4)
+   GC.gc(true)
+   try z = d[3]
+      @test z == 4
+   catch e
+      @test e isa KeyError
    end
 
    empty!(d)

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -110,6 +110,10 @@ function test_weak_cache(T, kreps, ireps)
    GC.@preserve x y begin
       d[x] = y
       @test (get(d, x) do; return BigInt(3); end) isa BigInt
+
+      @test pop!(d, x) == y
+      @test_throws KeyError pop!(d, x)
+      @test pop!(d, x, y) === y
    end
 end
 

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -94,13 +94,23 @@ function test_weak_cache(T, kreps, ireps)
    empty!(ddef)
    x = BigInt(1)
    y = BigInt(2)
-   ddef[1] = x
-   ddef[2] = y
-   # test get! where default modifies d
-   get!(d, 2) do; d[1] = x; return y; end
-   @test d[1] == x
-   @test d[2] == y
-   @test length(string(d)) > 3
+   GC.@preserve x y begin
+      ddef[1] = x
+      ddef[2] = y
+      # test get! where default modifies d
+      get!(d, 2) do; d[1] = x; return y; end
+      @test d[1] == x
+      @test d[2] == y
+      @test length(string(d)) > 3
+   end
+
+   empty!(d)
+   x = BigInt(1)
+   y = BigInt(2)
+   GC.@preserve x y begin
+      d[x] = y
+      @test (get(d, x) do; return BigInt(3); end) isa BigInt
+   end
 end
 
 

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -126,6 +126,27 @@ function test_weak_cache(T, kreps, ireps)
       @test_throws KeyError pop!(d, x)
       @test pop!(d, x, y) === y
    end
+
+   x = BigInt(1)
+   y = BigInt(2)
+   z = BigInt(3)
+   GC.@preserve x y z begin
+      D = T{BigInt, BigInt}(1=>x)
+      @test D[1] === x
+      @test_throws KeyError D[2]
+
+      D = T{BigInt, BigInt}(1=>x, 2=>y, 3=>z)
+      @test D[1] === x
+      @test D[2] === y
+      @test D[3] === z
+      @test_throws KeyError D[4]
+
+      D = T{BigInt, BigInt}([(1,x), (2,y), (3,z)])
+      @test D[1] === x
+      @test D[2] === y
+      @test D[3] === z
+      @test_throws KeyError D[4]
+   end
 end
 
 

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -1,15 +1,13 @@
-WeakValueCache = AbstractAlgebra.WeakValueCache
 WeakValueDict = AbstractAlgebra.WeakValueDict
 
-if VERSION >= v"1.6"
-@testset "WeakValueCache" begin
-   d = WeakValueCache{BigInt, BigInt}()
+function test_weak_cache(T, kreps, ireps)
+   d = T{BigInt, BigInt}()
    # keys missing from/present in ddeg are definitely missing from/present in d
    ddef  = Dict{BigInt, BigInt}()
    # if a key is in d, its value should match that of dmay
    dmay  = Dict{BigInt, BigInt}()
-   for k in 1:30
-      for i in 1:20
+   for k in 1:kreps
+      for i in 1:ireps
          for j in 1:2
             x = BigInt(rand(1:999))
             y = BigInt(rand(1:999))
@@ -49,8 +47,8 @@ if VERSION >= v"1.6"
    empty!(d)
    empty!(ddef)
    empty!(dmay)
-   for k in 1:30
-      for i in 1:20
+   for k in 1:kreps
+      for i in 1:ireps
          for j in 1:2
             x = BigInt(rand(1:999))
             y = BigInt(rand(1:999))
@@ -89,22 +87,34 @@ if VERSION >= v"1.6"
       GC.gc(true)
    end
 
-   # test get! where default modifies d
    empty!(d)
-   AbstractAlgebra.rehash!(d, 5)
+   if T === AbstractAlgebra.WeakValueCache
+      AbstractAlgebra.rehash!(d, 5) # test internal function
+   end
    empty!(ddef)
    x = BigInt(1)
    y = BigInt(2)
    ddef[1] = x
    ddef[2] = y
+   # test get! where default modifies d
    get!(d, 2) do; d[1] = x; return y; end
    @test d[1] == x
    @test d[2] == y
    @test length(string(d)) > 3
 end
-end # if VERSION >= v"1.6"
+
+
+@testset "WeakValueCache" begin
+   if VERSION >= v"1.6"
+      test_weak_cache(AbstractAlgebra.WeakValueCache, 30, 20)
+   end
+end
 
 @testset "WeakValueDict" begin
+   if VERSION >= v"1.6"
+      test_weak_cache(AbstractAlgebra.WeakValueDict, 30, 20)
+   end
+
     A = [1]
     B = [2]
     C = [3]

--- a/test/WeakValueDict-test.jl
+++ b/test/WeakValueDict-test.jl
@@ -1,9 +1,12 @@
 WeakValueCache = AbstractAlgebra.WeakValueCache
 WeakValueDict = AbstractAlgebra.WeakValueDict
 
+if VERSION >= v"1.6"
 @testset "WeakValueCache" begin
    d = WeakValueCache{BigInt, BigInt}()
+   # keys missing from/present in ddeg are definitely missing from/present in d
    ddef  = Dict{BigInt, BigInt}()
+   # if a key is in d, its value should match that of dmay
    dmay  = Dict{BigInt, BigInt}()
    for k in 1:30
       for i in 1:20
@@ -99,6 +102,7 @@ WeakValueDict = AbstractAlgebra.WeakValueDict
    @test d[2] == y
    @test length(string(d)) > 3
 end
+end # if VERSION >= v"1.6"
 
 @testset "WeakValueDict" begin
     A = [1]


### PR DESCRIPTION
I am not interested ATM in making a WeakValueDict, partly because it has many superfluous requirements, partly because I don't like locks in single-threaded code, and mainly because I don't see how it can coherently fulfill the dictionary interface.
I have not observed the AA or Nemo test code failing with this WeakValueCache, but to be fair, I did not observed the WeakValueDict failing on the same machine.