### PR TITLE
add evaluate_horner_lex

### DIFF
--- a/test/algorithms/MPolyEvaluate-test.jl
+++ b/test/algorithms/MPolyEvaluate-test.jl
@@ -11,6 +11,10 @@ function test_evaluate(f, v, q = evaluate(f, v))
   @test typeof(q) == typeof(e3[1]) == typeof(e3[2])
   @test q == e3[1]
   @test q == e3[2]
+
+  e4 = AbstractAlgebra.evaluate_horner_lex(f, v)
+  @test typeof(q) == typeof(e4)
+  @test q == e4
 end
 
 @testset "MPolyEvaluate.ZZ(ZZ[x])" begin
@@ -29,7 +33,7 @@ end
 end
 
 @testset "MPolyEvaluate.ZZ(QQ)" begin
-  R, (x, y, z, t) = ZZ["x", "y", "z", "t"]
+  R, (x, y, z, t) = PolynomialRing(ZZ, ["x", "y", "z", "t"], ordering = :degrevlex)
   test_evaluate(zero(R), [QQ(), QQ(), QQ(), QQ()])
   test_evaluate(one(R), [QQ(), QQ(), QQ(), QQ()])
   for i in 1:100


### PR DESCRIPTION
This isn't HechtiDerLach's original horner_lex code since I couldn't figure out why that code wasn't doing an iterated univariate horner. This code here has a better bound on the recursion depth (nvars instead of total degree), and it is about the same speed as the non-recursive horner while having sub-quadratic overhead in the worst case.