### PR TITLE
Let matrix literals actually concatenate

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1241,9 +1241,12 @@ getindex(S::Union{Set, Group}, i::Int) = gen(S, i)
 #
 ################################################################################
 
-typed_hvcat(R::Ring, dims::Dims, d...) = matrix(R, length(dims), dims[1], hvcat(dims, d...))
-typed_hcat(R::Ring, d...) = matrix(R, 1, length(d), hcat(d...))
-typed_vcat(R::Ring, d...) = matrix(R, length(d), 1, vcat(d...))
+Base.typed_hvncat(R::NCRing, args...) = _matrix(R, hvncat(args...))
+Base.typed_hvcat(R::NCRing, args...) = _matrix(R, hvcat(args...))
+Base.typed_hcat(R::NCRing, args...) = _matrix(R, hcat(args...))
+Base.typed_vcat(R::NCRing, args...) = _matrix(R, vcat(args...))
+_matrix(R::NCRing, a::AbstractVector) = matrix(R, length(a), isempty(a) ? 0 : 1, a)
+_matrix(R::NCRing, a::AbstractMatrix) = matrix(R, a)
 
 ###############################################################################
 #

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1241,7 +1241,7 @@ getindex(S::Union{Set, Group}, i::Int) = gen(S, i)
 #
 ################################################################################
 
-Base.typed_hvncat(R::NCRing, args...) = _matrix(R, hvncat(args...))
+VERSION >= v"1.7" && (Base.typed_hvncat(R::NCRing, args...) = _matrix(R, hvncat(args...)))
 Base.typed_hvcat(R::NCRing, args...) = _matrix(R, hvcat(args...))
 Base.typed_hcat(R::NCRing, args...) = _matrix(R, hcat(args...))
 Base.typed_vcat(R::NCRing, args...) = _matrix(R, vcat(args...))

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -194,18 +194,22 @@ end
       @test m[3, 1] == T(5)
       @test m[3, 2] == T(6)
 
-      @test T[;] == matrix(T, 0, 0, [])
-      @test T[;;] == matrix(T, 0, 0, [])
       @test T[1;] == matrix(T, 1, 1, [1])
-      @test T[1;;] == matrix(T, 1, 1, [1])
       @test T[[1 2; 3 4];] == matrix(T, [1 2; 3 4])
       @test T[[1 2]; 3 4] == matrix(T, [1 2; 3 4])
-      @test T[[1; 3];; 2; 4] == matrix(T, [1 2; 3 4])
       @test T[1:4;] == matrix(T, 4, 1, 1:4)
-      @test T[1:4;;5:8] == matrix(T, [1 5;2 6;3 7;4 8])
+      if VERSION >= v"1.7"
+         @test T[;] == matrix(T, 0, 0, [])
+         @test T[;;] == matrix(T, 0, 0, [])
+         @test T[1;;] == matrix(T, 1, 1, [1])
+         @test T[[1 2; 3 4];;] == matrix(T, [1 2; 3 4])
+         @test T[[1; 3];; 2; 4] == matrix(T, [1 2; 3 4])
+         @test T[1:4;; 5:8] == matrix(T, [1 5; 2 6; 3 7; 4 8])
+         @test_throws MethodError T[;;;]
+         @test_throws MethodError T[1;;;]
+      end
 
       @test_throws ArgumentError T[1; 2 3]
-      @test_throws MethodError T[1;;;]
    end
 
    arr = [1 2; 3 4]

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -198,14 +198,17 @@ end
       @test T[[1 2; 3 4];] == matrix(T, [1 2; 3 4])
       @test T[[1 2]; 3 4] == matrix(T, [1 2; 3 4])
       @test T[1:4;] == matrix(T, 4, 1, 1:4)
+      @test T[[];] == matrix(T, 0, 0, [])
+      @test T[[] ()...] == matrix(T, 0, 1, [])
+      @test T[[] []] == matrix(T, 0, 2, [])
       if VERSION >= v"1.7"
-         @test T[;] == matrix(T, 0, 0, [])
-         @test T[;;] == matrix(T, 0, 0, [])
+         # @test T[;] == matrix(T, 0, 0, []) # stalls Julia 1.6 parser
+         # @test T[;;] == matrix(T, 0, 0, []) # stalls Julia 1.6 parser
          @test T[1;;] == matrix(T, 1, 1, [1])
          @test T[[1 2; 3 4];;] == matrix(T, [1 2; 3 4])
          @test T[[1; 3];; 2; 4] == matrix(T, [1 2; 3 4])
          @test T[1:4;; 5:8] == matrix(T, [1 5; 2 6; 3 7; 4 8])
-         @test_throws MethodError T[;;;]
+         # @test_throws MethodError T[;;;] # stalls Julia 1.6 parser
          @test_throws MethodError T[1;;;]
       end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -194,7 +194,18 @@ end
       @test m[3, 1] == T(5)
       @test m[3, 2] == T(6)
 
+      @test T[;] == matrix(T, 0, 0, [])
+      @test T[;;] == matrix(T, 0, 0, [])
+      @test T[1;] == matrix(T, 1, 1, [1])
+      @test T[1;;] == matrix(T, 1, 1, [1])
+      @test T[[1 2; 3 4];] == matrix(T, [1 2; 3 4])
+      @test T[[1 2]; 3 4] == matrix(T, [1 2; 3 4])
+      @test T[[1; 3];; 2; 4] == matrix(T, [1 2; 3 4])
+      @test T[1:4;] == matrix(T, 4, 1, 1:4)
+      @test T[1:4;;5:8] == matrix(T, [1 5;2 6;3 7;4 8])
+
       @test_throws ArgumentError T[1; 2 3]
+      @test_throws MethodError T[1;;;]
    end
 
    arr = [1 2; 3 4]


### PR DESCRIPTION
This makes matrix literals (like `QQ[1 2; 3 4]`) more flexible. See the new tests for examples.