### PR TITLE
Extend view support to match supported matrix indexing

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -395,16 +395,10 @@ function _to_indices(x, rows, cols)
    (rows, cols)
 end
 
-function Base.view(M::MatElem{T}, rows::Colon, cols::UnitRange{Int}) where T <: NCRingElement
-   return view(M, 1:nrows(M), cols)
-end
-
-function Base.view(M::MatElem{T}, rows::UnitRange{Int}, cols::Colon) where T <: NCRingElement
-   return view(M, rows, 1:ncols(M))
-end
-
-function Base.view(M::MatElem{T}, rows::Colon, cols::Colon) where T <: NCRingElement
-   return view(M, 1:nrows(M), 1:ncols(M))
+function Base.view(M::MatElem,
+         rows::Union{Int,Colon,AbstractVector{Int}},
+         cols::Union{Int,Colon,AbstractVector{Int}})
+   return view(M, _to_indices(M, rows, cols)...)
 end
 
 Base.firstindex(M::MatrixElem{T}, i::Int) where T <: NCRingElement = 1

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -3983,6 +3983,12 @@ end
    @test fflu(N3) == fflu(M) # tests that deepcopy is correct
    @test M2 == M
 
+   for i in [ 1, 1:2, : ], j in [ 1, 1:2, : ]
+     v = @view M[i,j]
+     @test v isa Generic.MatSpaceView
+     @test M[i,j] == v
+   end
+
    # Test views over noncommutative ring
    R = MatrixAlgebra(ZZ, 2)
    
@@ -3990,13 +3996,11 @@ end
    
    M = rand(S, -10:10)
 
-   N1 = @view M[:,1:2]
-   N2 = @view M[1:2, :]
-   N3 = @view M[:,:]
-
-   @test isa(N1, Generic.MatSpaceView)
-   @test isa(N2, Generic.MatSpaceView)
-   @test isa(N3, Generic.MatSpaceView)
+   for i in [ 1, 1:2, : ], j in [ 1, 1:2, : ]
+     v = @view M[i,j]
+     @test v isa Generic.MatSpaceView
+     @test M[i,j] == v
+   end
 end
 
 @testset "Generic.Mat.change_base_ring" begin


### PR DESCRIPTION
This enables '@view m[1,:]' to work.

Resolves #1218