### PR TITLE
Make `deepcopy_internal` consistent

### DIFF
--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -83,7 +83,7 @@ constructions over permutation groups. Any custom permutation group
 implementation in AbstractAlgebra.jl should provide the group element
 arithmetic and comparison.
 
-A custom implementation also needs to implement `hash(::Perm, ::UInt)` and (possibly) `deepcopy_internal(::Perm, ::ObjectIdDict)`.
+A custom implementation also needs to implement `hash(::Perm, ::UInt)` and (possibly) `deepcopy_internal(::Perm, ::IdDict)`.
 
 !!! note
 

--- a/docs/src/ring.md
+++ b/docs/src/ring.md
@@ -109,7 +109,7 @@ elements.
 
 ```julia
 hash(f::RingElement, h::UInt)
-deepcopy_internal(a::RingElement, dict::ObjectIdDict)
+deepcopy_internal(a::RingElement, dict::IdDict)
 show(io::IO, R::NCRing)
 show(io::IO, a::NCRingElement)
 ```

--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -207,7 +207,7 @@ that objects that are the same arithmetically (or that have the same components)
 have different types (or structures), are unlikely to hash to the same value.
 
 ```julia
-deepcopy_internal(f::MyElem, dict::ObjectIdDict)
+deepcopy_internal(f::MyElem, dict::IdDict)
 ```
 
 Return a copy of the given element, recursively copying all components of the object.
@@ -852,8 +852,8 @@ function hash(f::ConstPoly, h::UInt)
    return xor(r, hash(f.c, h))
 end
 
-function deepcopy_internal(f::ConstPoly{T}, d::IdDict) where T <: RingElement
-   r = ConstPoly{T}(deepcopy_internal(f.c, d))
+function deepcopy_internal(f::ConstPoly{T}, dict::IdDict) where T <: RingElement
+   r = ConstPoly{T}(deepcopy_internal(f.c, dict))
    r.parent = f.parent # parent should not be deepcopied
    return r
 end

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -139,7 +139,7 @@ function deepcopy_internal(d::MatAlgElem{T}, dict::IdDict) where T <: NCRingElem
    z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
-         z[i, j] = deepcopy(d[i, j])
+         z[i, j] = deepcopy_internal(d[i, j], dict)
       end
    end
    return z

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -97,7 +97,7 @@ function is_zero_divisor_with_annihilator(a::ResElem)
 end
 
 deepcopy_internal(a::ResElem, dict::IdDict) =
-   parent(a)(deepcopy(data(a)))
+   parent(a)(deepcopy_internal(data(a), dict))
 
 function characteristic(a::ResidueRing{T}) where T <: Integer
    return modulus(a)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -63,7 +63,7 @@ polcoeff(a::AbsSeries, n::Int) = coeff(a, n)
 function deepcopy_internal(a::AbsSeries{T}, dict::IdDict) where T <: RingElement
    coeffs = Vector{T}(undef, length(a))
    for i = 1:length(a)
-      coeffs[i] = deepcopy(coeff(a, i - 1))
+      coeffs[i] = deepcopy_internal(coeff(a, i - 1), dict)
    end
    return parent(a)(coeffs, length(a), precision(a))
 end

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -341,7 +341,7 @@ modulus(a::LaurentSeriesElem{T}) where {T <: ResElem} = modulus(base_ring(a))
 function deepcopy_internal(a::LaurentSeriesElem{T}, dict::IdDict) where {T <: RingElement}
    coeffs = Vector{T}(undef, pol_length(a))
    for i = 1:pol_length(a)
-      coeffs[i] = deepcopy(polcoeff(a, i - 1))
+      coeffs[i] = deepcopy_internal(polcoeff(a, i - 1), dict)
    end
    return parent(a)(coeffs, pol_length(a), precision(a), valuation(a), scale(a))
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -90,14 +90,14 @@ function deepcopy_internal(d::MatSpaceElem{T}, dict::IdDict) where T <: NCRingEl
    z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
-         z[i, j] = deepcopy(d[i, j])
+         z[i, j] = deepcopy_internal(d[i, j], dict)
       end
    end
    return z
 end
 
 function deepcopy_internal(d::MatSpaceView{T}, dict::IdDict) where T <: NCRingElement
-   return MatSpaceView(deepcopy(d.entries), d.base_ring)
+   return MatSpaceView(deepcopy_internal(d.entries, dict), d.base_ring)
 end
 
 ###############################################################################

--- a/src/generic/Misc/Localization.jl
+++ b/src/generic/Misc/Localization.jl
@@ -156,7 +156,7 @@ function is_unit(a::LocElem{T})  where {T <: RingElem}
   return isin(inv(a.data), parent(a))
 end
 
-deepcopy_internal(a::LocElem, dict::IdDict) = parent(a)(deepcopy(data(a)))
+deepcopy_internal(a::LocElem, dict::IdDict) = parent(a)(deepcopy_internal(data(a), dict))
 
 ###############################################################################
 #

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -42,7 +42,7 @@ coeff(a::NCPoly, n::Int) = n >= length(a) ? base_ring(a)(0) : a.coeffs[n + 1]
 function deepcopy_internal(a::NCPoly{T}, dict::IdDict) where T <: NCRingElem
    coeffs = Vector{T}(undef, length(a))
    for i = 1:length(a)
-      coeffs[i] = deepcopy(a.coeffs[i])
+      coeffs[i] = deepcopy_internal(a.coeffs[i], dict)
    end
    return parent(a)(coeffs)
 end

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -28,8 +28,8 @@ check_parent(g::Perm, h::Perm) = length(g.d) == length(h.d) ||
 Base.hash(g::Perm, h::UInt) = foldl((h, x) -> hash(x, h), g.d,
                                     init = hash(0x0d9939c64ab650ca, h))
 
-Base.deepcopy_internal(g::Perm, stackdict::IdDict) =
-   Perm(Base.deepcopy_internal(g.d, stackdict), false)
+Base.deepcopy_internal(g::Perm, dict::IdDict) =
+   Perm(Base.deepcopy_internal(g.d, dict), false)
 
 function getindex(g::Perm, n::Integer)
    return g.d[n]

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -60,7 +60,7 @@ coeff(a::Poly, n::Int) = n >= length(a) ? base_ring(a)(0) : a.coeffs[n + 1]
 function deepcopy_internal(a::Poly{T}, dict::IdDict) where T <: RingElement
    coeffs = Vector{T}(undef, length(a))
    for i = 1:length(a)
-      coeffs[i] = deepcopy(a.coeffs[i])
+      coeffs[i] = deepcopy_internal(a.coeffs[i], dict)
    end
    return parent(a)(coeffs)
 end

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -260,7 +260,7 @@ function rescale!(a::PuiseuxSeriesElem)
 end
 
 function deepcopy_internal(a::PuiseuxSeriesElem{T}, dict::IdDict) where {T <: RingElement}
-    return parent(a)(deepcopy(a.data), a.scale)
+    return parent(a)(deepcopy_internal(a.data, dict), a.scale)
 end
 
 function characteristic(a::PuiseuxSeriesRing{T}) where T <: RingElement

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -53,7 +53,7 @@ end
 function deepcopy_internal(a::RelSeries{T}, dict::IdDict) where T <: RingElement
    coeffs = Vector{T}(undef, pol_length(a))
    for i = 1:pol_length(a)
-      coeffs[i] = deepcopy(polcoeff(a, i - 1))
+      coeffs[i] = deepcopy_internal(polcoeff(a, i - 1), dict)
    end
    return parent(a)(coeffs, pol_length(a), precision(a), valuation(a))
 end

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -299,7 +299,7 @@ function Base.hash(p::UnivPoly, h::UInt)
 end
 
 function deepcopy_internal(p::UnivPoly{T, U}, dict::IdDict) where {T, U}
-   return UnivPoly{T, U}(deepcopy(p.p), p.parent)
+   return UnivPoly{T, U}(deepcopy_internal(p.p, dict), p.parent)
 end
 
 ###############################################################################

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -110,7 +110,7 @@ end
 
 function deepcopy_internal(a::GFElem{T}, dict::IdDict) where T <: Integer
    R = parent(a)
-   return GFElem{T}(deepcopy(a.d), R)
+   return GFElem{T}(deepcopy_internal(a.d, dict), R)
 end
 
 ###############################################################################

--- a/test/algorithms/GenericFunctions-test.jl
+++ b/test/algorithms/GenericFunctions-test.jl
@@ -59,8 +59,8 @@ function hash(f::ConstPoly, h::UInt)
    return xor(r, hash(f.c, h))
 end
 
-function deepcopy_internal(f::ConstPoly{T}, d::IdDict) where T <: RingElement
-   r = ConstPoly{T}(deepcopy_internal(f.c, d))
+function deepcopy_internal(f::ConstPoly{T}, dict::IdDict) where T <: RingElement
+   r = ConstPoly{T}(deepcopy_internal(f.c, dict))
    r.parent = f.parent # parent should not be deepcopied
    return r
 end


### PR DESCRIPTION
All implementations now pass the `IdDict` along.
Fixed some references to `deepcopy_internal` in the docs.

Closes #906.