### PR TITLE
Add method for evaluation of polynomials with different caching pattern.

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1096,8 +1096,8 @@ function log_evaluate(f::MPolyElem, p::Vector{T};
     return result
   end
 
-  #return sum([c*eval_mon(a) for (c, a) in reverse(collect(zip(coefficients(f), exponent_vectors(f))))])
-  return sum([c*eval_mon(a) for (c, a) in collect(zip(coefficients(f), exponent_vectors(f)))])
+  return sum([c*eval_mon(a) for (c, a) in reverse(collect(zip(coefficients(f), exponent_vectors(f))))])
+  #return sum([c*eval_mon(a) for (c, a) in collect(zip(coefficients(f), exponent_vectors(f)))])
 end
 
 # For a list of polynomials f to be evaluated on the same elements p, 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1161,6 +1161,7 @@ function horner_for_lex_evaluate(
     power_cache::Vector{Vector{T}} = [[q] for q in p]
   ) where {T}
   R = parent(f)
+  ordering(R) == :lex || error("polynomial ring must have lexicographic ordering")
   kk = coefficient_ring(R)
   iszero(f) && return zero(kk)
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1082,22 +1082,22 @@ function log_evaluate(f::MPolyElem, p::Vector{T};
       return q
     end
 
-    c = [as_sum_of_powers_of_2(k) for k in a-b]
+    c = [as_sum_of_powers_of_2(k) for k in e]
 
     m = maximum([length(s) for s in c])
 
     result = q
+    exp_list = [[length(c[i]) <= j ? 0 : c[i][j] for i in 1:n] for j in m:-1:1]
     for j in 1:m
-      e = [length(c[i])>0 ? pop!(c[i]) : 0 for i in 1:n]
-      result *= look_up(e)
-      b += e
+      result *= look_up(exp_list[j])
+      b += exp_list[j]
       push!(cache, (b, result))
     end
     return result
   end
 
-  return sum([c*eval_mon(a) for (c, a) in reverse(collect(zip(coefficients(f), exponent_vectors(f))))])
-  #return sum([c*eval_mon(a) for (c, a) in collect(zip(coefficients(f), exponent_vectors(f)))])
+  #return sum([c*eval_mon(a) for (c, a) in reverse(collect(zip(coefficients(f), exponent_vectors(f))))])
+  return sum([c*eval_mon(a) for (c, a) in collect(zip(coefficients(f), exponent_vectors(f)))])
 end
 
 # For a list of polynomials f to be evaluated on the same elements p, 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1044,7 +1044,7 @@ function log_evaluate(f::MPolyElem, p::Vector{T};
       j = j << 1
       push!(list, k & j)
     end
-    return reverse(list)
+    return list
   end
 
   # The following method assumes that e contains entries 
@@ -1075,8 +1075,9 @@ function log_evaluate(f::MPolyElem, p::Vector{T};
     end
     b, q = (length(cache) == 0 ? ([0 for i in 1:length(a)], one(p[1])) : last(cache))
 
-    if haskey(power_cache, a-b) 
-      q = q*power_cache[a-b]
+    e = a-b
+    if haskey(power_cache, e) 
+      q = q*power_cache[e]
       push!(cache, (a, q))
       return q
     end
@@ -1087,7 +1088,7 @@ function log_evaluate(f::MPolyElem, p::Vector{T};
 
     result = q
     for j in 1:m
-      e = [length(c[i])>=j ? c[i][j] : 0 for i in 1:n]
+      e = [length(c[i])>0 ? pop!(c[i]) : 0 for i in 1:n]
       result *= look_up(e)
       b += e
       push!(cache, (b, result))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -941,6 +941,7 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V2)
+         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V2)
 
          V3 = [R(rand(-10:10)) for i in 1:num_vars]
 
@@ -950,6 +951,7 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V3)
+         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V3)
       end
    end
 
@@ -974,6 +976,7 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V1)
+         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V1)
       end
    end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -941,7 +941,6 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V2)
-         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V2)
 
          V3 = [R(rand(-10:10)) for i in 1:num_vars]
 
@@ -951,6 +950,32 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V3)
+      end
+   end
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+
+      S, varlist = PolynomialRing(R, var_names, ordering = :lex)
+
+      for iter = 1:50
+         f = rand(S, 0:5, 0:100, 0:0, -100:100)
+         g = rand(S, 0:5, 0:100, 0:0, -100:100)
+
+         V2 = [BigInt(rand(-10:10)) for i in 1:num_vars]
+
+         r1 = evaluate(f, V2)
+         r2 = evaluate(g, V2)
+         r3 = evaluate(f + g, V2)
+
+         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V2)
+
+         V3 = [R(rand(-10:10)) for i in 1:num_vars]
+
+         r1 = evaluate(f, V3)
+         r2 = evaluate(g, V3)
+         r3 = evaluate(f + g, V3)
+
          @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V3)
       end
    end
@@ -976,7 +1001,25 @@ end
 
          @test r3 == r1 + r2
          @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V1)
-         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V1)
+      end
+   end
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+
+      S, varlist = PolynomialRing(R, var_names, ordering = :lex)
+
+      for iter = 1:50
+         f = rand(S, 0:5, 0:100, 0:0, 0:0, -100:100)
+         g = rand(S, 0:5, 0:100, 0:0, 0:0, -100:100)
+
+         V1 = [rand(R1, 0:0, -10:10) for i in 1:num_vars]
+
+         r1 = evaluate(f, V1)
+         r2 = evaluate(g, V1)
+         r3 = evaluate(f + g, V1)
+
+         @test [r1, r2, r3] == AbstractAlgebra.horner_for_lex_evaluate([f, g, f+g], V1) 
       end
    end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -929,6 +929,9 @@ end
          r3 = evaluate(f + g, V1)
 
          @test r3 == r1 + r2
+         # The following does not work because log_evaluate does not 
+         # automatically convert to BigInt while evaluate somehow does.
+         #@test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V1)
 
          V2 = [BigInt(rand(-10:10)) for i in 1:num_vars]
 
@@ -937,6 +940,7 @@ end
          r3 = evaluate(f + g, V2)
 
          @test r3 == r1 + r2
+         @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V2)
 
          V3 = [R(rand(-10:10)) for i in 1:num_vars]
 
@@ -945,6 +949,7 @@ end
          r3 = evaluate(f + g, V3)
 
          @test r3 == r1 + r2
+         @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V3)
       end
    end
 
@@ -968,6 +973,7 @@ end
          r3 = evaluate(f + g, V1)
 
          @test r3 == r1 + r2
+         @test [r1, r2, r3] == AbstractAlgebra.log_evaluate([f, g, f+g], V1)
       end
    end
 


### PR DESCRIPTION
This is a code snippet for evaluation of polynomials with a different caching pattern. I found it to outperform the existing implementation when evaluating at elements of algebraic extensions of QQ. But since this is not part of AA, I didn't include this in the tests. Either way: This code might be useful for some special cases.