### PR TITLE
make `get_attribute` unambiguous

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -203,7 +203,7 @@ function get_attribute(G::Any, attr::Symbol, default::Any = nothing)
 end
 
 # unambiguous version
-function get_attribute(G::Any, attr::Symbol, default::Union{Symbol, Nothing} = nothing)
+function get_attribute(G::Any, attr::Symbol, default::Symbol)
    D = _get_attributes(G)
    D isa Dict && return get(D, attr, default)
    return default
@@ -240,7 +240,7 @@ function get_attribute!(G::Any, attr::Symbol, default::Any)
    return Base.get!(D, attr, default)
 end
 
-function get_attribute!(G::Any, attr::Symbol, default::Union{Symbol, Nothing} = nothing)
+function get_attribute!(G::Any, attr::Symbol, default::Symbol)
    D = _get_attributes!(G)
    return Base.get!(D, attr, default)
 end

--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -202,6 +202,13 @@ function get_attribute(G::Any, attr::Symbol, default::Any = nothing)
    return default
 end
 
+# unambiguous version
+function get_attribute(G::Any, attr::Symbol, default::Union{Symbol, Nothing} = nothing)
+   D = _get_attributes(G)
+   D isa Dict && return get(D, attr, default)
+   return default
+end
+
 """
     get_attribute!(f::Function, G::Any, attr::Symbol)
 
@@ -229,6 +236,11 @@ Return the value stored for the attribute `attr` of `G`, or if no value has been
 store `key => default`, and return `default`.
 """
 function get_attribute!(G::Any, attr::Symbol, default::Any)
+   D = _get_attributes!(G)
+   return Base.get!(D, attr, default)
+end
+
+function get_attribute!(G::Any, attr::Symbol, default::Union{Symbol, Nothing} = nothing)
    D = _get_attributes!(G)
    return Base.get!(D, attr, default)
 end

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -146,10 +146,8 @@ end
     @test get_attribute(x, :bar12) == :somesymbol
     @test get_attribute!(x, :bar12, :defaultsymbol) == :somesymbol
     @test get_attribute(x, :bar12) == :somesymbol
-    @test get_attribute!(x, :bar13) == nothing
-    @test get_attribute(x, :bar13) == nothing
-    @test get_attribute!(x, :bar14, :defaultsymbol) == :defaultsymbol
-    @test get_attribute(x, :bar14) == :defaultsymbol
+    @test get_attribute!(x, :bar13, :defaultsymbol) == :defaultsymbol
+    @test get_attribute(x, :bar13) == :defaultsymbol
 end
 
 

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -149,7 +149,7 @@ end
     @test get_attribute!(x, :bar13) == nothing
     @test get_attribute(x, :bar13) == nothing
     @test get_attribute!(x, :bar14, :defaultsymbol) == :defaultsymbol
-    @test get_attribute(x, :bar14) == :defailtsymbol
+    @test get_attribute(x, :bar14) == :defaultsymbol
 end
 
 

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -108,6 +108,12 @@ end
     @test get_attribute(() -> 42, x, :bar9) == 0
     @test get_attribute(x, :bar9) == 0
 
+    # test get_attribute with symbol entries
+    set_attribute!(x, :bar10 => :somesymbol)
+    @test get_attribute(x, :bar10) == :somesymbol
+    @test get_attribute(x, :bar11) == nothing
+    @test get_attribute(x, :bar11, :defaultsymbol) == :defaultsymbol
+
     # test get_attribute! with default value for new entry
     @test get_attribute(x, :bar4) == nothing
     @test get_attribute!(x, :bar4, 42) == 42
@@ -135,6 +141,15 @@ end
     @test get_attribute!(Vector{Int}, x, :bar8) isa Vector{Int}
     @test get_attribute(x, :bar8) == []
 
+    # test get_attribute with symbol entries
+    set_attribute!(x, :bar12 => :somesymbol)
+    @test get_attribute(x, :bar12) == :somesymbol
+    @test get_attribute!(x, :bar12) == :somesymbol
+    @test get_attribute(x, :bar12) == :somesymbol
+    @test get_attribute!(x, :bar13) == nothing
+    @test get_attribute(x, :bar13) == nothing
+    @test get_attribute!(x, :bar14, :defaultsymbol) == :defaultsymbol
+    @test get_attribute(x, :bar14) == :defailtsymbol
 end
 
 

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -144,7 +144,7 @@ end
     # test get_attribute with symbol entries
     set_attribute!(x, :bar12 => :somesymbol)
     @test get_attribute(x, :bar12) == :somesymbol
-    @test get_attribute!(x, :bar12) == :somesymbol
+    @test get_attribute!(x, :bar12, :defaultsymbol) == :somesymbol
     @test get_attribute(x, :bar12) == :somesymbol
     @test get_attribute!(x, :bar13) == nothing
     @test get_attribute(x, :bar13) == nothing


### PR DESCRIPTION
Fixes #1296.
I spared the docstring, since it is just a copy of `get_attribute(::Any, ::Symbol, ::Any)` and the user should not have to care about this ambiguity.

@thofma 