### PR TITLE
Remove hashp_seed

### DIFF
--- a/src/algorithms/LaurentPoly.jl
+++ b/src/algorithms/LaurentPoly.jl
@@ -32,8 +32,6 @@ end
 #
 ###############################################################################
 
-const hashp_seed = UInt === UInt64 ? 0xcdaf0e0b5ade239b : 0x5ade239b
-
 function Base.hash(p::LaurentPolyElem, h::UInt)
    for i in terms_degrees(p)
       c = coeff(p, i)
@@ -42,7 +40,7 @@ function Base.hash(p::LaurentPolyElem, h::UInt)
          h = hash(c, h)
       end
    end
-   hash(hashp_seed, h)
+   return h
 end
 
 # required implementation


### PR DESCRIPTION
I don't see what it is good for. Of course that doesn't mean it is important after all! If it is, it'd be good to document that in a comment.

Perhaps @rfourquet remembers why this was added?