### PR TITLE
Catch empty array of divisors in `divrem`

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3248,6 +3248,9 @@ Return a tuple `(q, r)` consisting of an array of polynomials `q`, one for
 each polynomial in `b`, and a polynomial `r` such that `a = sum_i b[i]*q[i] + r`.
 """
 function Base.divrem(a::MPoly{T}, b::Vector{MPoly{T}}) where {T <: RingElement}
+   if isempty(b)
+      return typeof(a)[], a
+   end
    v1, d = max_fields(a)
    len = length(b)
    N = parent(a).N

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -783,6 +783,8 @@ end
 
       S, varlist = PolynomialRing(R, var_names, ordering = ord)
 
+      @test divrem(varlist[1], elem_type(S)[]) == (elem_type(S)[], varlist[1])
+
       for iter = 1:10
          f = S(0)
          while iszero(f)


### PR DESCRIPTION
`divrem(a, [])` should just return `[], a` like it does for fmpq-mpoly's in Nemo.