### PR TITLE
Deflate and inflate exponents of only some variables

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -155,7 +155,7 @@ julia> push_term!(C, ZZ(3), [1, 2]);
 julia> push_term!(C, ZZ(2), [1, 1]);
 
 
-julia> push_term!(C, ZZ(4), [0, 0]); 
+julia> push_term!(C, ZZ(4), [0, 0]);
 
 
 julia> f = finish(C)
@@ -647,11 +647,15 @@ deflation(f::MPolyElem{T}) where T <: RingElement
 deflate(f::MPolyElem{T}, shift::Vector{Int}, defl::Vector{Int}) where T <: RingElement
 deflate(f::MPolyElem{T}, defl::Vector{Int}) where T <: RingElement
 deflate(f::MPolyElem{T}) where T <: RingElement
+deflate(f::MPolyElem, vars::Vector{Int}, shift::Vector{Int}, defl::Vector{Int})
+deflate(f::T, vars::Vector{T}, shift::Vector{Int}, defl::Vector{Int}) where T <: MPolyElem
 ```
 
 ```@docs
 inflate(f::MPolyElem{T}, shift::Vector{Int}, defl::Vector{Int}) where T <: RingElement
 inflate(f::MPolyElem{T}, defl::Vector{Int}) where T <: RingElement
+inflate(f::MPolyElem, vars::Vector{Int}, shift::Vector{Int}, defl::Vector{Int})
+inflate(f::T, vars::Vector{T}, shift::Vector{Int}, defl::Vector{Int}) where T <: MPolyElem
 ```
 
 **Examples**
@@ -673,6 +677,18 @@ julia> f2 = inflate(f1, def, shift)
 x^7*y^8 + 3*x^4*y^8 - x^4*y^2 + 5*x*y^5 - x*y^2
 
 julia> f2 == f
+true
+
+julia> g = (x+y+1)^2
+x^2 + 2*x*y + 2*x + y^2 + 2*y + 1
+
+julia> g0 = coeff(g, [y], [0])
+x^2 + 2*x + 1
+
+julia> g1 = deflate(g - g0, [y], [1], [1])
+2*x + y + 2
+
+julia> g == g0 + y * g1
 true
 
 ```

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -620,7 +620,7 @@ function inflate_deflate_vectors(R::AbstractAlgebra.MPolyRing, vars::Vector{Int}
 end
 
 @doc Markdown.doc"""
-    deflate(f::T, vars::Vector{Int}, shift::Vector{Int}, defl::Vector{Int}) where T <: AbstractAlgebra.MPolyElem
+    deflate(f::AbstractAlgebra.MPolyElem, vars::Vector{Int}, shift::Vector{Int}, defl::Vector{Int})
 
 Return a polynomial with the same coefficients as $f$ but where exponents of
 some variables (supplied as an array of variable indices) have been reduced by

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -103,7 +103,7 @@
 
    push_term!(B, QQ(5), [5, 5])
 
-   q = finish(B) 
+   q = finish(B)
 
    @test q == 5x^5*y^5
 
@@ -813,10 +813,10 @@ end
       S, varlist = PolynomialRing(ZZ, var_names, ordering = ord)
 
       for iter = 1:10
-         f = rand(S, 0:4, 0:5, -10:10)
+         p = rand(S, 0:4, 0:5, -10:10)
          shift = [rand(0:10) for i in 1:num_vars]
          defl = [rand(1:10) for i in 1:num_vars]
-         f = inflate(f, shift, defl)
+         f = inflate(p, shift, defl)
 
          s, d = deflation(f)
          g = deflate(f, s, d)
@@ -824,11 +824,25 @@ end
 
          @test h == f
 
-	 @test deflate(inflate(f, d), d) == f
+         @test deflate(inflate(f, d), d) == f
 
-	 g = inflate(f, defl)
-	 h, defl = deflate(g)
-	 @test g == inflate(h, defl)
+         g = inflate(f, defl)
+         h, defl = deflate(g)
+         @test g == inflate(h, defl)
+
+         vars = unique([rand(varlist) for _ in varlist])
+         shift = [rand(0:10) for _ in vars]
+         defl = [rand(1:10) for _ in vars]
+
+         @test p == deflate(inflate(p, vars, shift, defl), vars, shift, defl)
+
+         x = rand(varlist)
+         f = p + evaluate(p, [x], [1])  # otherwise f0 is usually zero
+         f0 = coeff(f, [x], [0])
+         f1 = deflate(f - f0, [x], [1], [1])
+
+         @test f == f0 + x * f1
+         @test f == f0 + inflate(f1, [x], [1], [1])
       end
    end
 end


### PR DESCRIPTION
Given an MPolyElem f and a list of some of the variables in f,
deflate(f, vars, shift, defl) returns a polynomial obtained by deflating
only the specified variables. vars can be an array of either generators
or variable indices. shift and defl var arrays of integers, one for each
of the specified variables. inflate(f, vars, shift, defl) is defined
similarly.

Example:
```
using AbstractAlgebra

R, (x,y,z) = PolynomialRing(ZZ, ["x", "y", "z"])

# How can I generate a random multivariate polynomial?
g = (2*x^2 + y*x + 3*y^2*z - 4*x^3 + x*z - 5*z^2)^2

g0 = coeff(g, [y], [0])
g1 = deflate(g - g0, [y], [1], [1])

@assert g == g0 + y * g1 == g0 + inflate(g1, [y], [1], [1])
```

For some code I am trying to write, some functions only use operations like those in the examples. I assume that inflate and deflate is faster than multiplying and dividing with a monomial?
