### PR TITLE
Remove `get_field` and `set_field!`

### DIFF
--- a/docs/src/map_interface.md
+++ b/docs/src/map_interface.md
@@ -90,42 +90,6 @@ if all features of the generic Map infrastructure are required. It is bad practi
 write functions for `MyMap` directly instead of `Map(MyMap)`, since other users will be
 unable to use generic constructions over the map type `MyMap`.
 
-## Getters and setters
-
-When writing new map types, it is very important to define getters and setters of the
-fields of the new map type, rather than to access them directly.
-
-Let us suppose that the `MyMap` type has a field called `foo`. Rather than access this
-field by writing `M.foo`, one must access it using `foo(M)` (at least until Julia 1.1).
-
-If such a getter only needs to access the field `foo` of `M`, there is a standard way of
-defining such a getter and setter when defining a new map type.
-
-```julia
-foo(M::Map(MyMap)) = get_field(M, :foo)
-```
-
-To set a field of a map, one needs a setter, which can be implemented as follows:
-
-```julia
-set_foo!(M::Map(MyMap), a) = set_field(M, :foo, a)
-```
-
-In general, setters should be used rarely for map types.
-
-!!! note
-
-    By providing getter and setter functions, map types need not even contain
-    fields with the given name. For example, for a `MyMap` map type for maps
-    between integers, one does not wish to explicitly store the domain and
-    codomain in `MyMap`. Instead, we can define the getter functions `domain`
-    and `codomain` to return `JuliaZZ` for any `MyMap` object.
-
-```julia
-domain(M::Map(MyMap)) = JuliaZZ
-codomain(M::Map(MyMap)) = JuliaZZ
-```
-
 ## Required functionality for maps
 
 All map types must implement a standard interface, which we specify here.

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -823,7 +823,6 @@ export gen
 export gens
 export get_attribute
 export get_attribute!
-export get_field
 export gram
 export has_attribute
 export has_bottom_neighbor
@@ -1060,7 +1059,6 @@ export set_attribute!
 export set_coefficient!
 export set_exponent_vector!
 export set_exponent_word!
-export set_field!
 export set_length!
 export set_limit!
 export set_precision!

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -165,9 +165,9 @@ import ..AbstractAlgebra: FieldElement
 import ..AbstractAlgebra: gen
 import ..AbstractAlgebra: gens
 import ..AbstractAlgebra: get_cached!
-import ..AbstractAlgebra: get_field
 import ..AbstractAlgebra: GFElem
 import ..AbstractAlgebra: identity_matrix
+import ..AbstractAlgebra: image_fn
 import ..AbstractAlgebra: inflate
 import ..AbstractAlgebra: Integers
 import ..AbstractAlgebra: integral
@@ -224,7 +224,6 @@ import ..AbstractAlgebra: Ring
 import ..AbstractAlgebra: RingElem
 import ..AbstractAlgebra: RingElement
 import ..AbstractAlgebra: set_coefficient!
-import ..AbstractAlgebra: set_field!
 import ..AbstractAlgebra: set_length!
 import ..AbstractAlgebra: set_precision!
 import ..AbstractAlgebra: set_valuation!

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -13,11 +13,14 @@
 Map(::Type{T}) where T <: Map = supertype(T)
 Map(::Type{S}) where S <: SetMap = Map{D, C, <:S, T} where {D, C, T}
 
-get_field(M, f) = getfield(M, f) # fall back to Julia builtin
-set_field!(M, f, g) = setfield!(M, f, g) # fall back to Julia builtin
+function domain end
+function codomain end
+function image_fn end
 
-domain(f::Map) = get_field(f, :domain)
-codomain(f::Map) = get_field(f, :codomain)
+domain(f::Map) = f.domain # fallback, FIXME: to be removed eventually
+codomain(f::Map) = f.codomain # fallback, FIXME: to be removed eventually
+image_fn(f::Map) = f.image_fn # fallback, FIXME: to be removed eventually
+
 
 function check_composable(a::Map, b::Map)
    codomain(a) != domain(b) && error("Incompatible maps")

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1161,13 +1161,11 @@ end
 ###############################################################################
 
 mutable struct CompositeMap{D, C} <: AbstractAlgebra.Map{D, C, AbstractAlgebra.SetMap, CompositeMap}
-   domain::D
-   codomain::C
    map1::AbstractAlgebra.Map
    map2::AbstractAlgebra.Map
 
    function CompositeMap(map1, map2)
-     return new{typeof(domain(map1)), typeof(codomain(map2))}(domain(map1), codomain(map2), map1, map2)
+     return new{typeof(domain(map1)), typeof(codomain(map2))}(map1, map2)
    end
 end
 
@@ -1200,14 +1198,12 @@ end
 ###############################################################################
 
 mutable struct FunctionalCompositeMap{D, C} <: AbstractAlgebra.Map{D, C, AbstractAlgebra.FunctionalMap, FunctionalCompositeMap}
-   domain::D
-   codomain::C
    map1::AbstractAlgebra.Map
    map2::AbstractAlgebra.Map
    fn_cache::Function
 
    function FunctionalCompositeMap(map1::Map(AbstractAlgebra.FunctionalMap){D, U}, map2::Map(AbstractAlgebra.FunctionalMap){U, C}) where {D, U, C}
-      return new{D, C}(domain(map1), codomain(map2), map1, map2)
+      return new{D, C}(map1, map2)
    end
 end
 

--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -41,7 +41,8 @@ end
 
 (f::IdentityMap)(a) = a
 
-codomain(f::AbstractAlgebra.Map(AbstractAlgebra.IdentityMap){D, C}) where {D, C} = domain(f)
+domain(f::IdentityMap) = f.domain
+codomain(f::IdentityMap) = f.domain
 
 function show(io::IO, M::IdentityMap)
    println(io, "Identity map with")
@@ -74,7 +75,9 @@ Base.inv(f::AbstractAlgebra.Map(AbstractAlgebra.IdentityMap)) = f
 #
 ################################################################################
 
-image_fn(f::AbstractAlgebra.Map(AbstractAlgebra.FunctionalMap)) = get_field(f, :image_fn)
+domain(f::FunctionalMap) = f.domain
+codomain(f::FunctionalMap) = f.codomain
+image_fn(f::FunctionalMap) = f.image_fn
 
 function (f::FunctionalMap{D, C})(a) where {D, C}
    parent(a) != domain(f) && throw(DomainError(f))
@@ -98,6 +101,9 @@ end
 #  FunctionalCompositeMap
 #
 ################################################################################
+
+domain(f::FunctionalCompositeMap) = domain(f.map1)
+codomain(f::FunctionalCompositeMap) = codomain(f.map2)
 
 # This is a device to prevent Julia trying to compute
 # the types of a very long composition of closures

--- a/src/generic/MapCache.jl
+++ b/src/generic/MapCache.jl
@@ -4,11 +4,9 @@
 #
 ################################################################################
 
-get_field(M::MapCache, f) = getfield(M.map, f) # pass accessors through
-set_field!(M::MapCache, f) = setfield(M.map, f) # pass accessors through
-
 domain(M::MapCache{D, C}) where {D, C} = domain(M.map)::D
 codomain(M::MapCache{D, C}) where {D, C} = codomain(M.map)::C
+image_fn(M::MapCache{D, C}) where {D, C} = image_fn(M.map)
 
 function set_limit!(M::MapCache, limit::Int)
    limit < 0 && error("Limit must be nonnegative")

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -10,6 +10,14 @@
 #
 ###############################################################################
 
+domain(f::ModuleHomomorphism) = f.domain
+codomain(f::ModuleHomomorphism) = f.codomain
+image_fn(f::ModuleHomomorphism) = f.image_fn
+
+domain(f::ModuleIsomorphism) = f.domain
+codomain(f::ModuleIsomorphism) = f.codomain
+image_fn(f::ModuleIsomorphism) = f.image_fn
+
 inverse_mat(f::Map(ModuleIsomorphism)) = f.inverse_matrix
 
 inverse_image_fn(f::Map(ModuleIsomorphism)) = f.inverse_image_fn

--- a/test/generic/Map-test.jl
+++ b/test/generic/Map-test.jl
@@ -2,10 +2,10 @@ mutable struct MyMap <: Map{AbstractAlgebra.Integers{BigInt}, AbstractAlgebra.In
    a::Int
 end
 
-Generic.domain(f::Map(MyMap)) = AbstractAlgebra.JuliaZZ
-Generic.codomain(f::Map(MyMap)) = AbstractAlgebra.JuliaZZ
+Generic.domain(f::MyMap) = AbstractAlgebra.JuliaZZ
+Generic.codomain(f::MyMap) = AbstractAlgebra.JuliaZZ
 
-a(f::Map(MyMap)) = Generic.get_field(f, :a)
+a(f::MyMap) = f.a
 
 (f::MyMap)(x) =  a(f)*(x + 1)
 

--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -3,6 +3,9 @@
 
    f = ModuleHomomorphism(M, M, matrix(ZZ, 2, 2, [1, 2, 3, 4]))
 
+   @test domain(f) == M
+   @test codomain(f) == M
+
    @test isa(f, Generic.Map(FunctionalMap))
 
    m = M([ZZ(1), ZZ(2)])
@@ -119,6 +122,8 @@ end
       N = randmat_with_rank(S, n, -10:10)
       f = ModuleIsomorphism(M, M, N)
 
+      @test domain(f) == M
+      @test codomain(f) == M
       @test mat(f) == N
       @test N*inverse_mat(f) == 1
 


### PR DESCRIPTION
I just came across this branch, which I wrote almost exactly a year ago but then never submitted. I tried to understand the `Map` code and `get_field` really took me some time to understand, and then determine that it seems mostly (?) useless? Anyway, I felt I should just submit this now, either we use it or we discard it *shrug*.

Here is the description from the original commit message:

There were meant to provide additional generality to maps in Oscar, and allow writing "more generic" code. In practice, as far as I can tell no public code outside of AbstractAlgebra ever used them. As to writing generic code: the idea, as I understand it (which may be wrong) seems to be that certain generic map implementation can use it to forward "arbitrary" map functionality, even beyond what they were made for. But the same could be done by adding explicit forwarding methods, as indeed this patch does for `domain` and `codomain`. This also means that not all map types must actually have fields `domain` and `codomain`, as was the case with the `get_field` mechanism.


