### PR TITLE
Optimize get_handle, remove some exports

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -135,8 +135,8 @@ export PolyRing, SeriesRing, ResRing, FracField, MatSpace, MatAlgebra,
 
 export ZZ, QQ, zz, qq, RealField, RDF
 
-export create_accessors, get_handle, package_handle, zeros,
-       Array, sig_exists
+export create_accessors, get_handle, zeros,
+       sig_exists
 
 export NotInvertibleError, error_dim_negative, ErrorConstrDimMismatch
 
@@ -640,11 +640,11 @@ include("Deprecations.jl")
 #
 ###############################################################################
 
-const package_handle = [1]
+const package_handle = Ref(0)
 
 function get_handle()
-   package_handle[1] += 1
-   return package_handle[1] - 1
+   package_handle[] += 1
+   return package_handle[]
 end
 
 ###############################################################################


### PR DESCRIPTION
Don't export `package_handle` and `Array`. Also, turn `package_handle`
into a `Ref{Int}`.

Before this patch:

    julia> @btime get_handle()
      1.982 ns (0 allocations: 0 bytes)
    500503

After this patch:

    julia> @btime C.get_handle()
      1.391 ns (0 allocations: 0 bytes)
    500503

Not that this matters, as this function is normally only called a few times ;-)