### PR TITLE
Use docstrings for euclidean ring interface

### DIFF
--- a/docs/src/euclidean_interface.md
+++ b/docs/src/euclidean_interface.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+DocTestSetup = :(using AbstractAlgebra)
+```
+
 # Euclidean Ring Interface
 
 If a ring provides a meaningful Euclidean structure such that a useful Euclidean
@@ -6,101 +11,18 @@ by AbstractAlgebra.jl for those rings. This functionality depends on the followi
 functions existing. An implementation must provide `divrem`, and the remaining
 are optional as generic fallbacks exist.
 
-```julia
-divrem(f::MyElem, g::MyElem)
+```@docs
+divrem
+mod(f::T, g::T) where T <: RingElem
+Base.div(f::T, g::T) where T <: RingElem
+mulmod(f::T, g::T, m::T) where T <: RingElem
+powermod(f::T, e::Int, m::T) where T <: RingElem
+invmod(f::T, m::T) where T <: RingElem
+divides(f::T, g::T) where T <: RingElem
+remove(f::T, p::T) where T <: RingElem
+valuation(f::T, p::T) where T <: RingElem
+gcd(f::T, g::T) where T <: RingElem
+lcm(f::T, g::T) where T <: RingElem
+gcdx(f::T, g::T) where T <: RingElem
+gcdinv(f::T, g::T) where T <: RingElem
 ```
-
-Return a pair `q, r` consisting of the Euclidean quotient and remainder of $f$
-by $g$. A `DivideError` should be thrown if $g$ is zero.
-
-```julia
-mod(f::MyElem, g::MyElem)
-```
-
-Return the Euclidean remainder of $f$ by $g$. A `DivideError` should be thrown
-if $g$ is zero.
-
-!!! note
-    For best compatibility with the internal assumptions made by AbstractAlgebra,
-    the Euclidean remainder function should provide unique representatives for
-    the residue classes; the `mod` function should satisfy
-        1. $\operatorname{mod}(a_1, b) = \operatorname{mod}(a_2, b)$ if and only if $b \mid (a_1 - a_2)$, and
-        2. $\operatorname{mod}(0, b) = 0$.
-
-```julia
-div(f::MyElem, g::MyElem)
-```
-
-Return the Euclidean quotient of $f$ by $g$. A `DivideError` should be thrown
-if $g$ is zero.
-
-```julia
-mulmod(f::MyElem, g::MyElem, m::MyElem)
-```
-
-Return $fg \pmod{m}$.
-
-```julia
-powermod(f::MyElem, e::Int, m::MyElem)
-```
-
-Return $f^e \pmod{m}$.
-
-```julia
-invmod(f::MyElem, m::MyElem)
-```
-
-Return the inverse of $f$ modulo $m$. If such an inverse doesn't exist, a
-`NotInvertibleError` should be thrown.
-
-```julia
-divides(f::MyElem, g::MyElem)
-```
-
-Return a pair, `flag, q`, where `flag` is set to `true` if $g$ divides $f$, in which
-case the quotient is set to the quotient or `flag` is set to `false` and the quotient
-is set to zero in the same ring as $f$ and $g$.
-
-```julia
-remove(f::MyElem, p::MyElem)
-```
-
-Return a pair `v, q` where $p^v$ is the highest power of $p$ dividing $f$ and $q$ is
-the cofactor after $f$ is divided by this power.
-
-```julia
-valuation(f::MyElem, p::MyElem)
-```
-
-Return `v` where $p^v$ is the highest power of $p$ dividing $f$.
-
-```julia
-gcd(f::MyElem, g::MyElem)
-```
-
-Return a greatest common divisor of $f$ and $g$.
-
-!!! note
-    For best compatibility with the internal assumptions made by
-    AbstractAlgebra, the return is expected to be unit-normalized in such a
-    way that if the return is a unit, that unit should be one.
-
-```julia
-lcm(f::MyElem, g::MyElem)
-```
-
-Return a least common multiple of $f$ and $g$.
-
-```julia
-gcdx(f::MyElem, g::MyElem)
-```
-
-Return a triple `d, s, t` such that $d = gcd(f, g)$ and $d = sf + tg$, with $s$
-loosely reduced modulo $g/d$ and $t$ loosely reduced modulo $f/d$.
-
-```julia
-gcdinv(f::MyElem, g::MyElem)
-```
-
-Return a tuple `d, s` such that $d = gcd(f, g)$ and $s = (f/d)^{-1} \pmod{g/d}$. Note
-that $d = 1$ iff $f$ is invertible modulo $g$, in which case $s = f^{-1} \pmod{g}$.

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -276,7 +276,7 @@ Univariate Polynomial Ring in y over Univariate Polynomial Ring in x over Intege
 
 ## Euclidean polynomial rings
 
-For polynomials over a field, the Euclidean Ring interface is implemented.
+For polynomials over a field, the [Euclidean Ring Interface](@ref) is implemented.
 
 ```julia
 mod(f::PolyElem, g::PolyElem)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1333,22 +1333,12 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    mulmod(a::PolyElem{T}, b::PolyElem{T}, d::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return $a\times b \pmod{d}$.
-"""
 function mulmod(a::PolyElem{T}, b::PolyElem{T}, d::PolyElem{T}) where T <: RingElement
    check_parent(a, b)
    check_parent(a, d)
    return mod(a*b, d)
 end
 
-@doc Markdown.doc"""
-    powermod(a::PolyElem{T}, b::Int, d::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return $a^b \pmod{d}$. There are no restrictions on $b$.
-"""
 function powermod(a::PolyElem{T}, b::Int, d::PolyElem{T}) where T <: RingElement
    check_parent(a, d)
    if b == 0
@@ -1382,11 +1372,6 @@ function powermod(a::PolyElem{T}, b::Int, d::PolyElem{T}) where T <: RingElement
    return z
 end
 
-@doc Markdown.doc"""
-    invmod(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return $a^{-1} \pmod{d}$.
-"""
 function invmod(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
    check_parent(a, b)
    g, z = gcdinv(a, b)
@@ -1463,11 +1448,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    mod(f::PolyElem{T}, g::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return $f \pmod{g}$.
-"""
 function mod(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
    check_parent(f, g)
    if length(g) == 0
@@ -1496,12 +1476,6 @@ function rem(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
   return mod(f, g)
 end
 
-@doc Markdown.doc"""
-    divrem(f::PolyElem{T}, g::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return a tuple $(q, r)$ such that $f = qg + r$ where $q$ is the euclidean
-quotient of $f$ by $g$.
-"""
 function Base.divrem(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
    check_parent(f, g)
    if length(g) == 0
@@ -1532,11 +1506,6 @@ function Base.divrem(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
    return q, f
 end
 
-@doc Markdown.doc"""
-    div(f::PolyElem{T}, g::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return the euclidean quotient of $f$ by $g$.
-"""
 function Base.div(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
    q, r = divrem(f, g)
    return q
@@ -1622,14 +1591,6 @@ end
 
 #CF TODO: use squaring for fast large valuation
 
-@doc Markdown.doc"""
-    remove(z::PolyElem{T}, p::PolyElem{T}) where T <: RingElement
-
-Compute the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::PolyElem{T}, p::PolyElem{T}) where T <: RingElement
  check_parent(z, p)
  !isexact_type(T) && error("remove requires an exact ring")
@@ -1649,14 +1610,6 @@ function remove(z::PolyElem{T}, p::PolyElem{T}) where T <: RingElement
  return v, q
 end
 
-@doc Markdown.doc"""
-    remove(z::PolyElem{T}, p::PolyElem{T}) where T <: Union{ResElem, FieldElement}
-
-Compute the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::PolyElem{T}, p::PolyElem{T}) where T <: Union{ResElem, FieldElement}
  check_parent(z, p)
  !isexact_type(T) && error("remove requires an exact ring")
@@ -1676,26 +1629,6 @@ function remove(z::PolyElem{T}, p::PolyElem{T}) where T <: Union{ResElem, FieldE
  return v, q
 end
 
-@doc Markdown.doc"""
-    valuation(z::PolyElem{T}, p::PolyElem{T}) where T <: RingElement
-
-Compute the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$.
-
-See also `remove`, which also returns $z/p^k$.
-"""
-function valuation(z::PolyElem{T}, p::PolyElem{T}) where T <: RingElement
- v, _ = remove(z, p)
- return v
-end
-
-@doc Markdown.doc"""
-    divides(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
-
-Return a pair consisting of a flag which is set to `true` if $g$ divides
-$f$ and `false` otherwise, and a polynomial $h$ such that $f = gh$ if
-such a polynomial exists. If not, the value of $h$ is undetermined.
-"""
 function divides(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
   check_parent(f, g)
   !isexact_type(T) && error("divides requires an exact ring")
@@ -1733,13 +1666,6 @@ function divides(f::PolyElem{T}, g::PolyElem{T}) where T <: RingElement
   return iszero(f), q
 end
 
-@doc Markdown.doc"""
-    divides(z::PolyElem{T}, x::T) where T <: RingElement
-
-Return a pair consisting of a flag which is set to `true` if $x$ divides
-$z$ and `false` otherwise, and a polynomial $y$ such that $z = xy$ if
-such a polynomial exists. If not, the value of $y$ is undetermined.
-"""
 function divides(z::PolyElem{T}, x::T) where T <: RingElement
   parent(x) != base_ring(z) && error("Wrong parents in divides")
   q = parent(z)()
@@ -1911,11 +1837,6 @@ function term_content(a::PolyElem{T}) where T <: RingElement
    return parent(a)()
 end
 
-@doc Markdown.doc"""
-    gcd(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement
-
-Return a greatest common divisor of $a$ and $b$ if it exists.
-"""
 function gcd(a::PolyElem{T}, b::PolyElem{T}, ignore_content::Bool = false) where T <: RingElement
    check_parent(a, b)
    if length(b) > length(a)
@@ -2021,11 +1942,6 @@ function gcd(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldEle
    return divexact(b, d)
 end
 
-@doc Markdown.doc"""
-    lcm(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement
-
-Return a least common multiple of $a$ and $b$ if it exists.
-"""
 function lcm(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement
    check_parent(a, b)
    g = gcd(a, b)
@@ -2627,12 +2543,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    gcdx(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return a tuple $(g, s, t)$ such that $g$ is the greatest common divisor of
-$a$ and $b$ and such that $g = a\times s + b\times t$.
-"""
 function gcdx(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
    check_parent(a, b)
    !isexact_type(T) && error("gcdx requires exact Bezout domain")
@@ -2673,13 +2583,6 @@ function gcdx(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldEl
    return divexact(A, d), divexact(u1, d), divexact(v1, d)
 end
 
-@doc Markdown.doc"""
-    gcdinv(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
-
-Return a tuple $(g, s)$ such that $g$ is the greatest common divisor of $a$
-and $b$ and such that $s = a^{-1} \pmod{b}$. This function is useful for
-inverting modulo a polynomial and checking that it really was invertible.
-"""
 function gcdinv(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, FieldElement}}
    check_parent(a, b)
    R = base_ring(a)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -2613,7 +2613,6 @@ function gcdinv(a::PolyElem{T}, b::PolyElem{T}) where {T <: Union{ResElem, Field
    u1 *= inv(c1)
    u2 *= inv(c2)
    while lenb > 0
-      d = lena - lenb
       (Q, B), A = divrem(A, B), B
       lena = lenb
       lenb = length(B)

--- a/src/algorithms/GenericFunctions.jl
+++ b/src/algorithms/GenericFunctions.jl
@@ -40,14 +40,47 @@ end
 #
 ###############################################################################
 
+@doc Markdown.doc"""
+    divrem(f::T, g::T) where T <: RingElem
+
+Return a pair `q, r` consisting of the Euclidean quotient and remainder of $f$
+by $g$. A `DivideError` should be thrown if $g$ is zero.
+"""
+function divrem end
+
+@doc Markdown.doc"""
+    mod(f::T, g::T) where T <: RingElem
+
+Return the Euclidean remainder of $f$ by $g$. A `DivideError` should be thrown
+if $g$ is zero.
+
+!!! note
+    For best compatibility with the internal assumptions made by AbstractAlgebra,
+    the Euclidean remainder function should provide unique representatives for
+    the residue classes; the `mod` function should satisfy
+
+    1. `mod(a_1, b) = mod(a_2, b)` if and only if $b$ divides $a_1 - a_2$, and
+    2. `mod(0, b) = 0`.
+"""
 function mod(a::T, b::T) where T <: RingElem
    return divrem(a, b)[2]
 end
 
+@doc Markdown.doc"""
+    div(f::T, g::T) where T <: RingElem
+
+Return the Euclidean quotient of $f$ by $g$. A `DivideError` should be thrown
+if $g$ is zero.
+"""
 function Base.div(a::T, b::T) where T <: RingElem
    return divrem(a, b)[1]
 end
 
+@doc Markdown.doc"""
+    mulmod(f::T, g::T, m::T) where T <: RingElem
+
+Return `mod(f*g, m)` but possibly computed more efficiently.
+"""
 function mulmod(a::T, b::T, m::T) where T <: RingElement
    return mod(a*b, m)
 end
@@ -68,6 +101,11 @@ function internal_powermod(a, n, m)
    return z
 end
 
+@doc Markdown.doc"""
+    powermod(f::T, e::Int, m::T) where T <: RingElem
+
+Return `mod(f^e, m)` but possibly computed more efficiently.
+"""
 function powermod(a::T, n::Integer, m::T) where T <: RingElem
    parent(a) == parent(m) || error("Incompatible parents")
    if n > 1
@@ -83,12 +121,27 @@ function powermod(a::T, n::Integer, m::T) where T <: RingElem
    end
 end
 
+@doc Markdown.doc"""
+    invmod(f::T, m::T) where T <: RingElem
+
+Return an inverse of $f$ modulo $m$, meaning that `isone(mod(invmod(f,m)*f,m))`
+returns `true`.
+
+If such an inverse doesn't exist, a `NotInvertibleError` should be thrown.
+"""
 function invmod(a::T, m::T) where T <: RingElem
    g, s = gcdinv(a, m)
    isone(g) || throw(NotInvertibleError(a, m))
    return mod(s, m)  # gcdinv has no canonicity requirement on s
 end
 
+@doc Markdown.doc"""
+    divides(f::T, g::T) where T <: RingElem
+
+Return a pair, `flag, q`, where `flag` is set to `true` if $g$ divides $f$, in which
+case `q` is set to the quotient, or `flag` is set to `false` and `q`
+is set to `zero(f)`.
+"""
 function divides(a::T, b::T) where T <: RingElem
    parent(a) == parent(b) || error("Incompatible parents")
    if iszero(b)
@@ -98,6 +151,14 @@ function divides(a::T, b::T) where T <: RingElem
    return iszero(r), q
 end
 
+@doc Markdown.doc"""
+    remove(f::T, p::T) where T <: RingElem
+
+Return a pair `v, q` where $p^v$ is the highest power of $p$ dividing $f$ and $q$ is
+the cofactor after $f$ is divided by this power.
+
+See also [`valuation`](@ref), which only returns the valuation.
+"""
 function remove(a::T, b::T) where T <: Union{RingElem, Number}
    parent(a) == parent(b) || error("Incompatible parents")
    if (iszero(b) || isunit(b))
@@ -114,10 +175,29 @@ function remove(a::T, b::T) where T <: Union{RingElem, Number}
    return v, a
 end
 
+@doc Markdown.doc"""
+    valuation(f::T, p::T) where T <: RingElem
+
+Return `v` where $p^v$ is the highest power of $p$ dividing $f$.
+
+See also [`remove`](@ref).
+"""
 function valuation(a::T, b::T) where T <: Union{RingElem, Number}
    return remove(a, b)[1]
 end
 
+@doc Markdown.doc"""
+    gcd(f::T, g::T) where T <: RingElem
+
+Return a greatest common divisor of $f$ and $g$, i.e., an element $d$
+which is a common divisor of $f$ and $g$, and with the property that
+any other common divisor of $f$ and $g$ divides $d$.
+
+!!! note
+    For best compatibility with the internal assumptions made by
+    AbstractAlgebra, the return is expected to be unit-normalized in such a
+    way that if the return is a unit, that unit should be one.
+"""
 function gcd(a::T, b::T) where T <: RingElem
    parent(a) == parent(b) || error("Incompatible parents")
    while !iszero(b)
@@ -126,12 +206,25 @@ function gcd(a::T, b::T) where T <: RingElem
    return iszero(a) ? a : divexact(a, canonical_unit(a))
 end
 
+@doc Markdown.doc"""
+    lcm(f::T, g::T) where T <: RingElem
+
+Return a least common multiple of $f$ and $g$, i.e., an element $d$
+which is a common multiple of $f$ and $g$, and with the property that
+any other common multiple of $f$ and $g$ is a multiple of $d$.
+"""
 function lcm(a::T, b::T) where T <: RingElem
    g = gcd(a, b)
    iszero(g) && return g
    return a*divexact(b, g)
 end
 
+@doc Markdown.doc"""
+    gcdx(f::T, g::T) where T <: RingElem
+
+Return a triple `d, s, t` such that $d = gcd(f, g)$ and $d = sf + tg$, with $s$
+loosely reduced modulo $g/d$ and $t$ loosely reduced modulo $f/d$.
+"""
 function gcdx(a::T, b::T) where T <: RingElem
    parent(a) == parent(b) || error("Incompatible parents")
    R = parent(a)
@@ -157,6 +250,12 @@ function gcdx(a::T, b::T) where T <: RingElem
    return divexact(a, t), divexact(m11, t), divexact(m21, t)
 end
 
+@doc Markdown.doc"""
+    gcdinv(f::T, g::T) where T <: RingElem
+
+Return a tuple `d, s` such that $d = gcd(f, g)$ and $s = (f/d)^{-1} \pmod{g/d}$. Note
+that $d = 1$ iff $f$ is invertible modulo $g$, in which case $s = f^{-1} \pmod{g}$.
+"""
 function gcdinv(a::T, b::T) where T <: RingElem
    g, s, t = gcdx(a, b)
    return (g, s)

--- a/src/generic/Misc/Localization.jl
+++ b/src/generic/Misc/Localization.jl
@@ -242,12 +242,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-     divides(a::LocElem{T}, b::LocElem{T}, checked::Bool = true) where {T <: RingElem}
-Returns tuple (`true`,`c`) if $b$ divides $a$ where `c`*$b$ = $a$.
-If 'checked = false' the corresponding element of the Fraction Field is returned and it is not
-checked whether it is an element of the given localization.
-"""
 function divides(a::LocElem, b::LocElem; checked::Bool = true)
    check_parent(a, b)
    c = divexact(data(a), data(b); check=false)
@@ -257,6 +251,7 @@ end
 
 @doc Markdown.doc"""
      divexact(a::LocElem{T}, b::LocElem{T}, checked::Bool = true)  where {T <: RingElem}
+
 Returns element 'c' of given localization s.th. `c`*$b$ = $a$ if such element exists.
 If 'checked = true' the result is checked to ensure it is an element of the given
 localization.
@@ -266,10 +261,6 @@ function divexact(a::LocElem, b::LocElem,; checked::Bool=true, check::Bool=true)
    d[1] ? d[2] : error("$a not divisible by $b in the given Localization")
 end
 
-@doc Markdown.doc"""
-     divrem(a::LocElem{T}, b::LocElem{T}, checked::Bool = true)  where {T <: RingElem}
-In case the ring is euclidean, return a euclidean division.
-"""
 function Base.divrem(a::LocElem{T}, b::LocElem{T}, checked::Bool = true)  where {T <: RingElem}
   check_parent(a, b)
   L = parent(a)
@@ -309,11 +300,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    gcd(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
-
-Returns gcd of $a$ and $b$ in canonical representation.
-"""
 function gcd(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
    check_parent(a,b)
    iszero(a) && return inv(canonical_unit(b)) * b
@@ -327,11 +313,6 @@ function gcd(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
    return par(elem)
 end
 
-@doc Markdown.doc"""
-    lcm(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
-
-Returns lcm of $a$ and $b$ in canonical representation.
-"""
 function lcm(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
    check_parent(a,b)
    par = parent(a)
@@ -350,12 +331,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    gcdx(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
-
-Returns tuple `(g,u,v)` s.th. `g` = gcd($a$,$b$) and `g` = `u` * $a$ + `v` * $b$.
-Requires method gcdx for ring that is localized.
-"""
 function gcdx(a::LocElem{T}, b::LocElem{T}) where {T <: RingElement}
    check_parent(a,b)
    L = parent(a)


### PR DESCRIPTION
This way, not all euclidean ring implementations need to repeat this.
Also, by inserting this as docstrings into the manual, these functions
become findable via the search feature of the online manual.

Also improve some of the docstrings, and remove some redundant docstrings.

BTW, what does "loosely reduced" means in the docstrings for `gcdx`?
