### PR TITLE
Implement block_diagonal_matrix constructors

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -245,6 +245,41 @@ julia> M = R()
 [0   0]
 ```
 
+## Block matrix constructors
+
+It is also possible to create block diagonal matrices from a vector of
+existing matrices. It is also possible to construct them from Julia
+matrices if one supplies the base ring.
+
+```@docs
+block_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
+block_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
+```
+
+**Examples**
+
+```jldoctest
+julia> block_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> N = matrix(ZZ, [4 5 6; 7 8 9])
+[4   5   6]
+[7   8   9]
+
+julia> block_matrix([M, N])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+```
+
 ## Conversion to Julia matrices and iteration
 
 While `AbstractAlgebra` matrices are not instances of `AbstractArray`,

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -245,21 +245,24 @@ julia> M = R()
 [0   0]
 ```
 
-## Block matrix constructors
+## Block diagonal matrix constructors
 
 It is also possible to create block diagonal matrices from a vector of
 existing matrices. It is also possible to construct them from Julia
 matrices if one supplies the base ring.
 
+Note that if the input matrices are not square, the output matrix may
+not be square.
+
 ```@docs
-block_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
-block_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
+block_diagonal_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
+block_diagonal_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
 ```
 
 **Examples**
 
 ```jldoctest
-julia> block_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
+julia> block_diagonal_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
 [1   2   0   0   0]
 [3   4   0   0   0]
 [0   0   4   5   6]
@@ -273,7 +276,7 @@ julia> N = matrix(ZZ, [4 5 6; 7 8 9])
 [4   5   6]
 [7   8   9]
 
-julia> block_matrix([M, N])
+julia> block_diagonal_matrix([M, N])
 [1   2   0   0   0]
 [3   4   0   0   0]
 [0   0   4   5   6]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 export MatrixSpace, add_column, add_column!, add_row, add_row!,
-       block_matrix, can_solve,
+       block_diagonal_matrix, can_solve,
        can_solve_left_reduced_triu, can_solve_with_kernel,
        can_solve_with_solution,  can_solve_with_solution_interpolation,
        charpoly, charpoly_danilevsky!, charpoly_danilevsky_ff!,
@@ -262,17 +262,17 @@ end
 
 ###############################################################################
 #
-#   Block matrices    
+#   Block diagonal matrices    
 #
 ###############################################################################
 
 @doc Markdown.doc"""
-    block_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
+    block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
 
 Create the block diagonal matrix whose blocks are given by the matrices in `V`.
 There must be at least one matrix in V.
 """
-function block_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
+function block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
    length(V) > 0 || error("At least one matrix is required")
    rows = sum(nrows(N) for N in V)
    cols = sum(ncols(N) for N in V)
@@ -301,14 +301,14 @@ function block_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
 end
 
 @doc Markdown.doc"""
-   block_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
+   block_diagonal_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
 
 Create the block diagonal matrix over the ring `R` whose blocks are given
 by the matrices in `V`. Entries are coerced into `R` upon creation.
 """
-function block_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
+function block_diagonal_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
    if length(V) == 0
-      return matrix(R, Matrix{T}(undef, (0, 0)))
+      return zero_matrix(R, 0, 0)
    end
    rows = sum(size(N)[1] for N in V)
    cols = sum(size(N)[2] for N in V)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -297,12 +297,12 @@ end
    N = matrix(ZZ, N1)
    K = matrix(ZZ, K1)
 
-   @test block_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
-   @test block_matrix([K]) == matrix(ZZ, 2, 0, [])
+   @test block_diagonal_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
+   @test block_diagonal_matrix([K]) == matrix(ZZ, 2, 0, [])
 
-   @test block_matrix(ZZ, Matrix{Int}[]) == matrix(ZZ, 0, 0, [])
-   @test block_matrix(ZZ, [M1, N1, K1]) == block_matrix([M, N, K])
-   @test block_matrix(ZZ, [K1]) == block_matrix([K])
+   @test block_diagonal_matrix(ZZ, Matrix{Int}[]) == matrix(ZZ, 0, 0, [])
+   @test block_diagonal_matrix(ZZ, [M1, N1, K1]) == block_diagonal_matrix([M, N, K])
+   @test block_diagonal_matrix(ZZ, [K1]) == block_diagonal_matrix([K])
 end
 
 @testset "Generic.Mat.size/axes" begin

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -288,6 +288,21 @@ end
    M = S(A)
 
    @test A[1, 1] === a
+
+   M1 = [1 2; 3 4]
+   N1 = [5 6 7; 8 9 10]
+   K1 = Matrix{Int}(undef, (2, 0))
+
+   M = matrix(ZZ, M1)
+   N = matrix(ZZ, N1)
+   K = matrix(ZZ, K1)
+
+   @test block_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
+   @test block_matrix([K]) == matrix(ZZ, 2, 0, [])
+
+   @test block_matrix(ZZ, Matrix{Int}[]) == matrix(ZZ, 0, 0, [])
+   @test block_matrix(ZZ, [M1, N1, K1]) == block_matrix([M, N, K])
+   @test block_matrix(ZZ, [K1]) == block_matrix([K])
 end
 
 @testset "Generic.Mat.size/axes" begin


### PR DESCRIPTION
There are two versions, one which accepts a ring and a vector of Julia matrices and another which accepts a vector of AA matrices.