### PR TITLE
Allow `/` as shortcut for `divexact`

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -90,9 +90,9 @@ function ==(x::NCRingElem, y::NCRingElem)
    end
  end
  
- ==(x::NCRingElem, y::NCRingElement) = x == parent(x)(y)
- 
- ==(x::NCRingElement, y::NCRingElem) = parent(y)(x) == y
+==(x::NCRingElem, y::NCRingElement) = x == parent(x)(y)
+
+==(x::NCRingElement, y::NCRingElem) = parent(y)(x) == y
 
 function divexact_left(x::NCRingElem, y::NCRingElem; check::Bool = true)
    return divexact_left(promote(x, y)...)
@@ -117,6 +117,14 @@ function divexact_right(
 
    return divexact_right(x, parent(x)(y); check = check)
 end
+
+#Base.:/(x::ModuleElem, y::RingElement) = divexact_right(x, y; check=true)
+Base.:/(x::NCRingElem, y::NCRingElement) = divexact_right(x, y; check=true)
+Base.:/(x::Union{Integer, Rational, AbstractFloat}, y::NCRingElem) = divexact_right(x, y; check=true)
+
+#Base.:\(y::RingElement, x::ModuleElem) = divexact_left(x, y; check=true)
+Base.:\(y::NCRingElement, x::NCRingElem) = divexact_left(x, y; check=true)
+Base.:\(y::NCRingElem, x::Union{Integer, Rational, AbstractFloat}) = divexact_left(x, y; check=true)
 
 Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -30,6 +30,10 @@ divexact_left(x::T, y::T; check::Bool=true) where T <: RingElement = divexact(x,
 
 divexact_right(x::T, y::T; check::Bool=true) where T <: RingElement = divexact(x, y; check=check)
 
+Base.:/(x::ModuleElem, y::RingElement) = divexact(x, y; check=true)
+Base.:/(x::RingElem, y::RingElement) = divexact(x, y; check=true)
+Base.:/(x::Union{Integer, Rational, AbstractFloat}, y::RingElem) = divexact(x, y; check=true)
+
 Base.inv(x::RingElem) = divexact(one(parent(x)), x)
 
 function is_divisible_by(x::T, y::T) where T <: RingElem

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -123,9 +123,12 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
                   @test iszero(b) || equality(divexact_left(b*a, b), a)
                   @test iszero(b) || equality(divexact_left(b*a, b, check = true), a)
                   @test iszero(b) || equality(divexact_left(b*a, b, check = false), a)
+                  @test iszero(b) || equality(b \ (b*a), a)
+
                   @test iszero(b) || equality(divexact_right(a*b, b), a)
                   @test iszero(b) || equality(divexact_right(a*b, b, check = true), a)
                   @test iszero(b) || equality(divexact_right(a*b, b, check = false), a)
+                  @test iszero(b) || equality((a*b) / b, a)
                else
                   try
                      t = divexact_left(b*a, b)
@@ -133,6 +136,8 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
                      t = divexact_left(b*a, b, check = true)
                      @test equality(b*t, b*a)
                      t = divexact_left(b*a, b, check = false)
+                     @test equality(b*t, b*a)
+                     t = b \ (b*a)
                      @test equality(b*t, b*a)
                   catch
                   end
@@ -142,6 +147,8 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
                      t = divexact_right(a*b, b, check = true)
                      @test equality(t*b, a*b)
                      t = divexact_right(a*b, b, check = false)
+                     @test equality(t*b, a*b)
+                     t = (a*b) / b
                      @test equality(t*b, a*b)
                   catch
                   end
@@ -232,6 +239,9 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
                @test iszero(b) || equality(divexact(b*a, b), a)
                @test iszero(b) || equality(divexact(b*a, b, check = true), a)
                @test iszero(b) || equality(divexact(b*a, b, check = false), a)
+               if T isa RingElem
+                  @test iszero(b) || equality((b*a) / b, a)
+               end
             else
                try
                   t = divexact(b*a, b)
@@ -240,6 +250,10 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
                   @test equality(t*b, a*b)
                   t = divexact(b*a, b, check = false)
                   @test equality(t*b, a*b)
+                  if T isa RingElem
+                     t = (b*a) / b
+                     @test equality(t*b, a*b)
+                  end
                catch
                end
             end


### PR DESCRIPTION
... as discussed in https://github.com/oscar-system/Oscar.jl/issues/1618

TODO:
- [ ] add test cases
- [ ] mention it in the `divexact` docstring
- [ ] mention it in the manual (where?)

