### PR TITLE
Access generator `x` as `R.x`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1237,6 +1237,17 @@ getindex(S::Union{Set, Group}, i::Int) = gen(S, i)
 
 ###############################################################################
 #
+#   Syntactic sugar gen(R, :x) and R.x for generator named x of R
+#
+###############################################################################
+
+
+const SymbolsTypes = Union{FreeAssAlgebra, LaurentMPolyRing, LaurentPolynomialRing, MPolyRing, MSeriesRing, NCPolyRing, PolyRing, UniversalPolyRing}
+gen(R::SymbolsTypes, x::VarName) = only(gens(R)[symbols(R) .== Symbol(x)])
+Base.getproperty(R::T, x::Symbol) where T<:SymbolsTypes = hasfield(T, x) ? getfield(R, x) : gen(R, x)
+
+###############################################################################
+#
 #   Matrix M = R[...] syntax
 #
 ################################################################################


### PR DESCRIPTION
This seems to be a reasonable syntax to me.

Some caveats and my solutions to them:
Caveat 1: Complication of `Base.getproperty` could possibly slow down other code → Wait for time needed in CI tests.
Caveat 2: Name clashes with field names → Silently prefer the field name.
Caveat 3: Several generators named the same, say `x` → Produce an error, when accessing `R.x`.
Caveat 4: Perhaps, I did not cover all types of parents with generators → I cover all (abstract) AbstractAlgebra types, for which `symbols` has a method, thus also including all specializations from Nemo. Perhaps appropriate code would have to be added in Hecke and Oscar as well.