### PR TITLE
Rational root functions

### DIFF
--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -141,19 +141,10 @@ julia> n = numerator(r)
 The functionality below supplements that provided by Julia itself for its
 `Rational{BigInt}` type.
 
-### Square root
+### Square and n-th root
 
-```@docs
-AbstractAlgebra.sqrt(a::Rational{BigInt})
-```
-
-```@docs
-issquare(a::Rational{BigInt})
-```
-
-```@docs
-AbstractAlgebra.exp(a::Rational{BigInt})
-```
+The functions `sqrt`, `issquare`, `issquare_with_sqrt` are all provided, as are
+`root`, `ispower` and `ispower_with_root`.
 
 **Examples**
 
@@ -164,8 +155,8 @@ julia> d = AbstractAlgebra.sqrt(ZZ(36)//ZZ(25))
 julia> issquare(ZZ(9)//ZZ(16))
 true
 
-julia> m = AbstractAlgebra.exp(ZZ(0)//ZZ(1))
-1//1
+julia> root(ZZ(27)//64, 3)
+3//4
 ```
 
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -245,9 +245,8 @@ sqrt_residues = [[0, 1], [0, 1, 4], [0, 1, 2, 4], [0, 1, 4]]
 @doc Markdown.doc"""
     sqrt(a::T; check::Bool=true) where T <: Integer
 
-Return the integer square root of $a$. By default the function will
-throw an exception if the input is not square. If `check=false` this test is
-omitted.
+Return the square root of $a$. By default the function will throw an exception
+if the input is not square. If `check=false` this test is omitted.
 """
 function sqrt(a::T; check::Bool=true) where T <: Integer
    s = isqrt(a)
@@ -294,7 +293,6 @@ function issquare_with_sqrt(a::BigInt)
    end
 end
 
-
 @doc Markdown.doc"""
     issquare(a::T) where T <: Integer
 
@@ -338,7 +336,7 @@ end
 
 Return the $n$-th root of $a$. If `check=true` the function will test if the
 input was a perfect $n$-th power, otherwise an exception will be raised. We
-require $n > 0$ and also $a \geq 0$ if $n$ is even.
+require $n > 0$.
 """
 function root(a::T, n::Int; check::Bool=true) where T <: Integer
    if n == 2
@@ -421,7 +419,7 @@ end
 @doc Markdown.doc"""
     ispower(a::T, n::Int) where T <: Integer
 
-Return `true` if $a$ is a perfect $n$-th power, i.e. if there is an integer $b$
+Return `true` if $a$ is a perfect $n$-th power, i.e. if there is a $b$
 such that $a = b^n$. We require $n > 0$.
 """
 function ispower(a::T, n::Int) where T <: Integer

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -166,31 +166,14 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    sqrt(a::Rational{T}; check::Bool=true) where T <: Integer
-
-Return the square root of $a$. By default the function throws an exception if
-the input is not square. If `check=false` this check is supressed.
-"""
 function sqrt(a::Rational{T}; check::Bool=true) where T <: Integer
    return sqrt(numerator(a, false); check=check)//sqrt(denominator(a, false); check=check)
 end
 
-@doc Markdown.doc"""
-    issquare(a::Rational{T}) where T <: Integer
-
-Return `true` if $a$ is the square of a rational.
-"""
 function issquare(a::Rational{T}) where T <: Integer
    return issquare(numerator(a)) && issquare(denominator(a))
 end
 
-@doc Markdown.doc"""
-    issquare_with_sqrt(a::Rational{T}) where T <: Integer
-
-Return `true, s` if $a$ is the square of a rational where `s` is a square root.
-Otherwise return `false, 0`.
-"""
 function issquare_with_sqrt(a::Rational{T}) where T <: Integer
    f1, s1 = issquare_with_sqrt(numerator(a))
    if !f1
@@ -201,6 +184,34 @@ function issquare_with_sqrt(a::Rational{T}) where T <: Integer
       return false, zero(T)
    end
    return true, s1//s2
+end
+
+###############################################################################
+#
+#   Root
+#
+###############################################################################
+
+function root(a::Rational{T}, n::Int; check::Bool=true) where T <: Integer
+   num = root(numerator(a, false), n; check=check)
+   den = root(denominator(a, false), n; check=check)   
+   return num//den
+end
+
+function ispower(a::Rational{T}, n::Int) where T <: Integer
+   return ispower(numerator(a), n) && ispower(denominator(a), n)
+end
+
+function ispower_with_root(a::Rational{T}, n::Int) where T <: Integer
+   f1, r1 = ispower_with_root(numerator(a), n)
+   if !f1
+      return false, zero(T)
+   end
+   f2, r2 = ispower_with_root(denominator(a), n)
+   if !f2
+      return false, zero(T)
+   end
+   return true, r1//r2
 end
 
 ###############################################################################

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -125,6 +125,65 @@ end
    @test issquare_with_sqrt(S(3, 7)) == (false, 0)
 end
 
+@testset "Julia.Rationals.root" begin
+   @test root(BigInt(1000)//27, 3) == 10//3
+   @test root(-BigInt(27)//343, 3) == -3//7
+   @test root(BigInt(27)//1331, 3; check=true) == 3//11
+   @test root(BigInt(16)//9, 2; check=true) == 4//3
+
+   @test_throws DomainError root(-BigInt(1000)//81, 4)
+   @test_throws DomainError root(BigInt(1000)//81, -3)
+   @test_throws DomainError root(BigInt(-16)//27, 2)
+
+   @test_throws ErrorException root(BigInt(1100)//27, 3)
+   @test_throws ErrorException root(BigInt(27)//1100, 3)
+   @test_throws ErrorException root(BigInt(1100)//13, 3)
+   @test_throws ErrorException root(-BigInt(40)//27, 3)
+   @test_throws ErrorException root(-BigInt(27)//4, 3)
+
+   @test root(1000//27, 3) == 10//3
+   @test root(-27//343, 3) == -3//7
+   @test root(27//1331, 3) == 3//11
+   @test root(16//9, 2) == 4//3
+
+   @test_throws DomainError root(-1000//81, 4)
+   @test_throws DomainError root(1000//81, -3)
+   @test_throws DomainError root(-16//27, 2)
+
+   @test_throws ErrorException root(1100//27, 3)
+   @test_throws ErrorException root(27//1100, 3)
+   @test_throws ErrorException root(1100//13, 3)
+   @test_throws ErrorException root(-40//27, 3)
+   @test_throws ErrorException root(-27//4, 3)
+
+   for T in [BigInt, Int]
+      for i = 1:1000
+         n = rand(1:20)
+         a = BigInt(rand(-1000:1000))
+         if iseven(n)
+            a = abs(a)
+         end
+         b = BigInt(rand(1:1000))
+         p = a^n
+         q = b^n
+         if T == BigInt || (ndigits(p; base=2) < ndigits(typemax(T); base=2) &&
+                            ndigits(q; base=2) < ndigits(typemax(T); base=2))
+            p = T(p)
+            q = T(q)
+
+            @test ispower(p//q, n)
+
+            flag, r = ispower_with_root(p//q, n)
+
+            @test flag && r == a//b
+         end
+      end
+
+      @test_throws DomainError ispower(Rational{T}(5//3), -1)
+      @test_throws DomainError ispower_with_root(Rational{T}(5//3), 0)
+   end
+end
+
 @testset "Julia.Rationals.exp" begin
    @test AbstractAlgebra.exp(0//1) == 1
    @test_throws DomainError AbstractAlgebra.exp(1//1)


### PR DESCRIPTION
* Add root, ispower and ispower_with_root for rationals
* Make docstrings for root, sqrt and friends more generic (so they apply to other rings as well)
* Remove docstrings for sqrt and friends in Rational.jl (rely on the more generic docstrings)