### PR TITLE
Turn `FreeModuleElem` into a `struct`

### DIFF
--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -108,7 +108,6 @@ function (M::FreeModule{T})(a::Vector{T}) where T <: Union{RingElement, NCRingEl
    R = base_ring(M)
    v = matrix(R, 1, length(a), a)
    z = FreeModuleElem{T}(M, v)
-   z.parent = M
    return z
 end
 
@@ -117,7 +116,6 @@ end
 #   R = base_ring(M)
 #   v = matrix(R, 1, length(a), a)
 #   z = FreeModuleElem{T}(M, v)
-#   z.parent = M
 #   return z
 #end
 
@@ -126,7 +124,6 @@ function (M::FreeModule{T})(a::Vector{S}) where {T <: Union{RingElement, NCRingE
    R = base_ring(M)
    v = matrix(R, 1, length(a), a)
    z = FreeModuleElem{T}(M, v)
-   z.parent = M
    return z
 end
 
@@ -139,7 +136,6 @@ function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: Union{Ring
    ncols(a) != rank(M) && error("Number of elements does not equal rank")
    nrows(a) != 1 && error("Matrix should have single row")
    z = FreeModuleElem{T}(M, a)
-   z.parent = M
    return z
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1291,13 +1291,13 @@ end
 
 const FreeModuleDict = CacheDictType{Tuple{NCRing, Int}, FreeModule}()
 
-mutable struct FreeModuleElem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
-    v::AbstractAlgebra.MatElem{T}
-    parent::FreeModule{T}
+struct FreeModuleElem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
+   parent::FreeModule{T}
+   v::MatElem{T}
 
-    function FreeModuleElem{T}(m::AbstractAlgebra.FPModule{T}, v::AbstractAlgebra.MatElem{T}) where T <: Union{RingElement, NCRingElem}
-       z = new{T}(v, m)
-    end
+   function FreeModuleElem{T}(m::FreeModule{T}, v::MatElem{T}) where T <: Union{RingElement, NCRingElem}
+      new{T}(m, v)
+   end
 end
 
 ###############################################################################


### PR DESCRIPTION
Note that you can still modify the content of a `FreeModuleElem`, as that just requires access to the the underlying vector, which is still perfectly mutable. So this is mostly an optimization: Julia is now free to stack allocate instances or completely elide them.