### PR TITLE
implement `copy` for young tableaux

### DIFF
--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -387,6 +387,8 @@ end
 
 hash(Y::YoungTableau, h::UInt) = hash(Y.part, hash(Y.fill, hash(typeof(Y), h)))
 
+Base.copy(Y::YoungTableau) = YoungTableau(Y.part, copy(Y.fill))
+
 ##############################################################################
 #
 #   String I/O for YoungTableaux

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -72,7 +72,7 @@ end
    end
 
    Z = copy(Y)
-   @test Z isa YoungTableau
+   @test Z isa Generic.YoungTableau
    @test Y == Z
    @test Z.fill !== Y.fill
 end

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -70,6 +70,11 @@ end
    for i in 1:sum(Y.part)
      @test Y[something(findfirst(isequal(i), Y), 0)] == i
    end
+
+   Z = copy(Y)
+   @test Z isa YoungTableau
+   @test Y == Z
+   @test Z.fill !== Y.fill
 end
 
 @testset "youngtabs.conjugation" begin


### PR DESCRIPTION
Otherwise this falls back to the generic `AbstractArray` method which produces a `Matrix`. I wasn't quite sure whether the partition should be copied as well, but decided against that for now, since a tableau is treated like a matrix, so only the entries are really supposed to be copied, not the shape.