### PR TITLE
Widen `zeros` to `NCRing`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -1290,9 +1290,9 @@ include("Deprecations.jl")
 #
 ###############################################################################
 
-Array(R::Ring, r::Int...) = Array{elem_type(R)}(undef, r)
+Array(R::NCRing, r::Int...) = Array{elem_type(R)}(undef, r)
 
-function zeros(R::Ring, r::Int...)
+function zeros(R::NCRing, r::Int...)
    T = elem_type(R)
    A = Array{T}(undef, r)
    for i in eachindex(A)


### PR DESCRIPTION
This will fix a failure in https://github.com/thofma/Hecke.jl/pull/1206.
And I see no reason why this functionality should be restricted to the commutative world.