### PR TITLE
Export `NCRing`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -255,6 +255,7 @@ export MPolyRing
 export MPolyRingElem
 export mul!
 export NCPolyRingElem
+export NCRing
 export NCRingElem
 export NotImplementedError
 export NotInvertibleError


### PR DESCRIPTION
`NCRingElem` gets already exported, then why not `NCRing`?