### PR TITLE
Declare is_one, is_zero as early as possible

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -146,9 +146,11 @@ export crt, factor, factor_squarefree, is_irreducible, is_squarefree
 include("Attributes.jl")
 include("AliasMacro.jl")
 
-# alternative names for LinearAlgebra
-const is_symmetric = issymmetric
-const is_upper_triangular = istriu
+# alternative names for some functions from Base and LinearAlgebra
+@alias is_one isone
+@alias is_zero iszero
+@alias is_symmetric issymmetric
+@alias is_upper_triangular istriu
 
 # for backwards compatibility
 export issymmetric, istriu
@@ -494,9 +496,9 @@ export abs_series, abs_series_type,
                  is_domain_type, is_exact_type, is_gen,
                  is_homogeneous,
                  is_isomorphic, is_monomial, is_monomial_recursive,
-                 is_negative, isone, is_reverse,
+                 is_negative, is_one, is_reverse,
                  is_submodule, is_symmetric,
-                 is_term_recursive, is_unit, iszero,
+                 is_term_recursive, is_unit, is_zero,
                  lcm,
                  laurent_series, length,
                  main_variable, main_variable_extract, main_variable_insert,

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -15,7 +15,7 @@ using InteractiveUtils
 using Test # for "interface-conformance" functions
 
 import GroupsCore
-import GroupsCore: gens, ngens, order, mul!
+import GroupsCore: gens, ngens, order, mul!, istrivial
 
 # A list of all symbols external packages should not import from AbstractAlgebra
 import_exclude = [:import_exclude, :QQ, :ZZ,
@@ -30,7 +30,7 @@ import_exclude = [:import_exclude, :QQ, :ZZ,
 # imported here and in Generic.jl, and exported below.
 # They should not be imported/exported anywhere else.
 
-import LinearAlgebra: det, issymmetric, istriu, norm, nullspace, rank,
+import LinearAlgebra: det, ishermitian, issymmetric, istriu, norm, nullspace, rank,
                       hessenberg
 
 import LinearAlgebra: lu, lu!, tr
@@ -146,14 +146,31 @@ export crt, factor, factor_squarefree, is_irreducible, is_squarefree
 include("Attributes.jl")
 include("AliasMacro.jl")
 
-# alternative names for some functions from Base and LinearAlgebra
+# alternative names for some functions from Base
+export is_equal, is_finite, is_inf, is_integer, is_less, is_one, is_real, is_subset, is_valid, is_zero
+
+@alias is_equal isequal
+@alias is_finite isfinite
+@alias is_inf isinf
+@alias is_integer isinteger
+@alias is_less isless
 @alias is_one isone
+@alias is_real isreal
+@alias is_subset issubset
+@alias is_valid isvalid
 @alias is_zero iszero
+
+# alternative names for some functions from GroupsCore
+export is_trivial
+
+@alias is_trivial istrivial
+
+# alternative names for some functions from LinearAlgebra
+export is_hermitian, is_symmetric, is_upper_triangular
+
+@alias is_hermitian ishermitian
 @alias is_symmetric issymmetric
 @alias is_upper_triangular istriu
-
-# for backwards compatibility
-export issymmetric, istriu
 
 ###############################################################################
 # Macros for fancy printing. to use, enable attribute storage for your struct,
@@ -496,9 +513,9 @@ export abs_series, abs_series_type,
                  is_domain_type, is_exact_type, is_gen,
                  is_homogeneous,
                  is_isomorphic, is_monomial, is_monomial_recursive,
-                 is_negative, is_one, is_reverse,
+                 is_negative, is_reverse,
                  is_submodule, is_symmetric,
-                 is_term_recursive, is_unit, is_zero,
+                 is_term_recursive, is_unit,
                  lcm,
                  laurent_series, length,
                  main_variable, main_variable_extract, main_variable_insert,

--- a/src/AliasMacro.jl
+++ b/src/AliasMacro.jl
@@ -23,12 +23,16 @@ true
 """
 macro alias(alias_name::Symbol, real_name::Symbol)
     result = quote
-        """
-            $($(string(alias_name)))
+        if isdefined($__module__, $(QuoteNode(alias_name)))
+            $alias_name === $real_name || error("Alias '$($(string(alias_name)))' is already defined with a different value")
+        else
+            """
+                $($(string(alias_name)))
 
-        Alias for `$($(string(real_name)))`.
-        """
-        const $alias_name = $real_name
+            Alias for `$($(string(real_name)))`.
+            """
+            const $alias_name = $real_name
+        end
         if $(QuoteNode(real_name)) in names($__module__)
             export $alias_name
         elseif $(QuoteNode(alias_name)) in names($__module__)

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,7 +1,3 @@
-# make some Julia names compatible with our naming conventions
-@alias is_one isone
-@alias is_zero iszero
-
 # for backwards compatibility
 @alias iscompatible is_compatible
 @alias isconstant is_constant


### PR DESCRIPTION
Also export them explicitly (before @alias did it for us), and use @alias for
our LinearAlgebra aliases, too (makes it easier to find them by grepping)

CC @HechtiDerLachs this is what I was talking about