### PR TITLE
Move `polynomial_ring` code to abstract level

### DIFF
--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -47,15 +47,9 @@ accept any AbstractAlgebra polynomial type.
 In order to construct polynomials in AbstractAlgebra.jl, one must first construct the
 polynomial ring itself. This is accomplished with the following constructor.
 
-```julia
-polynomial_ring(R::NCRing, s::AbstractString; cached::Bool = true)
+```@docs
+polynomial_ring(R::NCRing, s::Symbol; cached::Bool = true)
 ```
-
-Given a base ring `R` and string `s` specifying how the generator (variable) should be
-printed, return a tuple `S, x` representing the new polynomial ring $S = R[x]$ and the
-generator $x$ of the ring. By default the parent object `S` will depend only on `R` and 
-`x` and will be cached. Setting the optional argument `cached` to `false` will prevent
-the parent object `S` from being cached.
 
 A shorthand version of this function is provided: given a base ring `R`, we abbreviate
 the constructor as follows.

--- a/docs/src/poly_interface.md
+++ b/docs/src/poly_interface.md
@@ -136,17 +136,30 @@ Return the array `[s]` where `s` is a `Symbol` representing the variable of the 
 polynomial ring. This is provided for uniformity with the multivariate interface, where
 there is more than one variable and hence an array of symbols.
 
-Custom polynomial types over a given ring should define the following function
-which returns the type of a polynomial object over that ring.
-
 ```julia
 dense_poly_type(::Type{T}) where T <: RingElement
 ```
 
-Return the type of a polynomial whose coefficients have the given type.
+Return the type of a polynomial whose coefficients have the given type. In our
+example `MyPoly{T}`.
 
 This function is defined for generic polynomials and only needs to be defined for
 custom polynomial rings, e.g. ones defined by a C implementation.
+
+```@docs
+polynomial_ring_only(R::Ring, s::Symbol; cached::Bool=true)
+```
+
+The default implementation figures out the appropriate polynomial ring type via
+`dense_poly_type` and calls its constructor with `R, s, cached` as arguments.
+In our example, this would be
+
+```julia
+MyPolyRing{T}(R, s, cached)
+```
+
+Accordingly, `polynomial_ring_only` only needs to be defined, if such a
+constructor does not exist or other behaviour is wanted.
 
 ### Basic manipulation of rings and elements
 

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -48,21 +48,15 @@ can accept any AbstractAlgebra polynomial type.
 In order to construct polynomials in AbstractAlgebra.jl, one must first construct the
 polynomial ring itself. This is accomplished with the following constructor.
 
-```julia
-polynomial_ring(R::Ring, s::AbstractString; cached::Bool = true)
+```@docs
+polynomial_ring(R::Ring, s::Symbol; cached::Bool = true)
 ```
-
-Given a base ring `R` and string `s` specifying how the generator (variable) should be
-printed, return a tuple `S, x` representing the new polynomial ring $S = R[x]$ and the
-generator $x$ of the ring. By default the parent object `S` will depend only on `R` and
-`x` and will be cached. Setting the optional argument `cached` to `false` will prevent
-the parent object `S` from being cached.
 
 A shorthand version of this function is provided: given a base ring `R`, we abbreviate
 the constructor as follows.
 
 ```julia
-R["x"]
+R[:x]
 ```
 
 It is also possible to create a polynomial ring with default symbol as follows.
@@ -84,12 +78,6 @@ generators.
 **Examples**
 
 ```jldoctest
-julia> R, x = polynomial_ring(ZZ, "x")
-(Univariate Polynomial Ring in x over Integers, x)
-
-julia> S, y = polynomial_ring(R, "y")
-(Univariate Polynomial Ring in y over Univariate Polynomial Ring in x over Integers, y)
-
 julia> T, z = QQ["z"]
 (Univariate Polynomial Ring in z over Rationals, z)
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1196,8 +1196,8 @@ getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R,
 getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}, ss::Union{Symbol, AbstractString, Char}...) =
    polynomial_ring(R, [s, ss...])
 
-# syntax: Rxy, y = R["x"]["y"]
-getindex(R::Tuple{NCRing, NCPolyRingElem}, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R[1], s)
+# syntax: Rxy, y = R[:x][:y]
+getindex(R::Union{Tuple{PolyRing, PolyRingElem}, Tuple{NCPolyRing, NCPolyRingElem}}, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R[1], s)
 
 ###############################################################################
 #

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1196,7 +1196,7 @@ export Generic
 
 getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R, s)
 getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}, ss::Union{Symbol, AbstractString, Char}...) =
-   polynomial_ring(R, [s, ss...])
+   polynomial_ring(R, [Symbol(x) for x in (s, ss...)])
 
 # syntax: Rxy, y = R[:x][:y]
 getindex(R::Union{Tuple{PolyRing, PolyRingElem}, Tuple{NCPolyRing, NCPolyRingElem}}, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R[1], s)

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -983,7 +983,6 @@ export polcoeff
 export poly
 export poly_ring
 export poly_ring_type
-export poly_type
 export PolyCoeffs
 export polynomial
 export polynomial_ring

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -592,7 +592,6 @@ import .Generic: cycles
 import .Generic: defining_polynomial
 import .Generic: degrees
 import .Generic: dense_matrix_type
-import .Generic: dense_poly_type
 import .Generic: dim
 import .Generic: disable_cache!
 import .Generic: downscale
@@ -647,7 +646,6 @@ import .Generic: monomial_iszero
 import .Generic: monomial_set!
 import .Generic: monomial!
 import .Generic: monomials
-import .Generic: mpoly_type
 import .Generic: MPolyBuildCtx
 import .Generic: mullow_karatsuba
 import .Generic: ngens
@@ -942,6 +940,7 @@ export monomial_to_newton!
 export monomial!
 export monomials
 export mpoly_type
+export mpoly_ring_type
 export MPolyBuildCtx
 export mul_classical
 export mul_karatsuba
@@ -983,9 +982,12 @@ export pol_length
 export polcoeff
 export poly
 export poly_ring
+export poly_ring_type
+export poly_type
 export PolyCoeffs
 export polynomial
 export polynomial_ring
+export polynomial_ring_only
 export polynomial_to_power_sums
 export PolynomialElem
 export PolyRing

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1192,12 +1192,12 @@ export Generic
 #
 ###############################################################################
 
-getindex(R::NCRing, s::Union{String, Char, Symbol}) = polynomial_ring(R, s)
-getindex(R::NCRing, s::Union{String, Char, Symbol}, ss::Union{String, Char}...) =
+getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R, s)
+getindex(R::NCRing, s::Union{Symbol, AbstractString, Char}, ss::Union{Symbol, AbstractString, Char}...) =
    polynomial_ring(R, [s, ss...])
 
-# syntax x = R["x"]["y"]
-getindex(R::Tuple{Union{Ring, NCRing}, Union{PolyRingElem, NCPolyRingElem}}, s::Union{String, Char, Symbol}) = polynomial_ring(R[1], s)
+# syntax: Rxy, y = R["x"]["y"]
+getindex(R::Tuple{NCRing, NCPolyRingElem}, s::Union{Symbol, AbstractString, Char}) = polynomial_ring(R[1], s)
 
 ###############################################################################
 #

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -986,7 +986,6 @@ export poly_ring_type
 export PolyCoeffs
 export polynomial
 export polynomial_ring
-export polynomial_ring_only
 export polynomial_to_power_sums
 export PolynomialElem
 export PolyRing

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1299,15 +1299,18 @@ end
 @doc Markdown.doc"""
     polynomial_ring(R::Ring, s::Vector{T}; cached::Bool = true, ordering::Symbol = :lex) where T <: Union{Symbol, AbstractString, Char}
 
-Given a base ring `R` and an array of symbols/strings `s` specifying how the
-generators (variables) should be printed, return a tuple `T, (x1, x2, ...)`
-representing the new polynomial ring $T = R[x1, x2, ...]$ and the generators
-$x1, x2, ...$ of the polynomial ring.
+Given a base ring `R` and a vector `s` of variable names $x1, x2, \dots$ specifying
+how the generators (variables) should be printed, return a tuple `S, [x1, x2, ...]`
+representing the new polynomial ring $S = R[x1, x2, ...]$ and the generators
+$x1, x2, \dots$ of the polynomial ring.
 
-By default the parent object `T` depends only on `R` and `x1, x2, ...` and will be cached.
-Setting the optional argument `cached` to `false` will prevent the parent object `T` from being cached.
+Mathematically the object `S` depends only on `R` and `x1, x2, ...` and by
+default it will be cached, i.e., if `polynomial_ring` is invoked again with the
+same arguments, the same (*identical*) ring is returned. Setting the optional
+argument `cached` to `false` ensures a distinct new ring is returned, and will
+also prevent it from being cached.
 
-The `ordering` of the polynomial can be one of `:lex`, `:deglex` or `:degrevlex`.
+The `ordering` of the polynomial ring can be one of `:lex`, `:deglex` or `:degrevlex`.
 """
 polynomial_ring(R::Ring, s::Union{Tuple{Vararg{T}}, AbstractVector{T}}; kw...) where
       T<:Union{Symbol, AbstractString, Char} =

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1341,7 +1341,7 @@ polynomial_ring(R::Ring, n::Int, s::Union{AbstractString, Char}; kw...) =
    polynomial_ring(R, n, Symbol(s); kw...)
 
 polynomial_ring(R::Ring, n::Int, s::Symbol=:x; kw...) =
-   polynomial_ring(R, Symbol.(s, 1:n), kw...)
+   polynomial_ring(R, Symbol.(s, 1:n); kw...)
 
 MPolyRing(R::Ring, n::Int) =
    polynomial_ring_only(R, Symbol.(:x, 1:n); cached=false)

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -16,6 +16,32 @@ coefficient_ring(a::MPolyRingElem) = base_ring(a)
 
 coefficient_ring(R::MPolyRing) = base_ring(R)
 
+@doc md"""
+    mpoly_type(::Type{T}) where T<:RingElement
+
+The type of multivariate polynomials with coefficients of type `T`.
+Falls back to `Generic.MPoly{T}`.
+
+# Examples
+```julia
+mpoly_type(typeof(ZZ()))
+```
+"""
+mpoly_type(::Type{T}) where T<:RingElement = Generic.MPoly{T}
+
+@doc md"""
+    mpoly_ring_type(::Type{T}) where T<:Ring
+
+The type of multivariate polynomial rings with coefficients of type `T`.
+Implemented via [`mpoly_type`](@ref).
+
+# Examples
+```julia
+mpoly_ring_type(typeof(ZZ))
+```
+"""
+mpoly_ring_type(::Type{T}) where T<:Ring = parent_type(mpoly_type(elem_type(T)))
+
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: AbstractAlgebra.MPolyRingElem{S}}
    return is_domain_type(S)
 end
@@ -1299,20 +1325,7 @@ Like [`polynomial_ring(R::Ring, s::Vector{Symbol})`](@ref) but return only the
 multivariate polynomial ring.
 """
 polynomial_ring_only(R::T, s::Vector{Symbol}; ordering::Symbol=:lex, cached::Bool=true) where T<:Ring =
-   mpolynomial_ring_type(T)(R, s, ordering, cached)
-
-@doc md"""
-    mpolynomial_ring_type(::Type{T}) where T<:NCRing
-
-The type of multivariate polynomial rings with coefficients of type `T`.
-Falls back to `MPolyRing{elem_type(T)}`.
-
-# Examples
-```julia
-mpolynomial_ring_type(typeof(ZZ))
-```
-"""
-mpolynomial_ring_type(::Type{T}) where T<:Ring = Generic.MPolyRing{elem_type(T)}
+   mpoly_ring_type(T)(R, s, ordering, cached)
 
 # Alternative constructors
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1335,7 +1335,7 @@ polynomial_ring_only(R::T, s::Vector{Symbol}; ordering::Symbol=:lex, cached::Boo
 @doc Markdown.doc"""
     polynomial_ring(R::Ring, n::Int, s::T = :x; cached, ordering) where T<:Union{Symbol, AbstractString, Char}
 
-Given a symbol/string `s` and a number of variables `n` will
+Given a symbol, string or character `s` and a number of variables `n` will
 do the same as the first constructor except that the variables will be
 automatically numbered. For example if `s` is the string `x` and `n = 3` then
 the variables will print as `x1`, `x2`, `x3`.

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -18,6 +18,33 @@ function is_exact_type(a::Type{T}) where {S <: NCRingElem, T <: NCPolyRingElem{S
    return is_exact_type(S)
 end
 
+@doc md"""
+    poly_type(::Type{T}) where T<:NCRingElement
+
+The type of multivariate polynomials with coefficients of type `T`.
+Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
+
+# Examples
+```julia
+poly_type(typeof(ZZ()))
+```
+"""
+poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
+@alias dense_poly_type poly_type
+
+@doc md"""
+    poly_ring_type(::Type{T}) where T<:NCRing
+
+The type of polynomial rings with coefficients of type `T`.
+Implemented via [`poly_type`](@ref).
+
+# Examples
+```julia
+poly_ring_type(typeof(ZZ))
+```
+"""
+poly_ring_type(::Type{T}) where T<:NCRing = parent_type(poly_type(elem_type(T)))
+
 @doc Markdown.doc"""
     var(a::NCPolyRing)
 
@@ -682,20 +709,7 @@ Like [`polynomial_ring(R::Ring, s::Symbol)`](@ref) but return only the
 polynomial ring.
 """
 polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =
-   polynomial_ring_type(T)(R, s, cached)
-
-@doc md"""
-    polynomial_ring_type(::Type{T}) where T<:NCRing
-
-The type of polynomial rings with coefficients of type `T`.
-Falls back to `PolyRing{elem_type(T)}`.
-
-# Examples
-```julia
-polynomial_ring_type(typeof(ZZ))
-```
-"""
-polynomial_ring_type(::Type{T}) where T<:NCRing = Generic.NCPolyRing{elem_type(T)}
+   poly_ring_type(T)(R, s, cached)
 
 # Simplified constructor
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -19,31 +19,30 @@ function is_exact_type(a::Type{T}) where {S <: NCRingElem, T <: NCPolyRingElem{S
 end
 
 @doc md"""
-    poly_type(::Type{T}) where T<:NCRingElement
+    dense_poly_type(::Type{T}) where T<:NCRingElement
 
 The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 
 # Examples
 ```julia
-poly_type(typeof(ZZ()))
+dense_poly_type(typeof(ZZ()))
 ```
 """
-poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
-@alias dense_poly_type poly_type
+dense_poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
 
 @doc md"""
     poly_ring_type(::Type{T}) where T<:NCRing
 
 The type of polynomial rings with coefficients of type `T`.
-Implemented via [`poly_type`](@ref).
+Implemented via [`dense_poly_type`](@ref).
 
 # Examples
 ```julia
 poly_ring_type(typeof(ZZ))
 ```
 """
-poly_ring_type(::Type{T}) where T<:NCRing = parent_type(poly_type(elem_type(T)))
+poly_ring_type(::Type{T}) where T<:NCRing = parent_type(dense_poly_type(elem_type(T)))
 
 @doc Markdown.doc"""
     var(a::NCPolyRing)

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -657,25 +657,46 @@ rand(S::NCPolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v..
 ###############################################################################
 
 @doc Markdown.doc"""
-    polynomial_ring(R::NCRing, s::Union{AbstractString, Char, Symbol}; cached::Bool = true)
+    polynomial_ring(R::NCRing, s::Union{Symbol, AbstractString, Char}; cached::Bool = true)
 
-Given a base ring `R` and string `s` specifying how the generator (variable)
-should be printed, return a tuple `S, x` representing the new polynomial
-ring $S = R[x]$ and the generator $x$ of the ring. By default the parent
-object `S` will depend only on `R` and `x` and will be cached. Setting the
-optional argument `cached` to `false` will prevent the parent object `S` from
-being cached.
+Given a base ring `R` and symbol/string `s` specifying how the generator
+(variable) should be printed, return a tuple `S, x` representing the new
+polynomial ring $S = R[x]$ and the generator $x$ of the ring.
+
+By default the parent object `S` depends only on `R` and `x` and will be cached.
+Setting the optional argument `cached` to `false` will prevent the parent object `S` from being cached.
 """
-polynomial_ring(R::NCRing, s::Union{AbstractString, Char, Symbol}; cached::Bool = true)
+polynomial_ring(R::NCRing, s::Union{Symbol, AbstractString, Char}; kw...)
 
-function polynomial_ring(R::NCRing, s::Symbol; cached::Bool = true)
-   return Generic.polynomial_ring(R, s, cached=cached)
+polynomial_ring(R::NCRing, s::Union{AbstractString, Char}; kw...) = polynomial_ring(R, Symbol(s); kw...)
+
+function polynomial_ring(R::NCRing, s::Symbol; kw...)
+   S = polynomial_ring_only(R, s; kw...)
+   (S, gen(S))
 end
 
-function polynomial_ring(R::NCRing, s::AbstractString; cached::Bool = true)
-   return Generic.polynomial_ring(R, Symbol(s), cached=cached)
-end
+@doc md"""
+    polynomial_ring_only(R::Ring, s::Symbol; cached::Bool=true)
 
-function polynomial_ring(R::NCRing, s::Char; cached::Bool = true)
-   return Generic.polynomial_ring(R, Symbol(s); cached=cached)
-end
+Like [`polynomial_ring(R::Ring, s::Symbol)`](@ref) but return only the
+polynomial ring.
+"""
+polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =
+   polynomial_ring_type(T)(R, s, cached)
+
+@doc md"""
+    polynomial_ring_type(::Type{T}) where T<:NCRing
+
+The type of polynomial rings with coefficients of type `T`.
+Falls back to `PolyRing{elem_type(T)}`.
+
+# Examples
+```julia
+polynomial_ring_type(typeof(ZZ))
+```
+"""
+polynomial_ring_type(::Type{T}) where T<:NCRing = Generic.PolyRing{elem_type(T)}
+
+# Simplified constructor
+
+PolyRing(R::NCRing) = polynomial_ring_only(R, :x; cached=false)

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -691,6 +691,16 @@ polynomial ring $S = R[x]$ and the generator $x$ of the ring.
 
 By default the parent object `S` depends only on `R` and `x` and will be cached.
 Setting the optional argument `cached` to `false` will prevent the parent object `S` from being cached.
+
+# Examples
+
+```jldoctest
+julia> R, x = polynomial_ring(ZZ, :x)
+(Univariate Polynomial Ring in x over Integers, x)
+
+julia> S, y = polynomial_ring(R, :y)
+(Univariate Polynomial Ring in y over Univariate Polynomial Ring in x over Integers, y)
+```
 """
 polynomial_ring(R::NCRing, s::Union{Symbol, AbstractString, Char}; kw...)
 
@@ -702,9 +712,9 @@ function polynomial_ring(R::NCRing, s::Symbol; kw...)
 end
 
 @doc md"""
-    polynomial_ring_only(R::Ring, s::Symbol; cached::Bool=true)
+    polynomial_ring_only(R::NCRing, s::Symbol; cached::Bool=true)
 
-Like [`polynomial_ring(R::Ring, s::Symbol)`](@ref) but return only the
+Like [`polynomial_ring(R::NCRing, s::Symbol)`](@ref) but return only the
 polynomial ring.
 """
 polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -695,7 +695,7 @@ Falls back to `PolyRing{elem_type(T)}`.
 polynomial_ring_type(typeof(ZZ))
 ```
 """
-polynomial_ring_type(::Type{T}) where T<:NCRing = Generic.PolyRing{elem_type(T)}
+polynomial_ring_type(::Type{T}) where T<:NCRing = Generic.NCPolyRing{elem_type(T)}
 
 # Simplified constructor
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -694,7 +694,7 @@ Setting the optional argument `cached` to `false` will prevent the parent object
 
 # Examples
 
-```jldoctest
+```jldoctest; setup = :(using AbstractAlgebra)
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate Polynomial Ring in x over Integers, x)
 

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -20,7 +20,7 @@ coefficient_ring(a::PolynomialElem) = base_ring(a)
 
 parent(a::PolynomialElem) = a.parent
 
-poly_type(::Type{T}) where T<:RingElement = Generic.Poly{T}
+dense_poly_type(::Type{T}) where T<:RingElement = Generic.Poly{T}
 
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: PolyRingElem{S}}
    return is_domain_type(S)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3427,3 +3427,11 @@ function subst(f::PolyRingElem{T}, a::U) where {T <: RingElement, U}
    end
    return s
 end
+
+###############################################################################
+#
+#   polynomial_ring constructor
+#
+###############################################################################
+
+polynomial_ring_type(::Type{T}) where T<:Ring = Generic.PolyRing{elem_type(T)}

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3427,38 +3427,3 @@ function subst(f::PolyRingElem{T}, a::U) where {T <: RingElement, U}
    end
    return s
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-@doc Markdown.doc"""
-    polynomial_ring(R::Ring, s::Union{String, Char, Symbol}; cached::Bool = true)
-
-Given a base ring `R` and string `s` specifying how the generator (variable)
-should be printed, return a tuple `S, x` representing the new polynomial
-ring $S = R[x]$ and the generator $x$ of the ring. By default the parent
-object `S` will depend only on `R` and `x` and will be cached. Setting the
-optional argument `cached` to `false` will prevent the parent object `S` from
-being cached.
-"""
-polynomial_ring(R::Ring, s::Union{AbstractString, Char, Symbol}; cached::Bool = true)
-
-function polynomial_ring(R::Ring, s::Symbol; cached::Bool = true)
-   return Generic.polynomial_ring(R, s; cached=cached)
-end
-
-function polynomial_ring(R::Ring, s::AbstractString; cached::Bool = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function polynomial_ring(R::Ring, s::Char; cached::Bool = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::Ring)
-   T = elem_type(R)
-   return Generic.PolyRing{T}(R, :x, false)
-end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -20,6 +20,8 @@ coefficient_ring(a::PolynomialElem) = base_ring(a)
 
 parent(a::PolynomialElem) = a.parent
 
+poly_type(::Type{T}) where T<:RingElement = Generic.Poly{T}
+
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: PolyRingElem{S}}
    return is_domain_type(S)
 end
@@ -3427,11 +3429,3 @@ function subst(f::PolyRingElem{T}, a::U) where {T <: RingElement, U}
    end
    return s
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-polynomial_ring_type(::Type{T}) where T<:Ring = Generic.PolyRing{elem_type(T)}

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -333,7 +333,7 @@ end
 # :deglex
 # :degrevlex
 #
-# T is an Int which is the number of variables
+# N is an Int which is the number of variables
 # (plus one if ordered by total degree)
 
 mutable struct MPolyRing{T <: RingElement} <: AbstractAlgebra.MPolyRing{T}
@@ -349,6 +349,13 @@ mutable struct MPolyRing{T <: RingElement} <: AbstractAlgebra.MPolyRing{T}
          new{T}(R, s, ord, length(s), N)
       end::MPolyRing{T}
    end
+end
+
+function MPolyRing{T}(R::Ring, s::Vector{Symbol}, ordering::Symbol=:lex, cached::Bool=true) where T <: RingElement
+   @assert T == elem_type(R)
+   N = length(s)
+   ordering in (:deglex, :degrevlex) && (N+=1)
+   return MPolyRing{T}(R, s, ordering, N, cached)
 end
 
 const MPolyID = CacheDictType{Tuple{Ring, Vector{Symbol}, Symbol, Int}, Ring}()

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4127,22 +4127,3 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: Rin
    z = combine_like_terms!(z)
    return z
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::AbstractAlgebra.Ring, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   T = elem_type(R)
-   N = (ordering == :deglex || ordering == :degrevlex) ? length(s) + 1 : length(s)
-   parent_obj = MPolyRing{T}(R, s, ordering, N, cached)
-
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::AbstractAlgebra.Ring, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(v) for v in s]; cached=cached, ordering=ordering)
-end
-

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -16,14 +16,6 @@ parent_type(::Type{MPoly{T}}) where T <: RingElement = MPolyRing{T}
 
 elem_type(::Type{MPolyRing{T}}) where T <: RingElement = MPoly{T}
 
-@doc Markdown.doc"""
-    mpoly_type(::Type{T}) where T <: RingElement
-
-Return the type of a multivariate polynomial whose coefficients have the given
-type.
-"""
-mpoly_type(::Type{T}) where T <: RingElement = MPoly{T}
-
 base_ring(R::MPolyRing{T}) where T <: RingElement = R.base_ring::parent_type(T)
 
 @doc Markdown.doc"""

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -258,16 +258,3 @@ function (a::NCPolyRing{T})(b::T) where {T <: Integer}
    z.parent = a
    return z
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::AbstractAlgebra.NCRing, s::Symbol; cached::Bool = true)
-   T = elem_type(R)
-   parent_obj = NCPolyRing{T}(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -14,13 +14,6 @@ parent_type(::Type{Poly{T}}) where T <: RingElement = PolyRing{T}
 
 elem_type(::Type{PolyRing{T}}) where T <: RingElement = Poly{T}
 
-@doc Markdown.doc"""
-    dense_poly_type(::Type{T}) where T <: RingElement
-
-Return the type of a polynomial whose coefficients have the given type.
-"""
-dense_poly_type(::Type{T}) where T <: RingElement = Poly{T}
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -414,16 +414,3 @@ function (a::PolyRing{T})(b::T) where {T <: Integer}
    z.parent = a
    return z
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::AbstractAlgebra.Ring, s::Symbol; cached::Bool = true)
-   T = elem_type(R)
-   parent_obj = PolyRing{T}(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -112,6 +112,19 @@
    @test S isa Generic.MPolyRing{Generic.Poly{BigInt}}
    @test y isa Generic.MPoly{Generic.Poly{BigInt}}
    @test z isa Generic.MPoly{Generic.Poly{BigInt}}
+
+   ZZxyz, (x,y,z) = polynomial_ring(ZZ, 'x':'z')
+   @test ZZxyz isa Generic.MPolyRing
+
+   ZZxyz2, (x2,y2,z2) = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
+   @test ZZxyz == ZZxyz2
+   @test (x,y,z) == (x2,y2,z2)
+
+   ZZxyz3, _ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
+   @test ZZxyz == ZZxyz3
+
+   ZZxyz4, _ = ZZ["x", 'y', :z]
+   @test ZZxyz == ZZxyz4
 end
 
 @testset "Generic.MPoly.printing" begin

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -423,3 +423,9 @@ end
       @test derivative(g*f) == derivative(g)*f + g*derivative(f)
    end
 end
+
+@testset "Generic.NCPoly.printing" begin
+   M = MatrixAlgebra(ZZ, 3)
+   _, x = M['x']
+   @test string(M(-1)*x) isa String
+end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -100,16 +100,6 @@ end
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
-
-   ZZxyz, (x,y,z) = polynomial_ring(ZZ, 'x':'z')
-   @test ZZxyz isa Generic.MPolyRing
-
-   ZZxyz2, (x2,y2,z2) = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
-   @test ZZxyz == ZZxyz2
-   @test (x,y,z) == (x2,y2,z2)
-
-   ZZxyz3, _ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
-   @test ZZxyz == ZZxyz3
 end
 
 @testset "Generic.Poly.iterators" begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -60,16 +60,6 @@ end
 
    @test typeof(T) <: Generic.PolyRing
 
-   ZZxyz, (x,y,z) = polynomial_ring(ZZ, 'x':'z')
-   @test ZZxyz isa Generic.PolyRing
-
-   ZZxyz2, (x2,y2,z2) = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
-   @test ZZxyz == ZZxyz2
-   @test (x,y,z) == (x2,y2,z2)
-
-   ZZxyz3, _ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
-   @test ZZxyz == ZZxyz3
-
    @test isa(z, PolyRingElem)
 
    f = x^2 + y^3 + z + 1
@@ -110,6 +100,16 @@ end
 
    @test x in keys(Dict(x => 1))
    @test !(y in keys(Dict(x => 1)))
+
+   ZZxyz, (x,y,z) = polynomial_ring(ZZ, 'x':'z')
+   @test ZZxyz isa Generic.MPolyRing
+
+   ZZxyz2, (x2,y2,z2) = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
+   @test ZZxyz == ZZxyz2
+   @test (x,y,z) == (x2,y2,z2)
+
+   ZZxyz3, _ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
+   @test ZZxyz == ZZxyz3
 end
 
 @testset "Generic.Poly.iterators" begin

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -60,6 +60,16 @@ end
 
    @test typeof(T) <: Generic.PolyRing
 
+   ZZxyz, (x,y,z) = polynomial_ring(ZZ, 'x':'z')
+   @test ZZxyz isa Generic.PolyRing
+
+   ZZxyz2, (x2,y2,z2) = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
+   @test ZZxyz == ZZxyz2
+   @test (x,y,z) == (x2,y2,z2)
+
+   ZZxyz3, _ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
+   @test ZZxyz == ZZxyz3
+
    @test isa(z, PolyRingElem)
 
    f = x^2 + y^3 + z + 1
@@ -2966,12 +2976,6 @@ end
    F = GF(11)
    P, y = polynomial_ring(F, 'x')
    @test map_coefficients(t -> F(t) + 2, f) == 3y^2 + 5y^3 + 4y^6
-end
-
-@testset "Generic.Poly.printing" begin
-   M = MatrixAlgebra(ZZ, 3)
-   _, x = M['x']
-   @test string(M(-1)*x) isa String
 end
 
 @testset "Generic.Poly.polynomial_to_power_sums" begin


### PR DESCRIPTION
The AbstractAlgebra side to solve Nemocas/Nemo.jl#1405. Introduces new functions `polynomial_ring_only`, `polynomial_ring_type`, and `mpolynomial_ring_type`.