### PR TITLE
Avoid self-recursion in RandomExtensions.make

### DIFF
--- a/docs/src/rand.md
+++ b/docs/src/rand.md
@@ -64,7 +64,7 @@ function RandomExtensions.make(S::PolyRing, deg_range::AbstractUnitRange{Int}, v
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, deg_range, vs[1]) # forward to default Make constructor
    else
-      make(S, deg_range, make(R, vs...))
+      Make(S, deg_range, make(R, vs...))
    end
 end
 ```

--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -156,7 +156,7 @@ function RandomExtensions.make(S::MSeriesRing,
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, vs[1])
    else
-      make(S, term_range, make(R, vs...))
+      Make(S, term_range, make(R, vs...))
    end
 end
 

--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -928,7 +928,7 @@ function RandomExtensions.make(S::FracField, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/FreeAssAlgebra.jl
+++ b/src/FreeAssAlgebra.jl
@@ -164,7 +164,7 @@ function RandomExtensions.make(S::AbstractAlgebra.FreeAssAlgebra,
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, exp_bound, vs[1])
    else
-      make(S, term_range, exp_bound, make(R, vs...))
+      Make(S, term_range, exp_bound, make(R, vs...))
    end
 end
 

--- a/src/LaurentMPoly.jl
+++ b/src/LaurentMPoly.jl
@@ -103,7 +103,7 @@ function RandomExtensions.make(S::AbstractAlgebra.LaurentMPolyRing,
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, exp_bound, vs[1])
    else
-      make(S, term_range, exp_bound, make(R, vs...))
+      Make(S, term_range, exp_bound, make(R, vs...))
    end
 end
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1306,7 +1306,7 @@ function RandomExtensions.make(S::AbstractAlgebra.MPolyRing, term_range::Abstrac
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, exp_bound, vs[1])
    else
-      make(S, term_range, exp_bound, make(R, vs...))
+      Make(S, term_range, exp_bound, make(R, vs...))
    end
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6646,7 +6646,7 @@ function RandomExtensions.make(S::MatSpace, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -314,7 +314,7 @@ function RandomExtensions.make(S::MatAlgebra, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/Module.jl
+++ b/src/Module.jl
@@ -286,7 +286,7 @@ function RandomExtensions.make(M::FPModule, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(M, vs[1]) # forward to default Make constructor
    else
-      make(M, make(R, vs...))
+      Make(M, make(R, vs...))
    end
 end
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -684,7 +684,7 @@ function RandomExtensions.make(S::NCPolyRing, deg_range::AbstractUnitRange{Int},
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, deg_range, vs[1]) # forward to default Make constructor
    else
-      make(S, deg_range, make(R, vs...))
+      Make(S, deg_range, make(R, vs...))
    end
 end
 

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3300,7 +3300,7 @@ function RandomExtensions.make(S::PolyRing, deg_range::AbstractUnitRange{Int}, v
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, deg_range, vs[1]) # forward to default Make constructor
    else
-      make(S, deg_range, make(R, vs...))
+      Make(S, deg_range, make(R, vs...))
    end
 end
 
@@ -3309,7 +3309,7 @@ function RandomExtensions.make(S::PolyRing, deg::Int, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, deg, vs[1]) # forward to default Make constructor
    else
-      make(S, deg, make(R, vs...))
+      Make(S, deg, make(R, vs...))
    end
 end
 

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -1374,7 +1374,7 @@ function RandomExtensions.make(S::SeriesRing, val_range::AbstractUnitRange{Int},
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, val_range, vs[1]) # forward to default Make constructor
    else
-      make(S, val_range, make(R, vs...))
+      Make(S, val_range, make(R, vs...))
    end
 end
 

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -425,7 +425,7 @@ function RandomExtensions.make(S::ResidueRing, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1])
    else
-      make(S, make(base_ring(S), vs...))
+      Make(S, make(base_ring(S), vs...))
    end
 end
 

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -472,7 +472,7 @@ function RandomExtensions.make(S::ResidueField, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1])
    else
-      make(S, make(base_ring(S), vs...))
+      Make(S, make(base_ring(S), vs...))
    end
 end
 

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -1206,7 +1206,7 @@ function RandomExtensions.make(S::FunctionField, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, (n-1):(n-1), vs...))
+      Make(S, make(R, (n-1):(n-1), vs...))
    end
 end
 

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -431,12 +431,12 @@ RandomExtensions.maketype(S::LaurentPolyWrapRing, _, _) = elem_type(S)
 function RandomExtensions.make(S::LaurentPolyWrapRing, v1, vs...)
    R = S.polyring
    if length(vs) == 1 && vs[1] isa Integer && elem_type(R) == Random.gentype(v1)
-     Make(S, v1, vs[1]) # forward to default Make constructor
+      Make(S, v1, vs[1]) # forward to default Make constructor
    else
       degrees_range = v1
       m = minimum(degrees_range)
       degrees_range = degrees_range .- m
-      make(S, make(R, degrees_range, vs...), m)
+      Make(S, make(R, degrees_range, vs...), m)
    end
 end
 

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -1756,9 +1756,9 @@ RandomExtensions.maketype(S::LaurentSeriesRingOrField, ::AbstractUnitRange{Int},
 function RandomExtensions.make(S::LaurentSeriesRingOrField, val_range::AbstractUnitRange{Int}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-     Make(S, val_range, vs[1]) # forward to default Make constructor
+      Make(S, val_range, vs[1]) # forward to default Make constructor
    else
-      make(S, val_range, make(R, vs...))
+      Make(S, val_range, make(R, vs...))
    end
 end
 

--- a/src/generic/NumberField.jl
+++ b/src/generic/NumberField.jl
@@ -26,7 +26,7 @@ function RandomExtensions.make(S::ResidueField{Generic.Poly{Rational{BigInt}}}, 
       Make(S, vs[1])
    else
       n = degree(S.modulus)
-      make(S, make(base_ring(S), n - 1:n - 1, vs...))
+      Make(S, make(base_ring(S), n - 1:n - 1, vs...))
    end
 end
 

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -492,9 +492,9 @@ RandomExtensions.maketype(R::RationalFunctionField, _) = elem_type(R)
 function RandomExtensions.make(S::RationalFunctionField, vs...)
    R = base_ring(fraction_field(S))
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+      Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/generic/TotalFraction.jl
+++ b/src/generic/TotalFraction.jl
@@ -501,9 +501,9 @@ RandomExtensions.maketype(R::TotFracRing, _) = elem_type(R)
 function RandomExtensions.make(S::TotFracRing, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      RandomExtensions.Make(S, vs[1]) # forward to default Make constructor
+      Make(S, vs[1]) # forward to default Make constructor
    else
-      make(S, make(R, vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -974,7 +974,7 @@ function RandomExtensions.make(S::AbstractAlgebra.UniversalPolyRing, term_range:
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, exp_bound, vs[1])
    else
-      make(S, term_range, exp_bound, make(R, vs...))
+      Make(S, term_range, exp_bound, make(R, vs...))
    end
 end
 


### PR DESCRIPTION
Self-recursion disables optimizations and can lead to `@inferred` reporting failures as a result, even when `@code_warntype` seemingly suggests that the code being called is type stable.

As an example, without this patch the following reports failure

    using AbstractAlgebra, Test
    using AbstractAlgebra.RandomExtensions: RandomExtensions, make
    R = polynomial_ring(polynomial_ring(QQ,:x1)[1], :y)[1]
    @inferred make(R, 0:0, 1:10, -10:10)