### PR TITLE
Fix two docstrings

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -262,7 +262,7 @@ end
 
 
 """
-   @attr [RetType] funcdef
+    @attr [RetType] funcdef
 
 This macro is applied to the definition of a unary function, and enables
 caching ("memoization") of its return values based on the argument. This

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -301,7 +301,7 @@ function block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: RingElement
 end
 
 @doc Markdown.doc"""
-   block_diagonal_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
+    block_diagonal_matrix(R::Ring, V::Vector{<:Matrix{T}}) where T <: RingElement
 
 Create the block diagonal matrix over the ring `R` whose blocks are given
 by the matrices in `V`. Entries are coerced into `R` upon creation.


### PR DESCRIPTION
The first line should be indented with 4 spaces, to mark it as a Markdown codeblock
