### PR TITLE
Add `*poly*_type` methods for elements

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -18,6 +18,7 @@ coefficient_ring(R::MPolyRing) = base_ring(R)
 
 @doc md"""
     mpoly_type(::Type{T}) where T<:RingElement
+    mpoly_type(::T) where T<:RingElement
 
 The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.MPoly{T}`.
@@ -28,9 +29,12 @@ mpoly_type(typeof(ZZ()))
 ```
 """
 mpoly_type(::Type{T}) where T<:RingElement = Generic.MPoly{T}
+mpoly_type(::Type{T}) where T = ArgumentError("Type `$T` must be subtype of `RingElement`.")
+mpoly_type(x) = mpoly_type(typeof(x))
 
 @doc md"""
     mpoly_ring_type(::Type{T}) where T<:Ring
+    mpoly_ring_type(::T) where T<:Ring
 
 The type of multivariate polynomial rings with coefficients of type `T`.
 Implemented via [`mpoly_type`](@ref).
@@ -40,7 +44,7 @@ Implemented via [`mpoly_type`](@ref).
 mpoly_ring_type(typeof(ZZ))
 ```
 """
-mpoly_ring_type(::Type{T}) where T<:Ring = parent_type(mpoly_type(elem_type(T)))
+mpoly_ring_type(x) = parent_type(mpoly_type(elem_type(x)))
 
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: AbstractAlgebra.MPolyRingElem{S}}
    return is_domain_type(S)

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -33,8 +33,8 @@ AbstractAlgebra.Generic.MPoly{BigInt}
 ```
 """
 mpoly_type(::Type{T}) where T<:RingElement = Generic.MPoly{T}
-mpoly_type(::Type{T}) where T = ArgumentError("Type `$T` must be subtype of `RingElement`.")
-mpoly_type(x) = mpoly_type(typeof(x))
+mpoly_type(x) = mpoly_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
+mpoly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `RingElement`."))
 
 @doc md"""
     mpoly_ring_type(::Type{T}) where T<:Ring

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -24,8 +24,12 @@ The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.MPoly{T}`.
 
 # Examples
-```julia
-mpoly_type(typeof(ZZ()))
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> mpoly_type(elem_type(ZZ))
+AbstractAlgebra.Generic.MPoly{BigInt}
+
+julia> mpoly_type(ZZ(1))
+AbstractAlgebra.Generic.MPoly{BigInt}
 ```
 """
 mpoly_type(::Type{T}) where T<:RingElement = Generic.MPoly{T}
@@ -40,8 +44,12 @@ The type of multivariate polynomial rings with coefficients of type `T`.
 Implemented via [`mpoly_type`](@ref).
 
 # Examples
-```julia
-mpoly_ring_type(typeof(ZZ))
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> mpoly_ring_type(typeof(ZZ))
+AbstractAlgebra.Generic.MPolyRing{BigInt}
+
+julia> mpoly_ring_type(ZZ)
+AbstractAlgebra.Generic.MPolyRing{BigInt}
 ```
 """
 mpoly_ring_type(x) = parent_type(mpoly_type(elem_type(x)))

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -25,10 +25,10 @@ Falls back to `Generic.MPoly{T}`.
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> mpoly_type(elem_type(ZZ))
+julia> mpoly_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.MPoly{BigInt}
 
-julia> mpoly_type(ZZ(1))
+julia> mpoly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.MPoly{BigInt}
 ```
 """
@@ -45,10 +45,10 @@ Implemented via [`mpoly_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> mpoly_ring_type(typeof(ZZ))
+julia> mpoly_ring_type(typeof(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.MPolyRing{BigInt}
 
-julia> mpoly_ring_type(ZZ)
+julia> mpoly_ring_type(AbstractAlgebra.ZZ)
 AbstractAlgebra.Generic.MPolyRing{BigInt}
 ```
 """

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -35,8 +35,8 @@ AbstractAlgebra.Generic.Poly{BigInt}
 ```
 """
 dense_poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
-dense_poly_type(::Type{T}) where T = ArgumentError("Type `$T` must be subtype of `NCRingElement`.")
-dense_poly_type(x) = dense_poly_type(typeof(x))
+dense_poly_type(x) = dense_poly_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
+dense_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `NCRingElement`."))
 
 @doc md"""
     poly_ring_type(::Type{T}) where T<:NCRing

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -27,10 +27,10 @@ Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> dense_poly_type(elem_type(ZZ))
+julia> dense_poly_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.Poly{BigInt}
 
-julia> dense_poly_type(ZZ(1))
+julia> dense_poly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.Poly{BigInt}
 ```
 """
@@ -47,10 +47,10 @@ Implemented via [`dense_poly_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> poly_ring_type(typeof(ZZ))
+julia> poly_ring_type(typeof(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.PolyRing{BigInt}
 
-julia> poly_ring_type(ZZ)
+julia> poly_ring_type(AbstractAlgebra.ZZ)
 AbstractAlgebra.Generic.PolyRing{BigInt}
 ```
 """

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -20,6 +20,7 @@ end
 
 @doc md"""
     dense_poly_type(::Type{T}) where T<:NCRingElement
+    dense_poly_type(::T) where T<:NCRingElement
 
 The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
@@ -30,9 +31,12 @@ dense_poly_type(typeof(ZZ()))
 ```
 """
 dense_poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
+dense_poly_type(::Type{T}) where T = ArgumentError("Type `$T` must be subtype of `NCRingElement`.")
+dense_poly_type(x) = dense_poly_type(typeof(x))
 
 @doc md"""
     poly_ring_type(::Type{T}) where T<:NCRing
+    poly_ring_type(::T) where T<:NCRing
 
 The type of polynomial rings with coefficients of type `T`.
 Implemented via [`dense_poly_type`](@ref).
@@ -42,7 +46,7 @@ Implemented via [`dense_poly_type`](@ref).
 poly_ring_type(typeof(ZZ))
 ```
 """
-poly_ring_type(::Type{T}) where T<:NCRing = parent_type(dense_poly_type(elem_type(T)))
+poly_ring_type(x) = parent_type(dense_poly_type(elem_type(x)))
 
 @doc Markdown.doc"""
     var(a::NCPolyRing)

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -26,8 +26,12 @@ The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 
 # Examples
-```julia
-dense_poly_type(typeof(ZZ()))
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> dense_poly_type(elem_type(ZZ))
+AbstractAlgebra.Generic.Poly{BigInt}
+
+julia> dense_poly_type(ZZ(1))
+AbstractAlgebra.Generic.Poly{BigInt}
 ```
 """
 dense_poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
@@ -42,8 +46,12 @@ The type of polynomial rings with coefficients of type `T`.
 Implemented via [`dense_poly_type`](@ref).
 
 # Examples
-```julia
-poly_ring_type(typeof(ZZ))
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> poly_ring_type(typeof(ZZ))
+AbstractAlgebra.Generic.PolyRing{BigInt}
+
+julia> poly_ring_type(ZZ)
+AbstractAlgebra.Generic.PolyRing{BigInt}
 ```
 """
 poly_ring_type(x) = parent_type(dense_poly_type(elem_type(x)))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1576,3 +1576,9 @@ end
     R, _ = polynomial_ring(ZZ, Symbol[])
     @test R(1) != R(2)
 end
+
+@testset "Generic.MPoly.exceptions" begin
+   @test_throws MethodError polynomial_ring(Char, [:x])
+   @test_throws Exception mpoly_ring_type(Char)
+   @test_throws ArgumentError mpoly_type(Char)
+end

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -429,3 +429,9 @@ end
    _, x = M['x']
    @test string(M(-1)*x) isa String
 end
+
+@testset "Generic.NCPoly.exceptions" begin
+   @test_throws MethodError polynomial_ring(Char, :x)
+   @test_throws Exception poly_ring_type(Char)
+   @test_throws ArgumentError dense_poly_type(Char)
+end


### PR DESCRIPTION
Discussed in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1282#discussion_r1140590392. Adds methods `mpoly_type(x)`, `mpoly_ring_type(x)`, `dense_poly_type(x)`, `poly_ring_type(x)` which do the same as those functions called with `typeof(x)` instead.

I am inclined to metaprogram this

```julia
macro type_function(f::Symbol) quote
    $(esc(f))(x) = $(esc(f))(typeof(x))
    $(esc(f))(::Type{T}) = throw(MethodError($(esc(f)), (T,)))
end end
@type_function mpoly_type
@type_function elem_type
...
```

But we can also go with the manually added methods.