### PR TITLE
Make characteristic raise an exception if it cannot be computed easily.

### DIFF
--- a/docs/src/field.md
+++ b/docs/src/field.md
@@ -26,7 +26,8 @@ their elements.
 characteristic(R::MyParent)
 ```
 
-Return the characteristic of the field.
+Return the characteristic of the field. If the characteristic is not known, an
+exception is raised.
 
 ## Basic functions
 

--- a/docs/src/field_interface.md
+++ b/docs/src/field_interface.md
@@ -106,7 +106,8 @@ functionality.
 characteristic(R::MyParent)
 ```
 
-Return the characteristic of the field.
+Return the characteristic of the field. If the characteristic is not known, an
+exception is raised.
 
 ### Basic manipulation of rings and elements
 

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -176,7 +176,8 @@ Return the fraction field of the given fraction.
 characteristic(R::FracField)
 ```
 
-Return the characteristic of the base ring of the fraction field.
+Return the characteristic of the base ring of the fraction field. If the
+characteristic is not known an exception is raised.
 
 
 **Examples**

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -212,7 +212,8 @@ Return the polynomial ring of the given polynomial.
 characteristic(R::MPolyRing)
 ```
 
-Return the characteristic of the given polynomial ring.
+Return the characteristic of the given polynomial ring. If the characteristic
+is not known, an exception is raised.
 
 ## Polynomial functions
 

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -253,7 +253,8 @@ Return the polynomial ring of the given polynomial..
 characteristic(R::NCRing)
 ```
 
-Return the characteristic of the given polynomial ring.
+Return the characteristic of the given polynomial ring. If the characteristic
+is not known, an exception is raised.
 
 **Examples**
 

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -127,7 +127,8 @@ Return the parent of the given residue.
 characteristic(R::ResRing)
 ```
 
-Return the characteristic of the given residue ring.
+Return the characteristic of the given residue ring. If the characteristic is
+not known, an exception is raised.
 
 ## Residue ring functions
 

--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -691,9 +691,8 @@ characteristic(R::MyParent)
 ```
 
 Return the characteristic of the ring. The function should not be defined if
-it is not possible to unconditionally give the characteristic as the function
-is used in some generic code for correctness, but will always take the safe
-path if the function is not defined.
+it is not possible to unconditionally give the characteristic. AbstractAlgebra
+will raise an exception is such cases.
 
 ### Optional binary ad hoc operators
 

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -345,7 +345,8 @@ Return the parent of the given series.
 characteristic(R::SeriesRing)
 ```
 
-Return the characteristic of the given series ring.
+Return the characteristic of the given series ring. If the characteristic is
+not known, an exception is raised.
 
 ## Series functions
 

--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -51,7 +51,8 @@ base_ring(a::MSeriesElem) = base_ring(parent(a))
 @doc Markdown.doc"""
     characteristic(a::MSeriesRing)
 
-Return the characteristic of the base ring of the series `a`.
+Return the characteristic of the base ring of the series `a`. If the
+characteristic is not known, an exception is raised.
 """
 function characteristic(a::MSeriesRing)
     return characteristic(base_ring(a))

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -131,8 +131,9 @@ function isunit end
 #
 ###############################################################################
 
-# -1 means the characteristic is not known by default
-characteristic(R::NCRing) = -1
+function characteristic(R::NCRing)
+   error("Characteristic not known")
+end
 
 ###############################################################################
 #

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -40,11 +40,12 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
          @test isdomain_type(T) isa Bool
          @test isexact_type(T) isa Bool
 
-         # some rings don't support characteristic and return -1 (see issue #993)
-         if characteristic(R) != -1
+         # some rings don't support characteristic and raise an exception (see issue #993)
+         try ch = characteristic(R)
             @test iszero(R(characteristic(R)))
             @test iszero(characteristic(R) * one(R))
             @test iszero(one(R) * characteristic(R))
+         catch
          end
       end
 


### PR DESCRIPTION
Fixes #993 

This may cause some rings to no longer function when characteristic is used in generic code. But so far current tests pass (after modifying conformance tests to ignore the exception.