### PR TITLE
[WIP] Tweak evaluate a bit

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -1985,6 +1985,8 @@ function *(a::MPoly{T}, n::T) where {T <: RingElem}
    return r
 end
 
+mul!(b::MPoly{T}, n::T, a::MPoly{T}) where {T <: RingElement} = a * n
+
 *(n::Union{Integer, Rational, AbstractFloat}, a::MPoly) = a*n
 
 *(n::T, a::MPoly{T}) where {T <: RingElem} = a*n


### PR DESCRIPTION
@tthsqe12 I could you need your help here.

The aim is make the following example from some Oscar computation faster (brought to you by @HechtiDerLachs): https://gist.github.com/thofma/d57f49b9349a9e337870c9ea63dbf33e 
Note that with the branch here, the example should be run after `using Nemo` and also needs
```julia
function Nemo.mul!(a::fmpq_mpoly, b::fmpq, c::fmpq_mpoly)
  ccall((:fmpq_mpoly_scalar_mul_fmpq, Nemo.libflint), Nothing, (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq}, Ref{FmpqMPolyRing}), a, c, b, parent(a))
  return a
end
```

The improvement I propose here is just using `mul!` for the scalar multiplication (improves runtime a lot) and using a geobucket (improves runtime not so much). On my machine this improves the runtime from `3s` to `1.5s`.

Here are my questions:

1. Should we have a `mul!(a::RingElement, b::RingElement, c::RingElemt) = b * c` fallback? Then we could use `mul!` in both branches of the `evaluate`.
2. Can you provide some code for the `mul!(::MPoly{T}, T, ::MPoly{T}` method, i.e., the generic multivariate code?
3. Do you have other ideas to improve the case where one plugs polynomials into polynomials?