### PR TITLE
Adjustments for is_negative and is_positive

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -920,6 +920,7 @@ export is_monomial
 export is_monomial_recursive
 export is_negative
 export is_popov
+export is_positive
 export is_reverse
 export is_rimhook
 export is_rref
@@ -1352,8 +1353,6 @@ include("algorithms/DensePoly.jl")
 #  For backwards compatibility
 #
 ###############################################################################
-
-function is_negative end
 
 include("Aliases.jl")
 

--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -16,10 +16,8 @@ add!(z::Rational{Int}, x::Rational{Int}, y::Int) = x + y
 
 mul!(z::Rational{Int}, x::Rational{Int}, y::Int) = x * y
 
-is_negative(x::Rational) = x.num < 0
-
-is_negative(n::Integer) = cmp(n, 0) < 0
-is_positive(n::Integer) = cmp(n, 0) > 0
+is_negative(n::T) where T<:Real = n < zero(T)
+is_positive(n::T) where T<:Real = n > zero(T)
 
 # TODO (CF):
 # should be Bernstein'ed: this is slow for large valuations


### PR DESCRIPTION
- export `is_positive`
- drop `isnegative` alias
- add more generic methods for both

I realized that the `is_positive(::Integer)` method was the only mention of `is_positive` in `AbstractAlgebra.jl` at all. So this at least makes the situation "symmetric"

An alternative would be just move this back to Nemo -- I am not sure how useful it is to have it here, with no use cases and documentation.

CC @fieker @lgoettgens 