### PR TITLE
Avoid implicit conversion of Perm{T} to Vector{T}

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -46,8 +46,6 @@ Base.promote_rule(::Type{Perm{I}}, ::Type{Perm{J}}) where {I,J} =
 
 convert(::Type{Perm{T}}, p::Perm) where T = Perm(convert(Vector{T}, p.d), false)
 
-convert(::Type{Vector{T}}, p::Perm{T}) where {T} = Vector{T}(p)
-
 Vector{T}(p::Perm{T}) where {T} = p.d
 
 function Base.similar(p::Perm{T}, ::Type{S}=T) where {T, S<:Integer}

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -55,7 +55,6 @@ end
    @test parent(g) == G
    @test parent(g) == SymmetricGroup(T(10))
 
-   @test convert(Vector{T}, G(z)) == z
    @test Vector{T}(G(z)) == z
 
    if T != Int


### PR DESCRIPTION
First off, these cause invalidations. Secondly, doing this kind of
conversion implicitly also seems semantically dubious.

This is a breaking change.