### PR TITLE
Fail CI on deprecation warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,8 @@ jobs:
         uses: julia-actions/julia-buildpkg@latest
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
+        with:
+          depwarn: error
       - name: "Run doctests"
         if: ${{ matrix.julia-version == '1.6' }}
         run: |


### PR DESCRIPTION
The same as https://github.com/oscar-system/Oscar.jl/pull/1957, i.e. the tests should now fail once a deprecation warning is encountered.

cc @thofma @fieker @fingolfin