### PR TITLE
Restore use of types in `create_accessors`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -656,8 +656,8 @@ end
 mutable struct AccessorNotSetError <: Exception
 end
 
-function create_accessors(T, S, handle)
-   get = function(a, error::Bool = true)
+function create_accessors(::Type{T}, ::Type{S}, handle) where {T, S}
+   get = function(a::T, error::Bool = true)
       if handle > length(a.auxilliary_data) ||
          !isassigned(a.auxilliary_data, handle)
         if error
@@ -666,9 +666,9 @@ function create_accessors(T, S, handle)
           return nothing
         end
       end
-      return a.auxilliary_data[handle]
+      return a.auxilliary_data[handle]::S
    end
-   set = function(a, b)
+   set = function(a::T, b::S)
       if handle > length(a.auxilliary_data)
          resize!(a.auxilliary_data, handle)
       end


### PR DESCRIPTION
This was lost in 45d36dc5cd5a34f646e439c4c4f3f027f6732a88 which updated
AbstractAlgebra for Julia 0.6

I've been trying to understand `create_accessors`, which seems to be an alternative attributes implementation (I very vaguely recall @fieker telling me about something like that 1-2 years ago), and noticed that `S` and `T` were unused arguments.

Note that this change risks breaking stuff in so far as `S` and `T` were unused (and thus unchecked) for a long time, hence it is conceivable that something somewhere gets these arguments wrong. Hopefully these are easy to find and fix, though...