### PR TITLE
Rename the leading_* functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.27.6"
+version = "0.28.0"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -816,12 +816,12 @@ The leading and trailing coefficient, constant coefficient, leading monomial
 and leading term of a polynomial p are returned by the following functions:
 
 ```@docs
-leading_coefficient(::MPolyElem{T}) where T <: RingElement
-trailing_coefficient(p::MPolyElem{T}) where T <: RingElement
-leading_monomial(::MPolyElem{T}) where T <: RingElement
-leading_term(::MPolyElem{T}) where T <: RingElement
+AbstractAlgebra.lc(::MPolyElem{T}) where T <: RingElement
+AbstractAlgebra.tc(p::MPolyElem{T}) where T <: RingElement
+AbstractAlgebra.lm(::MPolyElem{T}) where T <: RingElement
+AbstractAlgebra.lt(::MPolyElem{T}) where T <: RingElement
 constant_coefficient(::MPolyElem{T}) where T <: RingElement
-tail(::MPolyElem{T}) where T <: RingElement
+AbstractAlgebra.tl(::MPolyElem{T}) where T <: RingElement
 ```
 
 **Examples**
@@ -831,12 +831,12 @@ tail(::MPolyElem{T}) where T <: RingElement
 using AbstractAlgebra
 R,(x,y) = PolynomialRing(ZZ, ["x", "y"], ordering=:deglex)
 p = 2*x*y + 3*y^3 + 1
-leading_term(p)
-leading_monomial(p)
-leading_coefficient(p)
-leading_term(p) == leading_coefficient(p) * leading_monomial(p)
+AbstractAlgebra.lt(p)
+AbstractAlgebra.lm(p)
+AbstractAlgebra.lc(p)
+AbstractAlgebra.lt(p) == AbstractAlgebra.lc(p) * AbstractAlgebra.lm(p)
 constant_coefficient(p)
-tail(p)
+AbstractAlgebra.tl(p)
 ```
 
 ### Least common multiple, greatest common divisor

--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -18,7 +18,7 @@ function O(a::AbsMSeriesElem{T}) where T <: RingElement
     R = parent(a)
     p = poly(a)
     v = vars(p)
-    (length(v) != 1 || length(p) != 1 || !isone(leading_coefficient(p))) &&
+    (length(v) != 1 || length(p) != 1 || !isone(lc(p))) &&
                                                error("Not a pure power in O()")
     ind = var_index(v[1])
     exps = first(exponent_vectors(p))

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -204,11 +204,11 @@ function coeff(f::AbstractAlgebra.MPolyElem{T}, m::AbstractAlgebra.MPolyElem{T})
 end
 
 @doc Markdown.doc"""
-    leading_coefficient(p::MPolyElem)
+    AbstractAlgebra.lc(p::MPolyElem)
 
 Return the leading coefficient of the polynomial $p$.
 """
-function leading_coefficient(p::MPolyElem{T}) where T <: RingElement
+function lc(p::MPolyElem{T}) where T <: RingElement
    if iszero(p)
       return zero(base_ring(p))
    else
@@ -216,13 +216,15 @@ function leading_coefficient(p::MPolyElem{T}) where T <: RingElement
    end
 end
 
+lc(p::PolyElem) = leading_coefficient(p)
+
 @doc Markdown.doc"""
-    trailing_coefficient(p::MPolyElem)
+    AbstractAlgebra.tc(p::MPolyElem)
 
 Return the trailing coefficient of the polynomial $p$, i.e. the coefficient of
 the last nonzero term, or zero if the polynomial is zero.
 """
-function trailing_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
+function tc(p::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
    coeff = zero(base_ring(p))
    for c in coefficients(p)
       coeff = c
@@ -231,12 +233,12 @@ function trailing_coefficient(p::AbstractAlgebra.MPolyElem{T}) where T <: RingEl
 end
 
 @doc Markdown.doc"""
-    tail(p::MPolyElem)
+    AbstractAlgebra.tl(p::MPolyElem)
 
 Return the tail of the polynomial $p$, i.e. the polynomial without its leading
 term (if any).
 """
-function tail(p::MPolyElem{T}) where T <: RingElement
+function tl(p::MPolyElem{T}) where T <: RingElement
    S = parent(p)
    if iszero(p)
       return S()
@@ -275,12 +277,12 @@ function constant_coefficient(p::MPolyElem)
 end
 
 @doc Markdown.doc"""
-    leading_monomial(p::MPolyElem)
+    AbstractAlgebra.lm(p::MPolyElem)
 
 Return the leading monomial of $p$.
 This function throws an `ArgumentError` if $p$ is zero.
 """
-function leading_monomial(p::MPolyElem{T}) where T <: RingElement
+function lm(p::MPolyElem{T}) where T <: RingElement
    if iszero(p)
       throw(ArgumentError("Zero polynomial does not have a leading monomial"))
    end
@@ -302,12 +304,12 @@ function leading_exponent_vector(p::MPolyElem{T}) where T <: RingElement
 end
 
 @doc Markdown.doc"""
-    leading_term(p::MPolyElem)
+    AbstractAlgebra.lt(p::MPolyElem)
 
 Return the leading term of the polynomial p.
 This function throws an `ArgumentError` if $p$ is zero.
 """
-function leading_term(p::MPolyElem{T}) where T <: RingElement
+function lt(p::MPolyElem{T}) where T <: RingElement
    if iszero(p)
       throw(ArgumentError("Zero polynomial does not have a leading term"))
    end
@@ -380,7 +382,7 @@ iszero(x::AbstractAlgebra.MPolyElem{T}) where T <: RingElement = length(x) == 0
 
 function is_unit(a::AbstractAlgebra.MPolyElem{T}) where T <: RingElement
    if is_constant(a)
-      return is_unit(leading_coefficient(a))
+      return is_unit(lc(a))
    elseif is_domain_type(elem_type(coefficient_ring(a)))
       return false
    elseif length(a) == 1
@@ -1052,7 +1054,7 @@ function to_univariate(R::AbstractAlgebra.PolyRing{T}, p::AbstractAlgebra.MPolyE
       error("Can only convert univariate polynomials of type MPoly.")
    end
    if is_constant(p)
-      return R(leading_coefficient(p))
+      return R(lc(p))
    end
    return R(coefficients_of_univariate(p))
 end

--- a/src/algorithms/MPolyFactor.jl
+++ b/src/algorithms/MPolyFactor.jl
@@ -165,7 +165,7 @@ function make_monic(a::E) where E
   if length(a) < 1
     return a
   end
-  lc = leading_coefficient(a)
+  lc = AbstractAlgebra.lc(a)
   if isone(lc)
     return a
   else

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -200,7 +200,7 @@ function is_gen(a::AbsMSeries)
     p = poly(a)
     v = vars(p)
     return length(v) == 1 && length(p) == 1 &&
-          isone(leading_coefficient(p)) && sum(first(exponent_vectors(p))) == 1
+          isone(AbstractAlgebra.lc(p)) && sum(first(exponent_vectors(p))) == 1
 end
 
 function deepcopy_internal(a::AbsMSeries, dict::IdDict)

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -67,7 +67,7 @@ end
 
 function isone(a::LaurentMPolyWrap)
     isone(length(a.mpoly)) || return false
-    isone(leading_coefficient(a.mpoly)) || return false
+    isone(AbstractAlgebra.lc(a.mpoly)) || return false
     e = leading_exponent_vector(a.mpoly)
     for i in 1:length(e)
         e[i] == -a.mindegs[i] || return false
@@ -392,7 +392,7 @@ end
 #### coefficients
 
 function leading_coefficient(a::LaurentMPolyWrap)
-    return leading_coefficient(a.mpoly)
+    return AbstractAlgebra.lc(a.mpoly)
 end
 
 function coefficients(a::LaurentMPolyWrap)
@@ -443,7 +443,7 @@ end
 #### monomials
 
 function leading_monomial(a::LaurentMPolyWrap)
-    return LaurentMPolyWrap(parent(a), leading_monomial(a.mpoly), a.mindegs)
+    return LaurentMPolyWrap(parent(a), AbstractAlgebra.lm(a.mpoly), a.mindegs)
 end
 
 struct LaurentMPolyWrapMonomials{T, S}
@@ -479,7 +479,7 @@ end
 #### terms
 
 function leading_term(a::LaurentMPolyWrap)
-    return LaurentMPolyWrap(parent(a), leading_term(a.mpoly), a.mindegs)
+    return LaurentMPolyWrap(parent(a), AbstractAlgebra.lt(a.mpoly), a.mindegs)
 end
 
 struct LaurentMPolyWrapTerms{T, S}

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -677,7 +677,7 @@ function coeff(x::MPoly, i::Int)
    return x.coeffs[i]
 end
 
-function trailing_coefficient(p::MPoly{T}) where T <: RingElement
+function AbstractAlgebra.tc(p::MPoly{T}) where T <: RingElement
    if iszero(p)
       return zero(base_ring(p))
    else

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -196,25 +196,25 @@ function term(p::UnivPoly{T, U}, i::Int) where {T, U}
    return UnivPoly{T, U}(t, S)
 end
 
-leading_coefficient(p::UnivPoly) = leading_coefficient(p.p)
+leading_coefficient(p::UnivPoly) = AbstractAlgebra.lc(p.p)
 
-trailing_coefficient(p::UnivPoly) = trailing_coefficient(p.p)
+trailing_coefficient(p::UnivPoly) = AbstractAlgebra.tc(p.p)
 
 function tail(p::UnivPoly{T, U}) where {T, U}
    S = parent(p)
-   return UnivPoly{T, U}(tail(p.p), S)
+   return UnivPoly{T, U}(AbstractAlgebra.tl(p.p), S)
 end
 
 constant_coefficient(p::UnivPoly) = constant_coefficient(p.p)
 
 function leading_monomial(p::UnivPoly{T, U}) where {T, U}
    S = parent(p)
-   return UnivPoly{T, U}(leading_monomial(p.p), S)
+   return UnivPoly{T, U}(AbstractAlgebra.lm(p.p), S)
 end
 
 function leading_term(p::UnivPoly{T, U}) where {T, U}
    S = parent(p)
-   return UnivPoly{T, U}(leading_term(p.p), S)
+   return UnivPoly{T, U}(AbstractAlgebra.lt(p.p), S)
 end
 
 max_fields(p::UnivPoly) = max_fields(p.p)

--- a/test/generic/Ideal-test.jl
+++ b/test/generic/Ideal-test.jl
@@ -27,8 +27,8 @@ function mix_ideal(I::Ideal{T}) where T <: RingElement
 end
 
 function spoly(f::T, g::T) where T <: MPolyElem
-   fc = leading_coefficient(f)
-   gc = leading_coefficient(g)
+   fc = AbstractAlgebra.lc(f)
+   gc = AbstractAlgebra.lc(g)
    mf = exponent_vector(f, 1)
    mg = exponent_vector(g, 1)
    c = lcm(fc, gc)
@@ -40,8 +40,8 @@ function spoly(f::T, g::T) where T <: MPolyElem
 end
 
 function gpoly(f::T, g::T) where T <: MPolyElem
-   fc = leading_coefficient(f)
-   gc = leading_coefficient(g)
+   fc = AbstractAlgebra.lc(f)
+   gc = AbstractAlgebra.lc(g)
    mf = exponent_vector(f, 1)
    mg = exponent_vector(g, 1)
    _, s, t = gcdx(fc, gc)
@@ -201,7 +201,7 @@ end
 
       for i = 2:length(G)
          @test length(G[i]) > length(G[i - 1])
-         @test divides(leading_coefficient(G[i - 1]), leading_coefficient(G[i]))[1]
+         @test divides(AbstractAlgebra.lc(G[i - 1]), AbstractAlgebra.lc(G[i]))[1]
       end
 
       @test Ideal(R, gens(I)) == I

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -364,7 +364,7 @@ z^4-4*x*y-10*x*z^2+8*y^2*z^5-9*y^2*z^3
    end
 end
 
-@testset "Generic.MPoly.leading_term" begin
+@testset "Generic.MPoly.AbstractAlgebra.lt" begin
    for num_vars=1:10
       ord = rand_ordering()
       var_names = ["x$j" for j in 1:num_vars]
@@ -375,18 +375,18 @@ end
       g = rand(R, 5:10, 1:10, -100:100)
 
       if !iszero(f) && !iszero(g)
-         @test leading_term(f*g) == leading_term(f)*leading_term(g)
+         @test AbstractAlgebra.lt(f*g) == AbstractAlgebra.lt(f)*AbstractAlgebra.lt(g)
       else
-         @test_throws ArgumentError leading_term(f)*leading_term(g)
+         @test_throws ArgumentError AbstractAlgebra.lt(f)*AbstractAlgebra.lt(g)
       end
-      @test leading_term(one(R)) == one(R)
-      @test_throws ArgumentError leading_term(zero(R))
+      @test AbstractAlgebra.lt(one(R)) == one(R)
+      @test_throws ArgumentError AbstractAlgebra.lt(zero(R))
 
       for v in vars_R
-         @test leading_term(v) == v
+         @test AbstractAlgebra.lt(v) == v
       end
 
-      @test parent(leading_term(f)) == parent(f)
+      @test parent(AbstractAlgebra.lt(f)) == parent(f)
    end
 
    for num_vars = 1:4
@@ -398,15 +398,15 @@ end
          f = rand(S, 0:4, 0:5, -10:10)
          g = rand(S, 0:4, 0:5, -10:10)
 
-         @test leading_coefficient(f*g) ==
-	       leading_coefficient(f)*leading_coefficient(g)
-         @test leading_coefficient(one(S)) == one(base_ring(S))
+         @test AbstractAlgebra.lc(f*g) ==
+	       AbstractAlgebra.lc(f)*AbstractAlgebra.lc(g)
+         @test AbstractAlgebra.lc(one(S)) == one(base_ring(S))
 
          for v in varlist
-            @test leading_coefficient(v) == one(base_ring(S))
+            @test AbstractAlgebra.lc(v) == one(base_ring(S))
          end
 
-         @test parent(leading_coefficient(f)) == base_ring(f)
+         @test parent(AbstractAlgebra.lc(f)) == base_ring(f)
       end
    end
 
@@ -425,18 +425,18 @@ end
             g = rand(S, 0:4, 0:5, -10:10)
          end
 
-         @test leading_monomial(f*g) == leading_monomial(f)*leading_monomial(g)
+         @test AbstractAlgebra.lm(f*g) == AbstractAlgebra.lm(f)*AbstractAlgebra.lm(g)
          @test leading_exponent_vector(f*g) == leading_exponent_vector(f) +
                                                leading_exponent_vector(g)
-         @test leading_monomial(one(S)) == one(S)
-         @test_throws ArgumentError leading_monomial(zero(S))
+         @test AbstractAlgebra.lm(one(S)) == one(S)
+         @test_throws ArgumentError AbstractAlgebra.lm(zero(S))
          @test_throws ArgumentError leading_exponent_vector(zero(S))
 
          for v in varlist
-            @test leading_monomial(v) == v
+            @test AbstractAlgebra.lm(v) == v
          end
 
-         @test parent(leading_monomial(f)) == parent(f)
+         @test parent(AbstractAlgebra.lm(f)) == parent(f)
       end
    end
 
@@ -447,14 +447,14 @@ end
    @test constant_coefficient(2x) == 0
    @test constant_coefficient(2x^2 + 3y^3 + 4) == 4
 
-   @test trailing_coefficient(x^2*y + 7x*y + 3x + 2y + 5) == 5
-   @test trailing_coefficient(x^2*y + 7x*y + 3x + 2y) == 2
-   @test trailing_coefficient(R(2)) == 2
-   @test trailing_coefficient(R()) == 0
+   @test AbstractAlgebra.tc(x^2*y + 7x*y + 3x + 2y + 5) == 5
+   @test AbstractAlgebra.tc(x^2*y + 7x*y + 3x + 2y) == 2
+   @test (R(2)) == 2
+   @test (R()) == 0
 
-   @test tail(2x^2 + 2x*y + 3) == 2x*y + 3
-   @test tail(R(1)) == 0
-   @test tail(R()) == 0
+   @test AbstractAlgebra.tl(2x^2 + 2x*y + 3) == 2x*y + 3
+   @test AbstractAlgebra.tl(R(1)) == 0
+   @test AbstractAlgebra.tl(R()) == 0
 end
 
 @testset "Generic.MPoly.total_degree" begin


### PR DESCRIPTION
Going back to good'ol `lm` and `lc` to allow more useful `leading_*` methods.