### PR TITLE
Fix doctests & get rid of VarNameNonSymbol

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1373,10 +1373,7 @@ do the same as the first constructor except that the variables will be
 automatically numbered. For example if `s` is the string `x` and `n = 3` then
 the variables will print as `x1`, `x2`, `x3`.
 """
-polynomial_ring(R::Ring, n::Int, s::VarNameNonSymbol; kw...) =
-   polynomial_ring(R, n, Symbol(s); kw...)
-
-polynomial_ring(R::Ring, n::Int, s::Symbol=:x; kw...) =
+polynomial_ring(R::Ring, n::Int, s::VarName=:x; kw...) =
    polynomial_ring(R, Symbol.(s, 1:n); kw...)
 
 MPolyRing(R::Ring, n::Int) =

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -735,12 +735,8 @@ julia> S, y = polynomial_ring(R, :y)
 (Univariate Polynomial Ring in y over Univariate Polynomial Ring in x over Integers, y)
 ```
 """
-polynomial_ring(R::NCRing, s::VarName; kw...)
-
-polynomial_ring(R::NCRing, s::VarNameNonSymbol; kw...) = polynomial_ring(R, Symbol(s); kw...)
-
-function polynomial_ring(R::NCRing, s::Symbol; kw...)
-   S = polynomial_ring_only(R, s; kw...)
+function polynomial_ring(R::NCRing, s::VarName; kw...)
+   S = polynomial_ring_only(R, Symbol(s); kw...)
    (S, gen(S))
 end
 

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -251,13 +251,6 @@ function gens end
 
 const VarName = Union{Symbol, AbstractString, Char}
 
-# Constructors which use `VarName` in their argument list often are implemented
-# by first converting all such inputs to use `Symbol` everywhere. For disambiguation
-# and to avoid infinite recursion, it then is sometimes necessary to have methods
-# in pairs, one using `Symbol`, and one using "`VarName` except for `Symbol`".
-# The latter is what `VarNameNonSymbol` is for.
-const VarNameNonSymbol = Union{AbstractString, Char}
-
 ###############################################################################
 #
 #   Unsafe functions

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -250,21 +250,17 @@ total_degree(p::UnivPoly) = total_degree(p.p)
 
 length(p::UnivPoly) = length(p.p)
 
-function gen(S::UniversalPolyRing{T, U}, s::Symbol) where {T <: RingElement, U <: AbstractAlgebra.MPolyRingElem{T}}
-   i = findfirst(x->x==s, S.S)
+function gen(S::UniversalPolyRing{T, U}, s::VarName) where {T <: RingElement, U <: AbstractAlgebra.MPolyRingElem{T}}
+   i = findfirst(==(Symbol(s)), S.S)
    if typeof(i) == Nothing
-      push!(S.S, s)
+      push!(S.S, Symbol(s))
       S.mpoly_ring = MPolyRing{T}(S.base_ring, S.S, S.ord, false)
       i = length(S.S)
    end
    return UnivPoly{T, U}(gen(mpoly_ring(S), i), S)
 end
 
-gen(S::UniversalPolyRing, s::AbstractAlgebra.VarNameNonSymbol) = gen(S, Symbol(s))
-
-gens(S::UniversalPolyRing, v::Vector{Symbol}) = tuple([gen(S, s) for s in v]...)
-
-gens(S::UniversalPolyRing, v::Vector{T}) where T <: AbstractAlgebra.VarNameNonSymbol = gens(S, [Symbol(s) for s in v])
+gens(S::UniversalPolyRing, v::Vector{<:VarName}) = tuple([gen(S, s) for s in v]...)
 
 function gen(S::UniversalPolyRing{T, U}, i::Int) where {T, U}
    i > nvars(S) && error("Variable index out of range")


### PR DESCRIPTION
This also fixes the doctests, which failed due to a reference to a `polynomial_ring(R::Ring, n::Int, s::VarName)` which did not exist before this patch.