### PR TITLE
Simplify setindex!

### DIFF
--- a/src/WeakValueDict.jl
+++ b/src/WeakValueDict.jl
@@ -517,13 +517,9 @@ trylock(f, wvh::WeakValueDict) = Base.trylock(f, wvh.lock)
 function Base.setindex!(wvh::WeakValueDict{K}, v, key) where K
     lock(wvh) do
         _cleanup_locked(wvh)
-        k = getkey(wvh.ht, key, nothing)
         # The object gets the finalizer no matter if the key is already there or not.
         finalizer(wvh.finalizer, v)
-        if k === nothing
-            k = key
-        end
-        wvh.ht[k] = WeakRef(v)
+        wvh.ht[key] = WeakRef(v)
     end
     return wvh
 end


### PR DESCRIPTION
The current implementation goes out of its way not to update the key if it `isequal` to but not egal to (`===`) an existing key. In almost all cases, that distinction does not matter, so I think it makes sense to go with this PR's simpler implementation that computes a single hash lookup instead of two. Further, the `setindex!(::Base.Dict, value, key)` method _does_ update the existing key (if any) to be egal to (`===`) the passed key, so I think this behavior should be preferred for consistency.

cc @thofma