### PR TITLE
Deprecate Matrix constructors with `::Type{MatElem}` param

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -21,3 +21,11 @@ end
 @deprecate factor(f::PolyRingElem, R::Field) factor(R, f)
 
 @deprecate roots(f::PolyRingElem, R::Field) roots(R, f)
+
+# Deprecated in 0.32.*
+
+@deprecate zero_matrix(::Type{MatElem}, R::Ring, n::Int) zero_matrix(R, n)
+
+@deprecate zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int) zero_matrix(R, n, m)
+
+@deprecate identity_matrix(::Type{MatElem}, R::Ring, n::Int) identity_matrix(R, n)

--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -78,14 +78,6 @@ ncols(A::Matrix{T}) where {T} = size(A)[2]
 
 zero_matrix(::Type{Int}, r, c) = zeros(Int, r, c)
 
-function zero_matrix(::Type{MatElem}, R::Ring, n::Int)
-    return zero_matrix(R, n)
-end
-
-function zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int)
-    return zero_matrix(R, n, m)
-end
-
 function matrix(A::Matrix{T}) where {T<:RingElem}
     r, c = size(A)
     (r < 0 || c < 0) && error("Array must be non-empty")
@@ -106,10 +98,6 @@ function scalar_matrix(R::Ring, n::Int, a::RingElement)
         z[i, i] = b
     end
     return z
-end
-
-function identity_matrix(::Type{MatElem}, R::Ring, n::Int)
-    return identity_matrix(R, n)
 end
 
 function is_zero_row(M::Matrix, i::Int)


### PR DESCRIPTION
These seem old and shouldn't be needed downstream