### PR TITLE
do not call `DocMeta.setdocmeta!` in AbstractAlgebra

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,10 @@
 using Documenter, AbstractAlgebra
 
-DocMeta.setdocmeta!(AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive = true)
+# We do *not* call `DocMeta.setdocmeta!` with value `:(using AbstractAlgebra)`
+# because we want to force that each jldoctest has its individual
+# `setup = :(using AbstractAlgebra)`.
+# The reason is that the AbstractAlgebra doctests are run also in Nemo,
+# where `using AbstractAlgebra` is deliberately avoided.
 
 makedocs(
          format = Documenter.HTML(),


### PR DESCRIPTION
(This is a follow-up of #1261.)