### PR TITLE
Remove generic is_power and root methods

### DIFF
--- a/src/generic/Misc/Rings.jl
+++ b/src/generic/Misc/Rings.jl
@@ -1,33 +1,3 @@
-###############################################################################
-#
-#  Power testing and root
-#
-###############################################################################
-
-function is_power(a::RingElem, n::Int)
-    if isone(a) || iszero(a)
-        return true, a
-    end
-    if isone(-a) && isodd(n)
-        return true, a
-    end
-    R = parent(a)
-    Rt = PolyRing(R)
-    x = gen(Rt)
-    r = roots(x^n - a)
-    if length(r) == 0
-        return false, a
-    else
-        return true, r[1]
-    end
-end
-  
-function root(a::RingElem, n::Int)
-    fl, b = is_power(a, n)
-    fl || error("element does not have a $n-th root")
-    return b
-end
-
 @doc raw"""
     rising_factorial(x::RingElement, n::Integer)
 


### PR DESCRIPTION
These method are not useful in practice.
