### PR TITLE
Fix `@alias` macro and add its tests to the test suite

### DIFF
--- a/src/AliasMacro.jl
+++ b/src/AliasMacro.jl
@@ -10,7 +10,9 @@ statement must come before the invocation of this macro.
 
 This can be used to provide aliases like `is_isomorphic` for `is_isomorphic`
 (or vice versa); unlike `@deprecate`, methods can be installed under either name,
-as the two names really refer to the same object
+as the two names really refer to the same object.
+
+The alias also gets a special docstring that points out that it is an alias
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
@@ -26,7 +28,7 @@ macro alias(alias_name::Symbol, real_name::Symbol)
         if isdefined($__module__, $(QuoteNode(alias_name)))
             $alias_name === $real_name || error("Alias '$($(string(alias_name)))' is already defined with a different value")
         else
-            """
+            @doc """
                 $($(string(alias_name)))
 
             Alias for `$($(string(real_name)))`.

--- a/test/AbstractAlgebra-test.jl
+++ b/test/AbstractAlgebra-test.jl
@@ -1,6 +1,7 @@
 include("conformance-tests.jl")
 
 include("error-test.jl")
+include("AliasMacro-test.jl")
 include("Attributes-test.jl")
 include("WeakValueDict-test.jl")
 include("Groups-test.jl")


### PR DESCRIPTION
The `@alias` macro is supposed to set a special docstring for aliases which indicate what they are an alias for. This was broken at some point, but because the tests were not run, nobody noticed.

I noticed this a few weeks ago, and was confused why the test I wrote for this didn't trigger... well, because I was / am stupid *sigh*.

I also discussed this with a few people (in Blaubeuren? perhaps with @fieker or @thofma ?!) Anyway, in that discussion, some people said they actually thought the current behavior (were the alias gets the same docstring as the original symbol) was intentional and perhaps even better. So of course we could also discuss dropping this behavior and the test instead. However, my rationale for having a different docstring for the alias is that this makes it clearer what goes on: otherwise it may not always be clear why asking for the docstring of `alias_name` shows the docstring for `real_name` instead. Having a seperate docstring allows us to specify what the preferred name is...