### PR TITLE
Change signature of / and \ methods

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -120,11 +120,11 @@ end
 
 #Base.:/(x::ModuleElem, y::RingElement) = divexact_right(x, y; check=true)
 Base.:/(x::NCRingElem, y::NCRingElement) = divexact_right(x, y; check=true)
-Base.:/(x::Union{Integer, Rational, AbstractFloat}, y::NCRingElem) = divexact_right(x, y; check=true)
+Base.:/(x::NCRingElem, y::Union{Integer, Rational, AbstractFloat}) = divexact_right(x, y; check=true)
 
 #Base.:\(y::RingElement, x::ModuleElem) = divexact_left(x, y; check=true)
 Base.:\(y::NCRingElement, x::NCRingElem) = divexact_left(x, y; check=true)
-Base.:\(y::NCRingElem, x::Union{Integer, Rational, AbstractFloat}) = divexact_left(x, y; check=true)
+Base.:\(y::Union{Integer, Rational, AbstractFloat}, x::NCRingElem) = divexact_left(x, y; check=true)
 
 Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -31,7 +31,8 @@ divexact_left(x::T, y::T; check::Bool=true) where T <: RingElement = divexact(x,
 divexact_right(x::T, y::T; check::Bool=true) where T <: RingElement = divexact(x, y; check=check)
 
 Base.:/(x::ModuleElem, y::RingElement) = divexact(x, y; check=true)
-Base.:/(x::RingElem, y::RingElement) = divexact(x, y; check=true)
+Base.:/(x::RingElem, y::RingElem) = divexact(x, y; check=true)
+Base.:/(x::RingElem, y::Union{Integer, Rational, AbstractFloat}) = divexact(x, y; check=true)
 Base.:/(x::Union{Integer, Rational, AbstractFloat}, y::RingElem) = divexact(x, y; check=true)
 
 Base.inv(x::RingElem) = divexact(one(parent(x)), x)


### PR DESCRIPTION
... to match those of their counterpart functions `divexact_right` and
`divexact_left`: it seems more natural to expect to be able to divide
a ring element *by* floats or rationals than the other way around.
