### PR TITLE
Remove weird `:` method

### DIFF
--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -1,5 +1,3 @@
-Base.:(:)(x::Int, y::Nothing) = 1:0
-
 export neg!
 
 function neg!(w::Vector{Int})


### PR DESCRIPTION
I could not find any uses downstream. And it is just completely weird and unintuitive to have. So I propose to remove it (if the OscarCI does not complain).

Edit: this is breaking