### PR TITLE
README.md: corrected developers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 AbstractAlgebra is a pure Julia package for computational abstract algebra. It grew out of the Nemo project and provides all of the abstract types and generic implementations that Nemo relies on.
 
-It is currently developed by William Hart, Tommy Hofmann, Fredrik Johansson,
-Claus Fieker with contributions from others.
+It was originally developed by William Hart, Tommy Hofmann, Fredrik Johansson and
+Claus Fieker with contributions from others. Current maintainers are Claus Fieker,
+Tommy Hofmann and Max Horn.
 
 AbstractAlgebra currently provides:
 


### PR DESCRIPTION
The list of people who supposedly develop AbstractAlgebra "currently" was not quite accurate. I tried to adjust this a bit.

Feedback welcome! In particular I really don't want to misrepresent anything or diminish someones contributions or whatever.

The justification for the order of the "original developers" is also unclear to me, nor whether it should be considered complete; I simply did not touch it.

See also https://github.com/Nemocas/Nemo.jl/pull/1589