### PR TITLE
Remove redundant 'convert' invocation

### DIFF
--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -165,7 +165,7 @@ end
 #        Expr(:hcat, a, b)       => a b
 
 
-function expressify(@nospecialize(a); context = nothing)::String
+function expressify(@nospecialize(a); context = nothing)
    return sprint(print, a; context = context)::String
 end
 


### PR DESCRIPTION
There is already a type assertion inside the code, so no
need for this conversion inducing type declaration.
