### PR TITLE
Fix bug in universal polynomial ring

### DIFF
--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -35,4 +35,3 @@ end
 function UniversalPolynomialRing(R::Ring; ordering=:lex, cached=true)
    return Generic.UniversalPolynomialRing(R; ordering=ordering, cached=cached)
 end
-

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -422,7 +422,7 @@ end
 
 const UnivPolyID = CacheDictType{Tuple{Ring, Symbol, DataType}, Ring}()
 
-mutable struct UnivPoly{T <: RingElement, U <: MPoly} <: AbstractAlgebra.UniversalPolyRingElem{T}
+mutable struct UnivPoly{T <: RingElement, U <: MPolyRingElem{T}} <: AbstractAlgebra.UniversalPolyRingElem{T}
    p::U
    parent::UniversalPolyRing{T}
 end

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -35,7 +35,7 @@ parent_type(::Type{UnivPoly{T, U}}) where {T <: RingElement, U <: AbstractAlgebr
    UniversalPolyRing{T, U}
 
 function mpoly_ring(S::UniversalPolyRing{T, U}) where {T <: RingElement, U <: AbstractAlgebra.MPolyRingElem{T}}
-   return S.mpoly_ring::parent_type(mpoly_type(T))
+   return S.mpoly_ring::Generic.MPolyRing{T}
 end
 
 nvars(S::UniversalPolyRing) = length(S.S)
@@ -1126,7 +1126,7 @@ end
 
 function UniversalPolynomialRing(R::Ring; ordering=:lex, cached=true)
    T = elem_type(R)
-   U = mpoly_type(T)
+   U = Generic.MPoly{T}
 
    return UniversalPolyRing{T, U}(R, ordering, cached)
 end


### PR DESCRIPTION
Not all multivariate polynomial rings can be constructed with
zero indeterminants (e.g. all ring coming from flint).
Thus we always use a generic polynomial ring underpinning the
universal one.

Fixes https://github.com/oscar-system/Oscar.jl/issues/2076

I cannot test it here.