### PR TITLE
Add docstrings for various map construction functions

### DIFF
--- a/docs/src/functional_map.md
+++ b/docs/src/functional_map.md
@@ -51,21 +51,6 @@ a Julia function/closure implementing the map.
 
 Such maps can be constructed using the following function:
 
-```julia
+```@docs
 map_from_func(f::Function, R, S)
-```
-
-Construct the generic functional map with domain and codomain given by the parent objects
-$R$ and $S$ corresponding to the Julia function $f$.
-
-**Examples**
-
-```jldoctest
-julia> f = map_from_func(x -> x + 1, ZZ, ZZ)
-Map defined by a Julia function
-  from integers
-  to integers
-
-julia> f(ZZ(2))
-3
 ```

--- a/docs/src/map_interface.md
+++ b/docs/src/map_interface.md
@@ -1,6 +1,8 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = :(using AbstractAlgebra)
+DocTestSetup = quote
+    using AbstractAlgebra
+end
 ```
 
 # Map Interface
@@ -166,7 +168,7 @@ map are identity maps on the same domain.
 To construct an identity map for a given domain, specified by a parent object `R`, say,
 we have the following function.
 
-```julia
+```@docs
 identity_map(R::Set)
 ```
 
@@ -189,11 +191,9 @@ should be applied.
 
 To construct a composition map from two existing maps, we have the following function:
 
-```julia
-compose(f::Map{D, U}, g::Map{U, C}) where {D, U, C}
+```@docs
+compose(f::Map, g::Map)
 ```
-
-Compose the two maps $f$ and $g$, i.e. return the map $h$ such that $h(x) = g(f(x))$.
 
 As a shortcut for this function we have the following operator:
 

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -27,6 +27,23 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    compose(f::Map, g::Map)
+
+Compose the two maps $f$ and $g$, i.e. return the map $h$ such that $h(x) = g(f(x))$.
+
+# Examples
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> f = map_from_func(x -> x + 1, ZZ, ZZ);
+
+julia> g = map_from_func(x -> QQ(x), ZZ, QQ);
+
+julia> h = compose(f, g)
+Functional composite map
+  first map: integers -> integers
+  next map: integers -> rationals
+```
+"""
 function compose(f::Map, g::Map)
    check_composable(f, g)
    return Generic.CompositeMap(f, g)
@@ -40,6 +57,24 @@ end
 #
 ################################################################################
 
+@doc raw"""
+    identity_map(R::D) where D <: AbstractAlgebra.Set
+
+Return an identity map on the domain $R$.
+
+# Examples
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> R, t = ZZ[:t]
+(Univariate polynomial ring in t over integers, t)
+
+julia> f = identity_map(R)
+Identity map
+  of univariate polynomial ring in t over integers
+
+julia> f(t)
+t
+```
+"""
 identity_map(R::D) where D <: AbstractAlgebra.Set = Generic.IdentityMap{D}(R)
 
 ################################################################################
@@ -48,6 +83,23 @@ identity_map(R::D) where D <: AbstractAlgebra.Set = Generic.IdentityMap{D}(R)
 #
 ################################################################################
 
+@doc raw"""
+    map_from_func(image_fn::Function, domain, codomain)
+
+Construct the generic functional map with domain and codomain given by the parent objects
+$R$ and $S$ corresponding to the Julia function $f$.
+
+# Examples
+```jldoctest; setup = :(using AbstractAlgebra)
+julia> f = map_from_func(x -> x + 1, ZZ, ZZ)
+Map defined by a Julia function
+  from integers
+  to integers
+
+julia> f(ZZ(2))
+3
+```
+"""
 function map_from_func(image_fn::Function, domain, codomain)
    return Generic.FunctionalMap(domain, codomain, image_fn)
 end

--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -62,7 +62,7 @@ codomain(f::IdentityMap) = f.domain
 
 function show(io::IO, ::MIME"text/plain", M::IdentityMap)
    io = pretty(io)
-   println("Identity map")
+   println(io, "Identity map")
    print(io, Indent(), "of ", Lowercase())
    show(io, MIME("text/plain"), domain(M))
    print(io, Dedent())


### PR DESCRIPTION
Also include jldoctests for each, and fix a bug in the printing of IdentityMap instances.