### PR TITLE
Enhance *poly*_type methods

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -19,44 +19,61 @@ coefficient_ring(R::MPolyRing) = base_ring(R)
 @doc md"""
     mpoly_type(::Type{T}) where T<:RingElement
     mpoly_type(::T) where T<:RingElement
+    mpoly_type(::Type{S}) where S<:Ring
+    mpoly_type(::S) where S<:Ring
 
-The type of multivariate polynomials with coefficients of type `T`.
+The type of multivariate polynomials with coefficients of type `T` respectively `elem_type(S)`.
 Falls back to `Generic.MPoly{T}`.
 
 See also [`mpoly_ring_type`](@ref), [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
+julia> mpoly_type(AbstractAlgebra.ZZ(1))
+AbstractAlgebra.Generic.MPoly{BigInt}
+
 julia> mpoly_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.MPoly{BigInt}
 
-julia> mpoly_type(AbstractAlgebra.ZZ(1))
+julia> mpoly_type(AbstractAlgebra.ZZ)
+AbstractAlgebra.Generic.MPoly{BigInt}
+
+julia> mpoly_type(typeof(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.MPoly{BigInt}
 ```
 """
 mpoly_type(::Type{T}) where T<:RingElement = Generic.MPoly{T}
+mpoly_type(::Type{S}) where S<:Ring = mpoly_type(elem_type(S))
 mpoly_type(x) = mpoly_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
 mpoly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `RingElement`."))
 
 @doc md"""
-    mpoly_ring_type(::Type{T}) where T<:Ring
-    mpoly_ring_type(::T) where T<:Ring
+    mpoly_ring_type(::Type{T}) where T<:RingElement
+    mpoly_ring_type(::T) where T<:RingElement
+    mpoly_ring_type(::Type{S}) where S<:Ring
+    mpoly_ring_type(::S) where S<:Ring
 
-The type of multivariate polynomial rings with coefficients of type `T`.
-Implemented via [`mpoly_type`](@ref).
+The type of multivariate polynomial rings with coefficients of type `T`
+respectively `elem_type(S)`. Implemented via [`mpoly_type`](@ref).
 
 See also [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> mpoly_ring_type(typeof(AbstractAlgebra.ZZ))
+julia> mpoly_ring_type(AbstractAlgebra.ZZ(1))
+AbstractAlgebra.Generic.MPolyRing{BigInt}
+
+julia> mpoly_ring_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.MPolyRing{BigInt}
 
 julia> mpoly_ring_type(AbstractAlgebra.ZZ)
 AbstractAlgebra.Generic.MPolyRing{BigInt}
+
+julia> mpoly_ring_type(typeof(AbstractAlgebra.ZZ))
+AbstractAlgebra.Generic.MPolyRing{BigInt}
 ```
 """
-mpoly_ring_type(x) = parent_type(mpoly_type(elem_type(x)))
+mpoly_ring_type(x) = parent_type(mpoly_type(x))
 
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: AbstractAlgebra.MPolyRingElem{S}}
    return is_domain_type(S)

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -21,44 +21,61 @@ end
 @doc md"""
     dense_poly_type(::Type{T}) where T<:NCRingElement
     dense_poly_type(::T) where T<:NCRingElement
+    dense_poly_type(::Type{S}) where S<:NCRing
+    dense_poly_type(::S) where S<:NCRing
 
-The type of multivariate polynomials with coefficients of type `T`.
+The type of univariate polynomials with coefficients of type `T` respectively `elem_type(S)`.
 Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 
 See also [`dense_poly_ring_type`](@ref), [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
+julia> dense_poly_type(AbstractAlgebra.ZZ(1))
+AbstractAlgebra.Generic.Poly{BigInt}
+
 julia> dense_poly_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.Poly{BigInt}
 
-julia> dense_poly_type(AbstractAlgebra.ZZ(1))
+julia> dense_poly_type(AbstractAlgebra.ZZ)
+AbstractAlgebra.Generic.Poly{BigInt}
+
+julia> dense_poly_type(typeof(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.Poly{BigInt}
 ```
 """
 dense_poly_type(::Type{T}) where T<:NCRingElement = Generic.NCPoly{T}
+dense_poly_type(::Type{S}) where S<:NCRing = dense_poly_type(elem_type(S))
 dense_poly_type(x) = dense_poly_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
 dense_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `NCRingElement`."))
 
 @doc md"""
-    dense_poly_ring_type(::Type{T}) where T<:NCRing
-    dense_poly_ring_type(::T) where T<:NCRing
+    dense_poly_ring_type(::Type{T}) where T<:NCRingElement
+    dense_poly_ring_type(::T) where T<:NCRingElement
+    dense_poly_ring_type(::Type{S}) where S<:NCRing
+    dense_poly_ring_type(::S) where S<:NCRing
 
-The type of polynomial rings with coefficients of type `T`.
-Implemented via [`dense_poly_type`](@ref).
+The type of univariate polynomial rings with coefficients of type `T` respectively
+`elem_type(S)`. Implemented via [`dense_poly_type`](@ref).
 
 See also [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> dense_poly_ring_type(typeof(AbstractAlgebra.ZZ))
+julia> dense_poly_ring_type(AbstractAlgebra.ZZ(1))
+AbstractAlgebra.Generic.PolyRing{BigInt}
+
+julia> dense_poly_ring_type(elem_type(AbstractAlgebra.ZZ))
 AbstractAlgebra.Generic.PolyRing{BigInt}
 
 julia> dense_poly_ring_type(AbstractAlgebra.ZZ)
 AbstractAlgebra.Generic.PolyRing{BigInt}
+
+julia> dense_poly_ring_type(typeof(AbstractAlgebra.ZZ))
+AbstractAlgebra.Generic.PolyRing{BigInt}
 ```
 """
-dense_poly_ring_type(x) = parent_type(dense_poly_type(elem_type(x)))
+dense_poly_ring_type(x) = parent_type(dense_poly_type(x))
 
 @doc Markdown.doc"""
     var(a::NCPolyRing)


### PR DESCRIPTION
They all now accept both rings, ring elements, or their types. Also fix the docstrings.

Motivated by https://github.com/Nemocas/Nemo.jl/issues/1423.