### PR TITLE
Replace many @aliases by @deprecate_binding

### DIFF
--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,45 +1,45 @@
 # for backwards compatibility
-@alias iscompatible is_compatible
-@alias isconstant is_constant
-@alias isdegree is_degree
-@alias isdivisible_by is_divisible_by
-@alias isdomain_type is_domain_type
-@alias isexact_type is_exact_type
-@alias isgen is_gen
-@alias ishessenberg is_hessenberg
-@alias ishnf is_hnf
-@alias ishomogeneous is_homogeneous
-@alias isinvertible is_invertible
-@alias isinvertible_with_inverse is_invertible_with_inverse
-@alias isirreducible is_irreducible
-@alias isisomorphic is_isomorphic
-@alias ismonic is_monic
-@alias ismonomial is_monomial
-@alias ismonomial_recursive is_monomial_recursive
-@alias isnegative is_negative
-@alias ispopov is_popov
-@alias ispower is_power
-@alias ispower_with_root is_power_with_root
-@alias isprobable_prime is_probable_prime
-@alias isreverse is_reverse
-@alias isrimhook is_rimhook
-@alias isrref is_rref
-@alias issnf is_snf
-@alias issquare is_square
-@alias issquare_with_sqrt is_square_with_sqrt
-@alias issquarefree is_squarefree
-@alias issubmodule is_submodule
-@alias isterm is_term
-@alias isterm_recursive is_term_recursive
-@alias isunit is_unit
-@alias isunivariate is_univariate
-@alias isweak_popov is_weak_popov
-@alias iszero_column is_zero_column
-@alias iszero_row is_zero_row
-@alias Localization localization
+Base.@deprecate_binding iscompatible is_compatible
+Base.@deprecate_binding isconstant is_constant
+Base.@deprecate_binding isdegree is_degree
+Base.@deprecate_binding isdivisible_by is_divisible_by
+Base.@deprecate_binding isdomain_type is_domain_type
+Base.@deprecate_binding isexact_type is_exact_type
+Base.@deprecate_binding isgen is_gen
+Base.@deprecate_binding ishessenberg is_hessenberg
+Base.@deprecate_binding ishnf is_hnf
+Base.@deprecate_binding ishomogeneous is_homogeneous
+Base.@deprecate_binding isinvertible is_invertible
+Base.@deprecate_binding isinvertible_with_inverse is_invertible_with_inverse
+Base.@deprecate_binding isirreducible is_irreducible
+Base.@deprecate_binding isisomorphic is_isomorphic
+Base.@deprecate_binding ismonic is_monic
+Base.@deprecate_binding ismonomial is_monomial
+Base.@deprecate_binding ismonomial_recursive is_monomial_recursive
+Base.@deprecate_binding isnegative is_negative
+Base.@deprecate_binding ispopov is_popov
+Base.@deprecate_binding ispower is_power
+Base.@deprecate_binding ispower_with_root is_power_with_root
+Base.@deprecate_binding isprobable_prime is_probable_prime
+Base.@deprecate_binding isreverse is_reverse
+Base.@deprecate_binding isrimhook is_rimhook
+Base.@deprecate_binding isrref is_rref
+Base.@deprecate_binding issnf is_snf
+Base.@deprecate_binding issquare is_square
+Base.@deprecate_binding issquare_with_sqrt is_square_with_sqrt
+Base.@deprecate_binding issquarefree is_squarefree
+Base.@deprecate_binding issubmodule is_submodule
+Base.@deprecate_binding isterm is_term
+Base.@deprecate_binding isterm_recursive is_term_recursive
+Base.@deprecate_binding isunit is_unit
+Base.@deprecate_binding isunivariate is_univariate
+Base.@deprecate_binding isweak_popov is_weak_popov
+Base.@deprecate_binding iszero_column is_zero_column
+Base.@deprecate_binding iszero_row is_zero_row
+Base.@deprecate_binding Localization localization
 
 #
-# Some deprecation aliases follow. They use @alias instead of @deprecate
+# Some deprecation aliases follow. They use Base.@deprecate_binding instead of @deprecate
 # because there are still packages adding methods for them, which would break
 # if we used @deprecate. Once those packages are updated, we can switch to
 # using @deprecate
@@ -47,39 +47,39 @@
 
 # Deprecated in 0.27.*
 
-@alias MatrixSpace matrix_space
+Base.@deprecate_binding MatrixSpace matrix_space
 
-@alias PolynomialRing polynomial_ring
-@alias PowerSeriesRing power_series_ring
-@alias LaurentPolynomialRing laurent_polynomial_ring
-@alias LaurentSeriesRing laurent_series_ring
-@alias LaurentSeriesField laurent_series_field
-@alias FractionField fraction_field
-@alias NumberField number_field
+Base.@deprecate_binding PolynomialRing polynomial_ring
+Base.@deprecate_binding PowerSeriesRing power_series_ring
+Base.@deprecate_binding LaurentPolynomialRing laurent_polynomial_ring
+Base.@deprecate_binding LaurentSeriesRing laurent_series_ring
+Base.@deprecate_binding LaurentSeriesField laurent_series_field
+Base.@deprecate_binding FractionField fraction_field
+Base.@deprecate_binding NumberField number_field
 
-@alias FunctionField function_field
-@alias RationalFunctionField rational_function_field
+Base.@deprecate_binding FunctionField function_field
+Base.@deprecate_binding RationalFunctionField rational_function_field
 
-@alias PolyElem PolyRingElem
-@alias NCPolyElem NCPolyRingElem
-@alias MPolyElem MPolyRingElem
-@alias UnivPolyElem UniversalPolyRingElem
-@alias LaurentPolyElem LaurentPolyRingElem
-@alias LaurentMPolyElem LaurentMPolyRingElem
+Base.@deprecate_binding PolyElem PolyRingElem
+Base.@deprecate_binding NCPolyElem NCPolyRingElem
+Base.@deprecate_binding MPolyElem MPolyRingElem
+Base.@deprecate_binding UnivPolyElem UniversalPolyRingElem
+Base.@deprecate_binding LaurentPolyElem LaurentPolyRingElem
+Base.@deprecate_binding LaurentMPolyElem LaurentMPolyRingElem
 
-@alias UnivPolyRing UniversalPolyRing
+Base.@deprecate_binding UnivPolyRing UniversalPolyRing
 
-@alias AbsSeriesRing AbsPowerSeriesRing
-@alias AbsSeriesElem AbsPowerSeriesRingElem
-@alias RelSeriesRing RelPowerSeriesRing
-@alias RelSeriesElem RelPowerSeriesRingElem
+Base.@deprecate_binding AbsSeriesRing AbsPowerSeriesRing
+Base.@deprecate_binding AbsSeriesElem AbsPowerSeriesRingElem
+Base.@deprecate_binding RelSeriesRing RelPowerSeriesRing
+Base.@deprecate_binding RelSeriesElem RelPowerSeriesRingElem
 
-@alias FreeAssociativeAlgebra free_associative_algebra
+Base.@deprecate_binding FreeAssociativeAlgebra free_associative_algebra
 
-@alias TotalRingOfFractions total_ring_of_fractions
+Base.@deprecate_binding TotalRingOfFractions total_ring_of_fractions
 
-@alias DirectSum direct_sum
+Base.@deprecate_binding DirectSum direct_sum
 
 # Deprecated in 0.34.*
-@alias PuiseuxSeriesField puiseux_series_field
-@alias PuiseuxSeriesRing puiseux_series_ring
+Base.@deprecate_binding PuiseuxSeriesField puiseux_series_field
+Base.@deprecate_binding PuiseuxSeriesRing puiseux_series_ring

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -345,17 +345,17 @@ include("generic/Misc/Localization.jl")
 
 # TODO/FIXME: deprecate aliases, remove in the future
 import ..AbstractAlgebra: @alias
-@alias ResF ResidueFieldElem
-@alias ResField ResidueField
-@alias Res ResidueRingElem
-@alias ResRing ResidueRing
+Base.@deprecate_binding ResF ResidueFieldElem
+Base.@deprecate_binding ResField ResidueField
+Base.@deprecate_binding Res ResidueRingElem
+Base.@deprecate_binding ResRing ResidueRing
 
-@alias Rat RationalFunctionFieldElem
+Base.@deprecate_binding Rat RationalFunctionFieldElem
 
-@alias AbsSeriesRing AbsPowerSeriesRing
-@alias AbsSeriesElem AbsPowerSeriesRingElem
-@alias RelSeriesRing RelPowerSeriesRing
-@alias RelSeriesElem RelPowerSeriesRingElem
+Base.@deprecate_binding AbsSeriesRing AbsPowerSeriesRing
+Base.@deprecate_binding AbsSeriesElem AbsPowerSeriesRingElem
+Base.@deprecate_binding RelSeriesRing RelPowerSeriesRing
+Base.@deprecate_binding RelSeriesElem RelPowerSeriesRingElem
 
 # Deprecated in 0.34.*
 @alias Frac FracFieldElem

--- a/src/generic/Misc/Localization.jl
+++ b/src/generic/Misc/Localization.jl
@@ -1,4 +1,4 @@
-export Localization, LocElem, Loc, prime
+export LocElem, Loc, prime
 
 ###############################################################################
 

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -343,7 +343,7 @@ function _make_parent(g, p::PuiseuxSeriesElem, cached::Bool)
    S = parent(p)
    sym = var(S)
    max_prec = max_precision(S)
-   return AbstractAlgebra.PuiseuxSeriesRing(R, max_prec, sym; cached=cached)[1]
+   return AbstractAlgebra.puiseux_series_ring(R, max_prec, sym; cached=cached)[1]
 end
 
 function map_coefficients(g, p::PuiseuxSeriesElem{<:RingElement};
@@ -366,7 +366,7 @@ end
 ################################################################################
 
 function _change_puiseux_series_ring(R, Rx, cached)
-   P, _ = AbstractAlgebra.PuiseuxSeriesRing(R, max_precision(Rx),
+   P, _ = AbstractAlgebra.puiseux_series_ring(R, max_precision(Rx),
                                                var(Rx), cached = cached)
    return P
 end


### PR DESCRIPTION
This way any access to them trigger a depwarning (if those are enabled,
as they are in our CI).

This is a first step to eventually removing these aliases.
