### PR TITLE
Improve `@attributes` for singleton types

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -24,6 +24,9 @@ The latter variant is useful to enable attribute storage for types defined in
 other packages. Note that `@attributes` is idempotent: when applied to a type
 for which attribute storage is already available, it does nothing.
 
+For singleton types, attribute storage is also supported, and in fact always
+enabled. Thus it is not necessary to apply this macro to such a type.
+
 !!! note
     When applied to a struct definition this macro adds a new field to the
     struct. For structs without constructor, this will change the signature of
@@ -82,6 +85,10 @@ macro attributes(expr)
       return quote
         Base.@__doc__($(esc(expr)))
       end
+   elseif expr isa Expr && expr.head === :struct && !expr.args[1] && all(x -> x isa LineNumberNode, expr.args[3].args)
+      # Ignore application to singleton types:
+      #    @attributes struct Singleton end
+      return esc(expr)
    elseif expr isa Symbol || (expr isa Expr && expr.head === :. &&
                               length(expr.args) == 2 && expr.args[2] isa QuoteNode) ||
                               (expr isa Expr && expr.head === :curly &&

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -52,7 +52,6 @@ end
 # applying @attributes to a singleton typename is supported but does nothing
 @attributes Tmp.Singleton
 
-
 @testset "@attributes input validation" begin
 
     @test_throws Exception @attributes Int

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -22,6 +22,10 @@ module Tmp
     struct Singleton
     end
 
+    # applying @attributes to a singleton type definition is supported but does nothing
+    @attributes struct AnotherSingleton
+    end
+
     struct NotSupported
         x::Int
         NotSupported() = new(0)
@@ -45,6 +49,10 @@ end
 @attributes Tmp.Quux
 @attributes Tmp.FooBar{Tmp.Quux}
 
+# applying @attributes to a singleton typename is supported but does nothing
+@attributes Tmp.Singleton
+
+
 @testset "@attributes input validation" begin
 
     @test_throws Exception @attributes Int
@@ -52,7 +60,7 @@ end
 
 end
 
-@testset "attributes for $T" for T in (Tmp.Foo, Tmp.Bar, Tmp.Quux, Tmp.FooBar{Tmp.Bar}, Tmp.FooBar{Tmp.Quux})
+@testset "attributes for $T" for T in (Tmp.Foo, Tmp.Bar, Tmp.Quux, Tmp.Singleton, Tmp.AnotherSingleton, Tmp.FooBar{Tmp.Bar}, Tmp.FooBar{Tmp.Quux})
 
     x = T()
 


### PR DESCRIPTION
- document that attribute storage is always enabled for singleton types
- allow applying `@attributes` to singleton types (it simply does nothing)
- actually perform tests with singleton types again (tests were accidentally
  disabled in a previous patch)
