### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -112,7 +112,7 @@ _tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
 hashindex(key, sz) = (((hash(key)::UInt % Int) & (sz-1)) + 1)::Int
 
 # filled -> missing
-function _deleteindex!(h::WeakValueCache, index) where {K, V}
+function _deleteindex!(h::WeakValueCache, index)
    h.nfilled -= 1
    h.nmissing += 1
    h.slots[index] = 0x2

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -430,7 +430,7 @@ end
 #
 ###############################################################################
 
-function ^(a::AbsMSeries, b::Int) where T <: RingElement
+function ^(a::AbsMSeries, b::Int)
     b < 0 && throw(DomainError(b, "Can't take negative power"))
     R = parent(a)
     prec = precision(a)

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -738,7 +738,7 @@ function remove(z::UnivPoly{T, U}, p::UnivPoly{T, U}) where {T, U}
    return val, UnivPoly{T, U}(q, S)
 end
 
-function valuation(z::UnivPoly{T}, p::UnivPoly{T}) where {T, U}
+function valuation(z::UnivPoly{T}, p::UnivPoly{T}) where {T}
   v, _ = remove(z, p)
   return v
 end

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -738,7 +738,7 @@ function remove(z::UnivPoly{T, U}, p::UnivPoly{T, U}) where {T, U}
    return val, UnivPoly{T, U}(q, S)
 end
 
-function valuation(z::UnivPoly{T}, p::UnivPoly{T}) where {T}
+function valuation(z::UnivPoly{T, U}, p::UnivPoly{T, U}) where {T, U}
   v, _ = remove(z, p)
   return v
 end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this isn't merely cosmetic.

FTR, there's a relevant function in Test in stdlib for checking this stuff:
https://docs.julialang.org/en/v1/stdlib/Test/#Test.detect_unbound_args