### PR TITLE
Rename poly_ring_type -> dense_poly_ring_type

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -774,6 +774,7 @@ export deflation
 export degree
 export degrees
 export dense_matrix_type
+export dense_poly_ring_type
 export dense_poly_type
 export derivative
 export det
@@ -994,7 +995,6 @@ export pol_length
 export polcoeff
 export poly
 export poly_ring
-export poly_ring_type
 export PolyCoeffs
 export polynomial
 export polynomial_ring

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -23,6 +23,8 @@ coefficient_ring(R::MPolyRing) = base_ring(R)
 The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.MPoly{T}`.
 
+See also [`mpoly_ring_type`](@ref), [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
+
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
 julia> mpoly_type(elem_type(AbstractAlgebra.ZZ))
@@ -42,6 +44,8 @@ mpoly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype o
 
 The type of multivariate polynomial rings with coefficients of type `T`.
 Implemented via [`mpoly_type`](@ref).
+
+See also [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -39,22 +39,22 @@ dense_poly_type(x) = dense_poly_type(typeof(x)) # to stop this method from etern
 dense_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `NCRingElement`."))
 
 @doc md"""
-    poly_ring_type(::Type{T}) where T<:NCRing
-    poly_ring_type(::T) where T<:NCRing
+    dense_poly_ring_type(::Type{T}) where T<:NCRing
+    dense_poly_ring_type(::T) where T<:NCRing
 
 The type of polynomial rings with coefficients of type `T`.
 Implemented via [`dense_poly_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> poly_ring_type(typeof(AbstractAlgebra.ZZ))
+julia> dense_poly_ring_type(typeof(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.PolyRing{BigInt}
 
-julia> poly_ring_type(AbstractAlgebra.ZZ)
+julia> dense_poly_ring_type(AbstractAlgebra.ZZ)
 AbstractAlgebra.Generic.PolyRing{BigInt}
 ```
 """
-poly_ring_type(x) = parent_type(dense_poly_type(elem_type(x)))
+dense_poly_ring_type(x) = parent_type(dense_poly_type(elem_type(x)))
 
 @doc Markdown.doc"""
     var(a::NCPolyRing)
@@ -730,7 +730,7 @@ Like [`polynomial_ring(R::NCRing, s::Symbol)`](@ref) but return only the
 polynomial ring.
 """
 polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =
-   poly_ring_type(T)(R, s, cached)
+   dense_poly_ring_type(T)(R, s, cached)
 
 # Simplified constructor
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -25,6 +25,8 @@ end
 The type of multivariate polynomials with coefficients of type `T`.
 Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 
+See also [`dense_poly_ring_type`](@ref), [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
+
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
 julia> dense_poly_type(elem_type(AbstractAlgebra.ZZ))
@@ -44,6 +46,8 @@ dense_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subt
 
 The type of polynomial rings with coefficients of type `T`.
 Implemented via [`dense_poly_type`](@ref).
+
+See also [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -432,6 +432,6 @@ end
 
 @testset "Generic.NCPoly.exceptions" begin
    @test_throws MethodError polynomial_ring(Char, :x)
-   @test_throws Exception poly_ring_type(Char)
+   @test_throws Exception dense_poly_ring_type(Char)
    @test_throws ArgumentError dense_poly_type(Char)
 end


### PR DESCRIPTION
... for consistency. We can rename it again in the future, but then together with `dense_poly_type`.

Resolves #1289

CC @mgkurtz 