### PR TITLE
Add bounds checks to all gen methods

### DIFF
--- a/docs/src/direct_sum.md
+++ b/docs/src/direct_sum.md
@@ -171,14 +171,14 @@ element in $D$.
 **Examples**
 
 ```jldoctest
-julia> N = FreeModule(QQ, 2);
+julia> N = FreeModule(QQ, 1);
 
-julia> M = FreeModule(QQ, 1);
+julia> M = FreeModule(QQ, 2);
 
 julia> D, _ = direct_sum(M, N, M);
 
 julia> D([gen(M, 1), gen(N, 1), gen(M, 2)])
-(1//1, 1//1, 0//1, 0//1)
+(1//1, 0//1, 1//1, 0//1, 1//1)
 ```
 ### Special Homomorphisms
 

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -169,6 +169,7 @@ Return the $i$-th generator (variable) of the series ring $R$. Numbering starts
 from $1$ for the most significant variable.
 """
 function gen(R::AbsMSeriesRing, i::Int)
+   @boundscheck 1 <= i <= nvars(R) || throw(ArgumentError("variable index out of range"))
    S = poly_ring(R)
    if R.weighted_prec == -1
       prec = [R.prec_max[ind] for ind in 1:nvars(R)]

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -25,6 +25,7 @@ ngens(N::DirectSumModule{T}) where T <: RingElement = sum(ngens(M) for M in N.m)
 gens(N::DirectSumModule{T}) where T <: RingElement = [gen(N, i) for i = 1:ngens(N)]
 
 function gen(N::DirectSumModule{T}, i::Int) where T <: RingElement
+   @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index is out of range"))
    R = base_ring(N)
    return N([(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])
 end

--- a/src/generic/FreeAssAlgebra.jl
+++ b/src/generic/FreeAssAlgebra.jl
@@ -86,7 +86,7 @@ function ngens(a::FreeAssAlgebra{T}) where T
 end
 
 function gen(a::FreeAssAlgebra{T}, i::Int) where T
-   0 < i <= nvars(a) || error("variable index out of range")
+   @boundscheck 1 <= i <= ngens(a) || throw(ArgumentError("variable index out of range"))
    c = one(base_ring(a))
    iszero(c) && return zero(a)
    return FreeAssAlgElem{T}(a, T[c], [Int[i]], 1)
@@ -148,7 +148,7 @@ end
 
 function (a::FreeAssAlgebra{T})(c::Vector{T}, e::Vector{Vector{Int}}) where T
    for ei in e
-      all(i -> (i <= nvars(a)), ei) || error("variable index out of range")
+      @boundscheck all(i -> (1 <= i <= nvars(a)), ei) || throw(ArgumentError("variable index out of range"))
    end
    n = length(c)
    n == length(e) || error("coefficient array and exponent array should have the same length")
@@ -163,18 +163,18 @@ end
 ###############################################################################
 
 function coeff(a::FreeAssAlgElem, i::Int)
-   0 < i <= length(a) || error("index out of range")
+   @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
    return a.coeffs[i]
 end
 
 function term(a::FreeAssAlgElem{T}, i::Int) where T <: RingElement
-   0 < i <= length(a) || error("index out of range")
+   @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
    R = parent(a)
    return FreeAssAlgElem{T}(R, [a.coeffs[i]], [a.exps[i]], 1)
 end
 
 function monomial(a::FreeAssAlgElem{T}, i::Int) where T <: RingElement
-   0 < i <= length(a) || error("index out of range")
+   @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
    R = parent(a)
    return FreeAssAlgElem{T}(R, T[one(base_ring(R))], [a.exps[i]], 1)
 end
@@ -187,7 +187,7 @@ $i$-th term of $a$. Term numbering begins at $1$, and the variable
 indices are given in the order of the variables for the ring.
 """
 function exponent_word(a::FreeAssAlgElem{T}, i::Int) where T <: RingElement
-   0 < i <= length(a) || error("index out of range")
+   @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
    return a.exps[i]
 end
 
@@ -278,7 +278,7 @@ end
 
 function set_exponent_word!(a::FreeAssAlgElem{T}, i::Int, w::Vector{Int}) where T <: RingElement
    n = nvars(parent(a))
-   all(x -> 0 < x <= n, w) || error("variable index out of range")
+   @boundscheck all(x -> 1 <= x <= n, w) || throw(ArgumentError("variable index out of range"))
    fit!(a, i)
    a.exps[i] = w
    if i > length(a)

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -50,6 +50,7 @@ function gens(N::FreeModule{T}) where T <: Union{RingElement, NCRingElem}
 end
 
 function gen(N::FreeModule{T}, i::Int) where T <: Union{RingElement, NCRingElem}
+   @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
    return N([(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])
 end

--- a/src/generic/InvariantFactorDecomposition.jl
+++ b/src/generic/InvariantFactorDecomposition.jl
@@ -27,6 +27,7 @@ ngens(N::SNFModule{T}) where T <: RingElement = length(N.invariant_factors)
 gens(N::SNFModule{T}) where T <: RingElement = [gen(N, i) for i = 1:ngens(N)]
 
 function gen(N::SNFModule{T}, i::Int) where T <: RingElement
+   @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
    return N([(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])
 end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -34,19 +34,22 @@ Return the number of variables of the polynomial ring.
 nvars(a::MPolyRing) = a.num_vars
 
 function gen(a::MPolyRing{T}, i::Int, ::Type{Val{:lex}}) where {T <: RingElement}
-    n = a.num_vars
+    n = nvars(a)
+    @boundscheck 1 <= i <= n || throw(ArgumentError("variable index out of range"))
     return a([one(base_ring(a))], reshape([UInt(j == n - i + 1)
             for j = 1:n], n, 1))
 end
 
 function gen(a::MPolyRing{T}, i::Int, ::Type{Val{:deglex}}) where {T <: RingElement}
-    n = a.num_vars
+    n = nvars(a)
+    @boundscheck 1 <= i <= n || throw(ArgumentError("variable index out of range"))
     return a([one(base_ring(a))], reshape([[UInt(j == n - i + 1)
             for j in 1:n]..., UInt(1)], n + 1, 1))
 end
 
 function gen(a::MPolyRing{T}, i::Int, ::Type{Val{:degrevlex}}) where {T <: RingElement}
-    n = a.num_vars
+    n = nvars(a)
+    @boundscheck 1 <= i <= n || throw(ArgumentError("variable index out of range"))
     return a([one(base_ring(a))], reshape([[UInt(j == i)
             for j in 1:n]..., UInt(1)], n + 1, 1))
 end

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -27,6 +27,7 @@ ngens(N::QuotientModule{T}) where T <: RingElement = length(N.gen_cols)
 gens(N::QuotientModule{T}) where T <: RingElement = elem_type(N)[gen(N, i) for i = 1:ngens(N)]
 
 function gen(N::QuotientModule{T}, i::Int) where T <: RingElement
+   @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
    mat = matrix(R, 1, ngens(N),
                 [(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])

--- a/src/generic/Submodule.jl
+++ b/src/generic/Submodule.jl
@@ -25,6 +25,7 @@ ngens(N::Submodule{T}) where T <: RingElement = length(N.gen_cols)
 gens(N::Submodule{T}) where T <: RingElement = [gen(N, i) for i = 1:ngens(N)]
 
 function gen(N::Submodule{T}, i::Int) where T <: RingElement
+   @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
    return N([(j == i ? one(R) : zero(R)) for j = 1:ngens(N)])
 end

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -263,7 +263,7 @@ end
 gens(S::UniversalPolyRing, v::Vector{<:VarName}) = tuple([gen(S, s) for s in v]...)
 
 function gen(S::UniversalPolyRing{T, U}, i::Int) where {T, U}
-   i > nvars(S) && error("Variable index out of range")
+   @boundscheck 1 <= i <= nvars(S) || throw(ArgumentError("generator index out of range"))
    return UnivPoly{T, U}(gen(mpoly_ring(S), i), S)
 end
 

--- a/test/generic/AbsMSeries-test.jl
+++ b/test/generic/AbsMSeries-test.jl
@@ -146,6 +146,8 @@ end
 
    @test is_gen(gen(R, 1))
    @test is_gen(gen(R, 2))
+   @test_throws ArgumentError gen(R, 0)
+   @test_throws ArgumentError gen(R, 5)
    @test !is_gen(x^2)
    @test !is_gen(R(1))
 
@@ -195,14 +197,16 @@ end
    @test zero(R) == 0
    @test one(R) == 1
 
-   @test isunit(1 + y + x)
-   @test !isunit(x)
-   @test !isunit(2 + x)
+   @test is_unit(1 + y + x)
+   @test !is_unit(x)
+   @test !is_unit(2 + x)
 
-   @test isgen(gen(R, 1))
-   @test isgen(gen(R, 2))
-   @test !isgen(x^2)
-   @test !isgen(R(1))
+   @test is_gen(gen(R, 1))
+   @test is_gen(gen(R, 2))
+   @test_throws ArgumentError gen(R, 0)
+   @test_throws ArgumentError gen(R, 5)
+   @test !is_gen(x^2)
+   @test !is_gen(R(1))
 
    @test gens(R) == [x, y]
 

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -26,6 +26,9 @@ using Random
    f = D([gen(F, 1), gen(F,2)])
    @test isa(f, Generic.DirectSumModuleElem)
    @test f == inj[1](gen(F,1)) + inj[2](gen(F, 2))
+
+   @test_throws ArgumentError gen(D, 0)
+   @test_throws ArgumentError gen(D, ngens(D) + 1)
 end
 
 @testset "Generic.DirectSum.basic_manipulation" begin

--- a/test/generic/FreeAssAlgebra-test.jl
+++ b/test/generic/FreeAssAlgebra-test.jl
@@ -103,6 +103,9 @@
          @test leading_exponent_word(g) == [i]
       end
 
+      @test_throws ArgumentError gen(S, 0)
+      @test_throws ArgumentError gen(S, num_vars + 1)
+
       @test_throws ArgumentError leading_term(zero(S))
       @test_throws ArgumentError leading_monomial(zero(S))
       @test_throws ArgumentError leading_exponent_word(zero(S))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -196,6 +196,9 @@ end
          @test var_index(gen(S, i)) == i
       end
 
+      @test_throws ArgumentError gen(S, 0)
+      @test_throws ArgumentError gen(S, num_vars + 1)
+
       nv = rand(1:num_vars)
       f = S(2)
 

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -114,6 +114,9 @@ end
             m2 = sum(m1[i]*gen(M, i) for i in 1:ngens(M))
          end
 
+         @test_throws ArgumentError gen(M, 0)
+         @test_throws ArgumentError gen(M, ngens(M) + 1)
+
          @test m1 == m2
       end
    end

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -86,6 +86,9 @@ end
       @test gen(Q, i) == G[i]
    end
 
+   @test_throws ArgumentError gen(Q, 0)
+   @test_throws ArgumentError gen(Q, ngens(Q) + 1)
+
    @test supermodule(Q) == M
 
    for iter in 1:20

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -74,6 +74,9 @@ end
       @test gen(N, i) == G[i]
    end
 
+   @test_throws ArgumentError gen(N, 0)
+   @test_throws ArgumentError gen(N, ngens(N) + 1)
+
    @test supermodule(N) == M
 
    for iter in 1:20

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -4,11 +4,14 @@
          ord = rand_ordering()
 
          @test UniversalPolynomialRing(R; ordering=ord, cached = true) === UniversalPolynomialRing(R; ordering=ord, cached = true)
-         UniversalPolynomialRing(R; ordering=ord, cached = true) !== UniversalPolynomialRing(R; ordering=ord, cached = true)
+         @test UniversalPolynomialRing(R; ordering=ord, cached = false) !== UniversalPolynomialRing(R; ordering=ord, cached = false)
 
          S = UniversalPolynomialRing(R; ordering=ord)
 
          x = gen(S, "x")
+
+         @test_throws ArgumentError gen(S, 0)
+         @test_throws ArgumentError gen(S, nvars(S) + 1)
 
          @test isa(x, UniversalPolyRingElem)
 


### PR DESCRIPTION
Also use @boundscheck annotation.

Note that I deliberately did not use `BoundsError` as upon closer inspection it does not seem to really apply in this situation and the error message is not any more helpful either. However, it could be changed later again if someone has a different preference, or we could even introduce our own exception type...

Resolves half of #571 by @ulthiel