### PR TITLE
add gcd and lcm versions for AbstractVector and vararg

### DIFF
--- a/docs/src/euclidean_interface.md
+++ b/docs/src/euclidean_interface.md
@@ -22,7 +22,11 @@ divides(f::T, g::T) where T <: RingElem
 remove(f::T, p::T) where T <: RingElem
 valuation(f::T, p::T) where T <: RingElem
 gcd(f::T, g::T) where T <: RingElem
+gcd(f::T, g::T, hs::T...) where T <: RingElem
+gcd(fs::AbstractArray{<:T}) where T <: RingElem
 lcm(f::T, g::T) where T <: RingElem
+lcm(f::T, g::T, hs::T...) where T <: RingElem
+lcm(fs::AbstractArray{<:T}) where T <: RingElem
 gcdx(f::T, g::T) where T <: RingElem
 gcdinv(f::T, g::T) where T <: RingElem
 ```

--- a/src/algorithms/GenericFunctions.jl
+++ b/src/algorithms/GenericFunctions.jl
@@ -207,6 +207,26 @@ function gcd(a::T, b::T) where T <: RingElem
 end
 
 @doc Markdown.doc"""
+    gcd(fs::AbstractArray{<:T}) where T <: RingElem
+
+Return a greatest common divisor of the elements in `fs`.
+Requires that `fs` is not empty.
+"""
+function gcd(fs::AbstractArray{<:T}) where T <: RingElem
+   length(fs) > 0 || error("Empty collection")
+   return reduce(gcd, fs)
+end
+
+@doc Markdown.doc"""
+    gcd(f::T, g::T, hs::T...) where T <: RingElem
+
+Return a greatest common divisor of $f$, $g$ and the elements in `hs`.
+"""
+function gcd(f::T, g::T, hs::T...) where T <: RingElem
+   return gcd(f, gcd(g, hs...))
+end
+
+@doc Markdown.doc"""
     lcm(f::T, g::T) where T <: RingElem
 
 Return a least common multiple of $f$ and $g$, i.e., an element $d$
@@ -217,6 +237,26 @@ function lcm(a::T, b::T) where T <: RingElem
    g = gcd(a, b)
    iszero(g) && return g
    return a*divexact(b, g)
+end
+
+@doc Markdown.doc"""
+    lcm(fs::AbstractArray{<:T}) where T <: RingElem
+
+Return a least common multiple of the elements in `fs`.
+Requires that `fs` is not empty.
+"""
+function lcm(fs::AbstractArray{<:T}) where T <: RingElem
+   length(fs) > 0 || error("Empty collection")
+   return reduce(lcm, fs)
+end
+
+@doc Markdown.doc"""
+    lcm(f::T, g::T, hs::T...) where T <: RingElem
+
+Return a least common multiple of $f$, $g$ and the elements in `hs`.
+"""
+function lcm(f::T, g::T, hs::T...) where T <: RingElem
+   return lcm(f, lcm(g, hs...))
 end
 
 @doc Markdown.doc"""

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -316,6 +316,8 @@ function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 20)
 
          @test !(iszero(f) && iszero(g)) || iszero(gcd(f, g))
          @test equality_up_to_units(gcd(f, g)*lcm(f, g), f*g)
+         @test gcd(f, gcd(g, m)) == gcd(gcd(f, g), m) == gcd(f, g, m) == gcd([f, g, m])
+         @test lcm(f, lcm(g, m)) == lcm(lcm(f, g), m) == lcm(f, g, m) == lcm([f, g, m])
 
          (d, s, t) = gcdx(f, g)
          @test d == gcd(f, g)

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -85,8 +85,8 @@ end
       s2 = rand(S, -100:100)
       s3 = rand(S, -100:100)
 
-      @test gcd(r1, gcd(r2, r3)) == gcd(gcd(r1, r2), r3)
-      @test gcd(s1, gcd(s2, s3)) == gcd(gcd(s1, s2), s3)
+      @test gcd(r1, gcd(r2, r3)) == gcd(gcd(r1, r2), r3) == gcd(r1, r2, r3) == gcd([r1, r2, r3])
+      @test gcd(s1, gcd(s2, s3)) == gcd(gcd(s1, s2), s3) == gcd(s1, s2, s3) == gcd([s1, s2, s3])
    end
 end
 


### PR DESCRIPTION
closes #1165 

while I was at it, I also added the corresponding functions for `lcm`.

If somebody knows how to change the documentation to one box containing all three same-named methods instead of the current three separate boxes, that would be appreciated.