### PR TITLE
Improve type stability in `rref!`

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1836,8 +1836,8 @@ function rref_rational(M::MatrixElem{T}) where {T <: RingElement}
 end
 
 function rref!(A::MatrixElem{T}) where {T <: FieldElement}
-   m = nrows(A)
-   n = ncols(A)
+   m = nrows(A)::Int
+   n = ncols(A)::Int
    R = base_ring(A)
    P = one(SymmetricGroup(m))
    rnk = lu!(P, A)


### PR DESCRIPTION
... and thereby also resulting method invalidations, by adding
type assertion guaranteeing that nrows and ncols return an `Int`.

In an ideal world Julia could always deduce this from type inference.
But in practice, this may sometimes be impossible, namely if the
type of the matrix `A` is not fully known (e.g. because the code
invoking `rref!`, does not know it -- in other words, if somewhere
above in the call stack the type is not known).
