### PR TITLE
Add get_attribute(f::Function, G::Any, attr::Symbol)

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -163,6 +163,27 @@ function has_attribute(G::Any, attr::Symbol)
 end
 
 """
+    get_attribute(f::Function, G::Any, attr::Symbol)
+
+Return the value stored for the attribute `attr`, or if no value has been set,
+return `f()`.
+
+This is intended to be called using `do` block syntax.
+
+```julia
+get_attribute(obj, attr) do
+    # default value calculated here if needed
+    ...
+end
+```
+"""
+function get_attribute(f, G::Any, attr::Symbol)
+   D = _get_attributes(G)
+   D isa Dict && return get(f, D, attr)
+   return f()
+end
+
+"""
     get_attribute(G::Any, attr::Symbol, default::Any = nothing)
 
 Return the value stored for the attribute `attr`, or if no value has been set,
@@ -179,6 +200,15 @@ end
 
 Return the value stored for the attribute `attr` of `G`, or if no value has been set,
 store `key => f()` and return `f()`.
+
+This is intended to be called using `do` block syntax.
+
+```julia
+get_attribute!(obj, attr) do
+    # default value calculated here if needed
+    ...
+end
+```
 """
 function get_attribute!(f, G::Any, attr::Symbol)
    D = _get_attributes!(G)

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -84,6 +84,17 @@ end
     @test get_attribute(x, :bar3, 42) == 0
     @test get_attribute(x, :bar3) == 0
 
+    # test get_attribute with callback for new entry
+    @test get_attribute(x, :bar8) == nothing
+    @test get_attribute(() -> 42, x, :bar8) == 42
+    @test get_attribute(x, :bar8) == nothing
+
+    # test get_attribute with callback for pre-existing entry
+    set_attribute!(x, :bar9 => 0)
+    @test get_attribute(x, :bar9) == 0
+    @test get_attribute(() -> 42, x, :bar9) == 0
+    @test get_attribute(x, :bar9) == 0
+
     # test get_attribute! with default value for new entry
     @test get_attribute(x, :bar4) == nothing
     @test get_attribute!(x, :bar4, 42) == 42


### PR DESCRIPTION
Also improve docstring for `get_attribute!(f::Function, G::Any, attr::Symbol)`
by mentioning that it is meant for use with `do` blocks
