### PR TITLE
Another fix for the printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.30.4"
+version = "0.30.5"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -149,7 +149,7 @@ Matrix space of 2 rows and 3 columns
   over rationals
 
 julia> T = MatrixAlgebra(QQ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over rationals
 
 julia> M1 = S(Rational{BigInt}[2 3 1; 1 0 4])
@@ -240,7 +240,7 @@ julia> P = zero_matrix(ZZ, 3, 2)
 [0   0]
 
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> M = R()

--- a/docs/src/matrix_algebras.md
+++ b/docs/src/matrix_algebras.md
@@ -76,7 +76,7 @@ julia> R, t = polynomial_ring(QQ, "t")
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S = MatrixAlgebra(R, 3)
-Matrix Algebra of degree 3
+Matrix algebra of degree 3
   over univariate polynomial ring in t over rationals
 
 julia> A = S()
@@ -144,7 +144,7 @@ julia> R, t = polynomial_ring(QQ, "t")
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S = MatrixAlgebra(R, 3)
-Matrix Algebra of degree 3
+Matrix algebra of degree 3
   over univariate polynomial ring in t over rationals
 
 julia> A = S([t + 1 t R(1); t^2 t t; R(-2) t + 2 t^2 + t + 1])

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -791,7 +791,7 @@ julia> evaluate(f, [1, 2], [x + z, x - z])
 x^4 - 2*x^2*z^2 + 5*x*z + z^4 - z^2 + z + 1
 
 julia> S = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> M1 = S([1 2; 3 4])

--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -65,17 +65,17 @@ resulting parent objects to coerce various elements into the polynomial ring.
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> U, z = R["z"]
-(Univariate polynomial ring in z over Matrix Algebra of degree 2 over integers, z)
+(Univariate polynomial ring in z over matrix algebra of degree 2 over integers, z)
 
 julia> f = S()
 0
@@ -119,14 +119,14 @@ We give some examples of such functionality.
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> f = x^3 + 3x + 21
 x^3 + [3 0; 0 3]*x + [21 0; 0 21]
@@ -150,16 +150,16 @@ julia> n = length(g)
 3
 
 julia> U = base_ring(T)
-Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers
+Univariate polynomial ring in x over matrix algebra of degree 2 over integers
 
 julia> V = base_ring(y + 1)
-Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers
+Univariate polynomial ring in x over matrix algebra of degree 2 over integers
 
 julia> v = var(T)
 :y
 
 julia> U = parent(y + 1)
-Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers
+Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers
 
 julia> g == deepcopy(g)
 true
@@ -206,14 +206,14 @@ is_term(::NCPolyRingElem)
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> a = zero(T)
 0
@@ -264,14 +264,14 @@ mullow(::NCPolyRingElem{T}, ::NCPolyRingElem{T}, ::Int) where T <: NCRingElem
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -298,14 +298,14 @@ reverse(::NCPolyRingElem)
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -332,14 +332,14 @@ shift_right(::NCPolyRingElem, ::Int)
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -366,14 +366,14 @@ evaluated at $a$ by writing $f(a)$.
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 
 julia> f = x*y^2 + (x + 1)*y + 3
@@ -400,14 +400,14 @@ derivative(::NCPolyRingElem)
 
 ```jldoctest
 julia> R = MatrixAlgebra(ZZ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over integers
 
 julia> S, x = polynomial_ring(R, "x")
-(Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, x)
+(Univariate polynomial ring in x over matrix algebra of degree 2 over integers, x)
 
 julia> T, y = polynomial_ring(S, "y")
-(Univariate polynomial ring in y over Univariate polynomial ring in x over Matrix Algebra of degree 2 over integers, y)
+(Univariate polynomial ring in y over univariate polynomial ring in x over matrix algebra of degree 2 over integers, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -160,7 +160,7 @@ is_square(a::MatAlgElem) = true
 ###############################################################################
 
 function show(io::IO, ::MIME"text/plain", a::MatAlgebra)
-  print(io, "Matrix Algebra of")
+  print(io, "Matrix algebra of")
   print(io, " degree ", a.n)
   println(io)
   io = pretty(io)
@@ -170,10 +170,10 @@ end
 
 function show(io::IO, a::MatAlgebra)
    if get(io, :supercompact, false)
-      print(io, "Matrix Algebra")
+      print(io, "Matrix algebra")
    else
       io = pretty(io)
-      print(io, "Matrix Algebra of ")
+      print(io, "Matrix algebra of ")
       print(io, "degree ", a.n, " over ")
       print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
    end

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1645,6 +1645,8 @@ julia> io = AbstractAlgebra.pretty(stdout);
 """
 pretty(io::IO) = IOCustom(io)
 
+pretty(io::IOContext) = io.io isa IOCustom ? io : IOCustom(io)
+
 export pretty, Lowercase, LowercaseOff, Indent, Dedent
 
 end # PrettyPrinting

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -145,7 +145,7 @@ either an element or parent.
 # Examples
 ```jldoctest; setup = :(using AbstractAlgebra)
 julia> S = MatrixAlgebra(QQ, 2)
-Matrix Algebra of degree 2
+Matrix algebra of degree 2
   over rationals
 
 julia> zero(S)

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -360,4 +360,12 @@ let
   @test String(take!(io)) == "test"
   print(io, AbstractAlgebra.Lowercase(), AbstractAlgebra.LowercaseOff(), "Test")
   @test String(take!(io)) == "Test"
+
+  # Fix bug for pretty(IOCustom(pretty(io))) forgetting everything
+  io = IOBuffer()
+  io = AbstractAlgebra.pretty(io)
+  print(io, AbstractAlgebra.Lowercase())
+  io = AbstractAlgebra.pretty(IOContext(io))
+  print(io, "A")
+  @test String(take!(io.io)) == "a"
 end


### PR DESCRIPTION
There was a bug in handling newio = pretty(IOContext(pretty(io))),
since newio did not preserve the state of io. One fix would be
be to specialize IOCustom(io::IOContext{<:IOCustom}), but the
easiest thing is to make pretty(x::IOContext{<:IOCustom}) = x
since we consider IOCustom already prettified.
