### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-doc/abstractalgebra.aux
-doc/abstractalgebra.log
-doc/abstractalgebra.out
-doc/abstractalgebra.pdf
-doc/abstractalgebra.toc
-doc/build/assets
-doc/site
-temp
+/docs/build/
+Manifest.toml
+.DS_Store


### PR DESCRIPTION
The `.gitignore` file seems not up to date. At least I propose to add the three lines analogously to [Oscar.jl `.gitignore`](https://github.com/oscar-system/Oscar.jl/blob/c6aafa8c25796368d4c99f1f738720ba1c28b36a/.gitignore).

For the lines to be removed, I could not find any references in this repo of places where those files get created. If there is some reason to keep them, that would be fine with me as well.