### PR TITLE
Fix `zero` and `one for `PolyRing`

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -191,9 +191,9 @@ end
 
 Return the zero polynomial in the given polynomial ring.
 """
-zero(R::PolyRing) = R(0)
+zero(R::PolyRing) = R(zero(base_ring(R)))
 
-one(R::PolyRing) = R(1)
+one(R::PolyRing) = R(one(base_ring(R)))
 
 @doc raw"""
     gen(R::PolyRing)


### PR DESCRIPTION
The `0` and `1` should be `zero` and `one` of the base ring instead. This was fixed in a special case, and could be fixed in general:

https://github.com/oscar-system/Oscar.jl/blob/6abf75f599c1f81abb17a2325e569cb6fcadee25/src/AlgebraicGeometry/TropicalGeometry/semiring.jl#L465-L468