### PR TITLE
Revert GC HACK

### DIFF
--- a/test/generic/LaurentMPoly-test.jl
+++ b/test/generic/LaurentMPoly-test.jl
@@ -23,9 +23,6 @@ end
     test_Ring_interface(L)
 end
 
-# HACK: for GC to workaround bug
-GC.gc()
-
 @testset "Generic.LaurentMPoly.constructors" begin
     L, (x, y) = laurent_polynomial_ring(GF(5), 2, "x", cached = true)
     @test L != laurent_polynomial_ring(GF(5), 2, 'x', cached = false)[1]


### PR DESCRIPTION
This reverts commit 72ce576375506501997bdf825e4efd9415ac7a8d.

For now this will likely just result in the 1.10 CI tests failing. We should re-run the tests here once 1.10 has reverted those changes (I assumes that means 1.10-beta4 or 1.10-rc1 or so). I am mostly opening this PR now so that we won't forget later.