### PR TITLE
Use LowerCaseOff in @show_name

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -381,8 +381,10 @@ macro show_name(io, O)
         set_name!(o, s)
       end
     end
-    if get(i, :compact, false) &&
-       s !== nothing
+    if get(i, :compact, false) && s !== nothing
+      if AbstractAlgebra.PrettyPrinting._supports_io_custom(i)
+        print(i, LowercaseOff())
+      end
       print(i, s)
       return
     end

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1504,8 +1504,11 @@ mutable struct IOCustom{IO_t <: IO} <: Base.AbstractPipe
 end
 
 _unwrap(io::IOCustom) = io
-
 _unwrap(io::IOContext) = io.io
+
+_supports_io_custom(io::IOCustom) = true
+_supports_io_custom(io::IOContext) = _supports_io_custom(io.io)
+_supports_io_custom(io::Any) = false
 
 indent_string!(io::IO, str::String) = (_unwrap(io).indent_str = str; io)
 


### PR DESCRIPTION
If we print a name, we don't want to change its capitalization.

I don't have a good test case here, but it fixes this bug in Oscar:

    julia> F = cyclotomic_field(3)[1];

    julia> vector_space(Fun, 6)
    Vector space of dimension 6 over f

Resolves #1449