### PR TITLE
CI: use concrete action version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,9 +48,9 @@ jobs:
       - name: "Cache artifacts"
         uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
       - name: "Run doctests"
@@ -79,8 +79,8 @@ jobs:
         with:
           version: '1.9'
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/pull/2770 for AbstractAlgebra. This is recommended by the [readme](https://github.com/julia-actions/julia-buildpkg#usage).