### PR TITLE
Make dense_matrix_type more consistent

### DIFF
--- a/docs/src/matrix_interface.md
+++ b/docs/src/matrix_interface.md
@@ -157,11 +157,16 @@ applied to a view, rather than another view.
 ### Basic manipulation of matrices
 
 ```julia
-dense_matrix_type(::Type{T}) where T <: RingElem
+dense_matrix_type(::Type{T}) where T<:NCRingElement
+dense_matrix_type(::T) where T<:NCRingElement
+dense_matrix_type(::Type{S}) where S<:NCRing
+dense_matrix_type(::S) where S<:NCRing
 ```
 
-Return the type of dense matrices whose entries have the given type. E.g.
-in Nemo, which depends on AbstractAlgebra, we define
+Return the type of dense matrices whose entries have type `T` respectively
+`elem_type(S)`. It suffices to provide a method with the first signature.
+For the other three signatures, the default methods dispatch to the first.
+E.g. in Nemo, which depends on AbstractAlgebra, we define
 `dense_matrix_type(::Type{ZZRingElem}) = ZZMatrix`.
 
 ```julia

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -21,14 +21,21 @@ Return the parent object of the given matrix.
 """
 parent(a::Mat{T}) where T <: NCRingElement = MatSpace{T}(a.base_ring, size(a.entries)...)
 
-dense_matrix_type(::Type{T}) where T <: NCRingElement = MatSpaceElem{T}
-
 @doc Markdown.doc"""
-    dense_matrix_type(R::Ring)
-    
-Return the type of matrices over the given ring.
+    dense_matrix_type(::Type{T}) where T<:NCRingElement
+    dense_matrix_type(::T) where T<:NCRingElement
+    dense_matrix_type(::Type{S}) where S<:NCRing
+    dense_matrix_type(::S) where S<:NCRing
+
+Return the type of matrices with coefficients of type `T` respectively
+`elem_type(S)`.
 """
-dense_matrix_type(R::NCRing) = dense_matrix_type(elem_type(R))
+dense_matrix_type(::T) where T <: NCRing = dense_matrix_type(elem_type(T))
+dense_matrix_type(::T) where T <: NCRingElement = dense_matrix_type(T)
+dense_matrix_type(::Type{T}) where T <: NCRing = dense_matrix_type(elem_type(T))
+
+# default: MatSpaceElem
+dense_matrix_type(::Type{T}) where T <: NCRingElement = MatSpaceElem{T}
 
 ###############################################################################
 #

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -328,6 +328,9 @@ end
    @test parent_type(Generic.MatSpaceElem{elem_type(R)}) == Generic.MatSpace{elem_type(R)}
 
    @test dense_matrix_type(R) == elem_type(S)
+   @test dense_matrix_type(R(1)) == elem_type(S)
+   @test dense_matrix_type(typeof(R)) == elem_type(S)
+   @test dense_matrix_type(typeof(R(1))) == elem_type(S)
 
    @test isa(S(), MatElem)
    @test isa(S(ZZ(1)), MatElem)


### PR DESCRIPTION
Before it only supported rings (documented) and ring element types
(undocumented) as argument. Now it also supports ring types and ring
elements as arguments.
