### PR TITLE
Allow `S[i]` as shorthand for `gen(S,i)` for all parents `S`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1197,6 +1197,17 @@ getindex(R::Union{Tuple{PolyRing, PolyRingElem}, Tuple{NCPolyRing, NCPolyRingEle
 
 ###############################################################################
 #
+#   Syntax S[i] for all parents S as a shortcut for gen(S, i)
+#
+################################################################################
+
+# Unfortunately `Group` is not a subtype of Set because we derive it from the
+# GroupsCore package (oh, if only Julia allowed inheritance from multiple
+# abstract types...)
+getindex(S::Union{Set, Group}, i::Int) = gen(S, i)
+
+###############################################################################
+#
 #   Matrix M = R[...] syntax
 #
 ################################################################################

--- a/test/generic/AbsMSeries-test.jl
+++ b/test/generic/AbsMSeries-test.jl
@@ -149,6 +149,8 @@ end
    @test !is_gen(x^2)
    @test !is_gen(R(1))
 
+   @test gen(R,1) == R[1]
+
    @test gens(R) == [x, y]
 
    @test parent(x) == R
@@ -203,6 +205,8 @@ end
    @test isgen(gen(R, 2))
    @test !isgen(x^2)
    @test !isgen(R(1))
+
+   @test gen(R,1) == R[1]
 
    @test gens(R) == [x, y]
 

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -24,6 +24,7 @@ using Random
    F = FreeModule(QQ,2)
    D, inj, pro = direct_sum(F, F)
    f = D([gen(F, 1), gen(F,2)])
+   @test gen(D, 1) == D[1]
    @test isa(f, Generic.DirectSumModuleElem)
    @test f == inj[1](gen(F,1)) + inj[2](gen(F, 2))
 end

--- a/test/generic/FreeAssAlgebra-test.jl
+++ b/test/generic/FreeAssAlgebra-test.jl
@@ -98,6 +98,7 @@
       @test !is_gen(one(S))
       for i in 1:num_vars
          g = gen(S, i)
+         @test g == S[i]
          @test is_gen(g)
          @test !is_gen(g + 1)
          @test leading_exponent_word(g) == [i]

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -193,6 +193,7 @@ end
          @test is_gen(g[i])
          @test !is_gen(g[i] + 1)
          @test gen(S, i) == g[i]
+         @test gen(S, i) == S[i]
          @test var_index(gen(S, i)) == i
       end
 

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -112,6 +112,7 @@ end
 
          if ngens(M) != 0
             m2 = sum(m1[i]*gen(M, i) for i in 1:ngens(M))
+            @test gen(M, 1) == M[1]
          end
 
          @test m1 == m2

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -84,6 +84,7 @@ end
    G = gens(Q)
    for i = 1:ngens(Q)
       @test gen(Q, i) == G[i]
+      @test gen(Q, i) == Q[i]
    end
 
    @test supermodule(Q) == M

--- a/test/generic/Submodule-test.jl
+++ b/test/generic/Submodule-test.jl
@@ -72,6 +72,7 @@ end
    G = gens(N)
    for i = 1:ngens(N)
       @test gen(N, i) == G[i]
+      @test gen(N, i) == N[i]
    end
 
    @test supermodule(N) == M

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -9,10 +9,12 @@
          S = UniversalPolynomialRing(R; ordering=ord)
 
          x = gen(S, "x")
+         @test x == S[1]
 
          @test isa(x, UniversalPolyRingElem)
 
          y, z = gens(S, ["y", "z"])
+         @test y == S[2]
 
          @test elem_type(S) == Generic.UnivPoly{elem_type(R), Generic.MPoly{elem_type(R)}}
          @test elem_type(Generic.UniversalPolyRing{elem_type(R), Generic.MPoly{elem_type(R)}}) == Generic.UnivPoly{elem_type(R), Generic.MPoly{elem_type(R)}}


### PR DESCRIPTION
As requested by @ulthiel in #571. Together with PR #1331 this resolves #571, *if* we choose to merge it.

This one might be a bit controversial, so paging @fieker @thofma @simonbrandhorst @ThomasBreuer and anyone else who might care about such things.