### PR TITLE
Fix compose signature

### DIFF
--- a/src/Map.jl
+++ b/src/Map.jl
@@ -22,7 +22,7 @@ set_field!(M, f, g) = setfield!(M, f, g) # fall back to Julia builtin
 domain(f::Map) = get_field(f, :domain)
 codomain(f::Map) = get_field(f, :codomain)
 
-function check_composable(a::Map{D, U}, b::Map{U, C}) where {D, U, C}
+function check_composable(a::Map, b::Map)
    codomain(a) != domain(b) && error("Incompatible maps")
 end
 
@@ -32,7 +32,7 @@ end
 #
 ###############################################################################
 
-function compose(f::Map{D, U}, g::Map{U, C}) where {D, U, C}
+function compose(f::Map, g::Map)
    check_composable(f, g)
    return Generic.CompositeMap(f, g)
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1011,8 +1011,8 @@ mutable struct CompositeMap{D, C} <: AbstractAlgebra.Map{D, C, AbstractAlgebra.S
    map1::AbstractAlgebra.Map
    map2::AbstractAlgebra.Map
 
-   function CompositeMap(map1::AbstractAlgebra.Map{D, U}, map2::AbstractAlgebra.Map{U, C}) where {D, U, C}
-      return new{D, C}(domain(map1), codomain(map2), map1, map2)
+   function CompositeMap(map1, map2)
+     return new{typeof(domain(map1)), typeof(codomain(map2))}(domain(map1), codomain(map2), map1, map2)
    end
 end
 

--- a/test/generic/Map-test.jl
+++ b/test/generic/Map-test.jl
@@ -67,6 +67,13 @@ end
 
    @test map1(t) === f
    @test map2(t) === s
+
+   V = FreeModule(QQ, 2)
+   f = AbstractAlgebra.ModuleHomomorphism(V, V, QQ[1 1; 1 2])
+   g = identity_map(V)
+   h = f * g
+   @test domain(h) == V
+   @test codomain(h) == V
 end
 
 @testset "Generic.Map.IdentityMap" begin


### PR DESCRIPTION
The restriction on the signature of the compose functions does not
work together with the design of module morphisms. Here is an example:
```julia
julia> using Revise, AbstractAlgebra

julia> V = FreeModule(QQ, 2)
Vector space of dimension 2 over Rationals

julia> f = AbstractAlgebra.ModuleHomomorphism(V, V, QQ[1 1; 1 2])
Module homomorphism with
Domain: V
Codomain: V

julia> g = identity_map(V)
Identity map with

Domain:
=======
Vector space of dimension 2 over Rationals

julia> f * g
ERROR: MethodError: no method matching compose(::AbstractAlgebra.Generic.ModuleHomomorphism{Rational{BigInt}}, ::AbstractAlgebra.Generic.IdentityMap{AbstractAlgebra.Generic.FreeModule{Rational{BigInt}}})
Closest candidates are:
  compose(::Map{D, D, var"#s451", T} where {T, var"#s451"<:IdentityMap}, ::Map{D, D, var"#s451", T} where {T, var"#s451"<:IdentityMap}) where D at /Users/thofma/.julia/dev/AbstractAlgebra/src/generic/Map.jl:64
  compose(::Map{D, C, var"#s451", T} where {D, C, T, var"#s451"<:AbstractAlgebra.FPModuleHomomorphism}, ::Map{D, C, var"#s451", T} where {D, C, T, var"#s451"<:AbstractAlgebra.FPModuleHomomorphism}) at /Users/thofma/.julia/dev/AbstractAlgebra/src/ModuleHomomorphism.jl:40
  compose(::Map{D, U, var"#s451", T} where {T, var"#s451"<:FunctionalMap}, ::Map{U, C, var"#s451", T} where {T, var"#s451"<:FunctionalMap}) where {D, U, C} at /Users/thofma/.julia/dev/AbstractAlgebra/src/Map.jl:67
```
See #1052 for more details on why the previous implementation could not work.