### PR TITLE
Fix one `diagonal_matrix` dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.32.2"
+version = "0.32.3"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7019,7 +7019,11 @@ function diagonal_matrix(x::T, xs::T...) where {T<:MatElem}
 end
 
 function diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
-    return block_diagonal_matrix(map(x -> change_base_ring(R, x), V))
+    if length(V) == 0
+        return zero_matrix(R, 0, 0)
+    else
+        return block_diagonal_matrix(map(x -> change_base_ring(R, x), V))
+    end
 end
 
 


### PR DESCRIPTION
It appears that #1438 was in fact breaking for https://github.com/thofma/Hecke.jl/blob/75dbabf5ab7c863bba8fc233a85583b674211554/src/QuadForm/Quad/ZGenus.jl#L1600 in Hecke, as it removed the possibility to use `diagonal_matrix(::NCRing, ::Vector{<:MatElem})` with empty list of blocks.
Thus, currently, Hecke master's CI is broken (but there have been no runs yet). I thus would like to have this patch here released shortly.