### PR TITLE
Disable karatsuba by default

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -747,7 +747,7 @@ function mul_classical(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement
 end
 
 function use_karamul(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement
-   return length(a) > 5 && length(b) > 5
+   return false
 end
 
 function *(a::PolyElem{T}, b::PolyElem{T}) where T <: RingElement


### PR DESCRIPTION
This is for https://github.com/Nemocas/Nemo.jl/blob/master/benchmarks/fateman.jl. It seems this is a benchmark we brag about, so we should not make it slower and slower.

Before:
```
benchmark_fateman ...   2.114 s (594448 allocations: 43.20 MiB)
```

After:
```
benchmark_fateman ...   1.171 s (150346 allocations: 11.95 MiB)
```

@tthsqe12 do you know a better way to fix this regression?
