### PR TITLE
Yet more attributes related tweaks

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -180,7 +180,7 @@ end
 Return the value stored for the attribute `attr` of `G, or if no value has been set,
 store `key => f()` and return `f()`.
 """
-function get_attribute!(f::Function, G::Any, attr::Symbol)
+function get_attribute!(f, G::Any, attr::Symbol)
    D = _get_attributes!(G)
    return Base.get!(f, D, attr)
 end

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -106,4 +106,9 @@ end
     @test get_attribute!(() -> 42, x, :bar7) == 0
     @test get_attribute(x, :bar7) == 0
 
+    # test get_attribute! with callback a type
+    @test get_attribute(x, :bar8) == nothing
+    @test get_attribute!(Vector{Int}, x, :bar8) isa Vector{Int}
+    @test get_attribute(x, :bar8) == []
+
 end


### PR DESCRIPTION
- Unify attribute tests
- Remove type restriction for `f` in `get_attribute!(f,G,attr)`:
  Many "callable" things are not of type `Function`, including type constructors. Being able to pass such non-function callables can be handy.