### PR TITLE
Remove mutation for julia types

### DIFF
--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -126,6 +126,9 @@ end
 #
 ###############################################################################
 
+# No actual mutation is permitted for Julia types
+# See #1077
+
 function zero!(a::T) where T <: AbstractFloat
    return T(0)
 end

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -126,69 +126,28 @@ end
 #
 ###############################################################################
 
-function zero!(a::AbstractFloat)
-   return 0
-end
-
-function zero!(a::BigFloat)
-   ccall((:mpfr_set_si, :libmpfr), Nothing,
-         (Ref{BigFloat}, Int, Int32), a, 0, Base.MPFR.ROUNDING_MODE[])
-   return a
+function zero!(a::T) where T <: AbstractFloat
+   return T(0)
 end
 
 function mul!(a::T, b::T, c::T) where T <: AbstractFloat
    return b*c
 end
 
-function mul!(a::BigFloat, b::BigFloat, c::BigFloat)
-   ccall((:mpfr_mul, :libmpfr), Nothing,
-         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                 a, b, c, Base.MPFR.ROUNDING_MODE[])
-   return a
-end
-
 function add!(a::T, b::T, c::T) where T <: AbstractFloat
    return b + c
-end
-
-function add!(a::BigFloat, b::BigFloat, c::BigFloat)
-   ccall((:mpfr_add, :libmpfr), Nothing,
-         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                 a, b, c, Base.MPFR.ROUNDING_MODE[])
-   return a
 end
 
 function addeq!(a::T, b::T) where T <: AbstractFloat
    return a + b
 end
 
-function addeq!(a::BigFloat, b::BigFloat)
-   ccall((:mpfr_add, :libmpfr), Nothing,
-         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                 a, a, b, Base.MPFR.ROUNDING_MODE[])
-   return a
-end
-
 function addmul!(a::T, b::T, c::T, d::T) where T <: AbstractFloat
    return a + b*c
 end
 
-function addmul!(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat)
-   ccall((:mpfr_fma, :libmpfr), Nothing,
-         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                 a, b, c, a, Base.MPFR.ROUNDING_MODE[])
-   return a
-end
-
 function addmul!(a::T, b::T, c::T) where T <: AbstractFloat # special case, no temporary required
    return a + b*c
-end
-
-function addmul!(a::BigFloat, b::BigFloat, c::BigFloat) # special case, no temporary required
-   ccall((:mpfr_fma, :libmpfr), Nothing,
-         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                 a, b, c, a, Base.MPFR.ROUNDING_MODE[])
-   return a
 end
 
 ###############################################################################

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -540,6 +540,9 @@ end
 #
 ###############################################################################
 
+# No actual mutation is permitted for Julia types
+# See #1077
+
 function zero!(a::T) where T <: Integer
    return T(0)
 end

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -540,58 +540,28 @@ end
 #
 ###############################################################################
 
-function zero!(a::Integer)
-   return 0
-end
-
-function zero!(a::BigInt)
-   ccall((:__gmpz_set_si, :libgmp), Nothing, (Ref{BigInt}, Int), a, 0)
-   return a
+function zero!(a::T) where T <: Integer
+   return T(0)
 end
 
 function mul!(a::T, b::T, c::T) where T <: Integer
    return b*c
 end
 
-function mul!(a::BigInt, b::BigInt, c::BigInt)
-   ccall((:__gmpz_mul, :libgmp), Nothing, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
-   return a
-end
-
 function add!(a::T, b::T, c::T) where T <: Integer
    return b + c
-end
-
-function add!(a::BigInt, b::BigInt, c::BigInt)
-   ccall((:__gmpz_add, :libgmp), Nothing, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
-   return a
 end
 
 function addeq!(a::T, b::T) where T <: Integer
    return a + b
 end
 
-function addeq!(a::BigInt, b::BigInt)
-   ccall((:__gmpz_add, :libgmp), Nothing, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, a, b)
-   return a
-end
-
 function addmul!(a::T, b::T, c::T, d::T) where T <: Integer
    return a + b*c
 end
 
-function addmul!(a::BigInt, b::BigInt, c::BigInt, d::BigInt)
-   ccall((:__gmpz_addmul, :libgmp), Nothing, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
-   return a
-end
-
 function addmul!(a::T, b::T, c::T) where T <: Integer # special case, no temporary required
    return a + b*c
-end
-
-function addmul!(a::BigInt, b::BigInt, c::BigInt) # special case, no temporary required
-   ccall((:__gmpz_addmul, :libgmp), Nothing, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
-   return a
 end
 
 ###############################################################################

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -245,6 +245,9 @@ end
 #
 ###############################################################################
 
+# No actual mutation is permitted for Julia types
+# See #1077
+
 function zero!(a::Rational{T}) where T <: Integer
    n = a.num
    n = zero!(n)

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2807,6 +2807,15 @@ end
       @test !f1 || f == s1^2
    end
 
+   f = x^2 + x + 1//4
+
+   @test issquare(f) # duplication intended, see #1075
+   @test issquare(f) # duplication intended, see #1075
+
+   f = -1//8*x^17 - 11//16*x^16 + 1//2*x^15 - 1//3*x^14 + 4//3*x^13 + 3//5*x^12 + 5//4*x^11 - 7//15*x^10 + 1//5*x^9 + 1//4*x^8 + 1//3*x^7 - 2*x^6 + 8//3*x^5 + 14*x^4 - x^2 + 9//2*x - 2//7
+
+   @test issquare(f^2) # see #1075
+
    # Characteristic p field
    for p in [2, 7, 19, 65537, ZZ(2), ZZ(7), ZZ(19), ZZ(65537)]
       R = ResidueField(ZZ, p)


### PR DESCRIPTION
Fixes #1077 
Fixes #1075 (both issues)

Turning off mutation for Julia types appears to be necessary for correctness (see #1077), as Julia doesn't make the same assumptions as us that new objects are created that don't alias even in part when arithmetic operations are performed, e.g. "-a" for a Rational{BigInt} keeps the same denominator identically.

 Test code now takes about 9 minutes to run, which seems acceptable.