### PR TITLE
Avoid some method invalidations

### DIFF
--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1513,8 +1513,6 @@ IOCustom(io::IO, force_newlines = false) = IOCustom{typeof(io)}(io, 0, false, " 
 
 IOCustom(io::IOCustom, force_newlines = false) = begin io.force_newlines = force_newlines; io; end
 
-convert(::Type{IOCustom}, io::IOCustom) = io
-
 in(key_value::Pair, io::IOCustom) = in(key_value, io.io, ===)
 haskey(io::IOCustom, key) = haskey(io.io, key)
 getindex(io::IOCustom, key) = getindex(io.io, key)


### PR DESCRIPTION
The Julia library already provides `convert(::Type{T},x::T)=x`.

Reduces the number of invalidations from 607 to 511 in this snippet:

    using SnoopCompileCore
    invalidations = @snoopr using AbstractAlgebra;
    using SnoopCompile
    length(uinvalidated(invalidations))
