### PR TITLE
Reintroduce `Generic.polynomial_ring`

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1360,8 +1360,9 @@ end
 Like [`polynomial_ring(R::Ring, s::Vector{Symbol})`](@ref) but return only the
 multivariate polynomial ring.
 """
-polynomial_ring_only(R::T, s::Vector{Symbol}; ordering::Symbol=:lex, cached::Bool=true) where T<:Ring =
-   mpoly_ring_type(T)(R, s, ordering, cached)
+polynomial_ring_only(R::T, s::Vector{Symbol};
+      ordering::Symbol=:lex, cached::Bool=true, generic::Bool=false) where T<:Ring =
+   (generic ? Generic : AbstractAlgebra).mpoly_ring_type(T)(R, s, ordering, cached)
 
 # Alternative constructors
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -750,8 +750,8 @@ end
 Like [`polynomial_ring(R::NCRing, s::Symbol)`](@ref) but return only the
 polynomial ring.
 """
-polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =
-   dense_poly_ring_type(T)(R, s, cached)
+polynomial_ring_only(R::T, s::Symbol; cached::Bool=true, generic::Bool=false) where T<:NCRing =
+   (generic ? Generic : AbstractAlgebra).dense_poly_ring_type(T)(R, s, cached)
 
 # Simplified constructor
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -18,6 +18,8 @@ elem_type(::Type{MPolyRing{T}}) where T <: RingElement = MPoly{T}
 
 base_ring(R::MPolyRing{T}) where T <: RingElement = R.base_ring::parent_type(T)
 
+mpoly_ring_type(::Type{T}) where T <: Ring = MPolyRing{elem_type(T)}
+
 @doc Markdown.doc"""
     symbols(a::MPolyRing)
 
@@ -4120,3 +4122,5 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: Rin
    z = combine_like_terms!(z)
    return z
 end
+
+polynomial_ring(args...; kw...) = AbstractAlgebra.polynomial_ring(args...; kw..., generic=true)

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -14,6 +14,8 @@ parent_type(::Type{NCPoly{T}}) where T <: NCRingElem = NCPolyRing{T}
 
 elem_type(::Type{NCPolyRing{T}}) where T <: NCRingElem = NCPoly{T}
 
+dense_poly_ring_type(::Type{T}) where T <: NCRing = NCPolyRing{elem_type(T)}
+
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -14,6 +14,8 @@ parent_type(::Type{Poly{T}}) where T <: RingElement = PolyRing{T}
 
 elem_type(::Type{PolyRing{T}}) where T <: RingElement = Poly{T}
 
+dense_poly_ring_type(::Type{T}) where T <: Ring = PolyRing{elem_type(T)}
+
 ###############################################################################
 #
 #   Basic manipulation


### PR DESCRIPTION
Before #1282, `Generic.polynomial_ring` always constructed generic polynomial rings, even if `polynomial_ring` would result in a specialized implementation. After that PR, it was identical to `AbstractAlgebra.polynomial_ring`. Now, it produces generic polynomial rings again.