### PR TITLE
Adjust heading in universal polynomial ring docs

### DIFF
--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -18,7 +18,7 @@ would consist of two integers. Later, when the ring has more variable, these
 exponent vectors will still be accepted. The exponent vectors are simply padded
 out to the full number of variables behind the scenes.
 
-## Generic sparse distributed multivariable polynomial types
+## Generic sparse distributed universal multivariable polynomial types
 
 AbstractAlgebra provides a generic universal polynomial type `Generic.UnivPoly{T, U}`
 where `T` is the type of elements of the coefficient ring and `U` is the type of


### PR DESCRIPTION
The same heading already exists in the multivariate docs, which broke the reference to the heading "Generic sparse distributed multivariable polynomial types" in the Oscar docs.

We could work around this in another way preserving the heading, but I think it makes sense to sprinkle in the word "universal".
