### PR TITLE
Change @attr to use fixed symbols for compute functions

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -330,9 +330,10 @@ macro attr(ex1, exs...)
    # store the original function name
    name = d[:name]
 
-   # take the original function and rename it; use a unique name to ensure
-   # there are no clashes caused by spurious additional methods
-   compute_name = gensym("compute_$(name)")
+   # take the original function and rename it; use a distinctive name to
+   # minimize the risk of accidental conflicts. We deliberately don't
+   # use gensym anymore because this interacts badly with Revise.
+   compute_name = Symbol("__compute_$(name)__")
    compute_def = copy(d)
    compute_def[:name] = compute_name
    compute = MacroTools.combinedef(compute_def)


### PR DESCRIPTION
When using Revise and editing a function using @attr, one previously got warning like this one:

    ┌ Warning: skipping callee ##compute_elements#699 (called by false) due to UndefVarError(Symbol("#3732#3733"))
    └ @ LoweredCodeUtils ~/.julia/packages/LoweredCodeUtils/0oUEK/src/signatures.jl:292

This patch avoids this, and perhaps also is useful for debugging the underlying code of a function decorated by `@attr`


CC @simonbrandhorst 