### PR TITLE
Restrict VarNames union type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.34.0"
+version = "0.34.1"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1390,11 +1390,8 @@ Return a tuple `S, generators...` with `generators[i]` corresponding to `varname
 # Examples
 
 ```jldoctest; setup = :(using AbstractAlgebra)
-julia> S, a, b, c = polynomial_ring(ZZ, :a, :b, :c)
-(Multivariate polynomial ring in 3 variables over integers, a, b, c)
-
-julia> polynomial_ring(ZZ, :a, :b, :c) == polynomial_ring(ZZ, (:a, :b, :c))
-true
+julia> S, (a, b, c) = polynomial_ring(ZZ, [:a, :b, :c])
+(Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[a, b, c])
 
 julia> S, x, y = polynomial_ring(ZZ, :x => (1:2, 1:2), :y => 1:3);
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -114,15 +114,13 @@
    @test z isa Generic.MPoly{Generic.Poly{BigInt}}
 
    ZZxyz_ = polynomial_ring(ZZ, 'x':'z')
-   ZZxyz2, xyz2... = polynomial_ring(ZZ, (:x, 'y', GenericString("z")))
-   ZZxyz3, xyz3... = polynomial_ring(ZZ, :x, 'y', GenericString("z"))
+   ZZxyz2, xyz2 = polynomial_ring(ZZ, VarName[:x, 'y', GenericString("z")])
    ZZxyz4_ = polynomial_ring(ZZ, Union{String,Char,Symbol}["x", 'y', :z])
    ZZxyz5_ = ZZ["x", 'y', :z]
-   ZZxyz6 = @polynomial_ring(ZZ, :x, :y, :z)
+   ZZxyz6 = @polynomial_ring(ZZ, [:x, :y, :z])
 
    @test ZZxyz_[1] isa Generic.MPolyRing
-   @test ZZxyz_ == (ZZxyz2, collect(xyz2))
-   @test ZZxyz_ == (ZZxyz3, collect(xyz3))
+   @test ZZxyz_ == (ZZxyz2, xyz2)
    @test ZZxyz_ == ZZxyz4_
    @test ZZxyz_ == ZZxyz5_
    @test ZZxyz_ == (ZZxyz6, [x, y, z])


### PR DESCRIPTION
We don't `VarName` as part of `VarNAmes`. This removes a few call variations
of `polynomial_ring` etc., that we did not actually agree to put in (they were
likely a leftover of an earlier iteration of the recent varname changes).

This allows us to remove some `polynomial_ring` methods that were added purely
for disambiguation, but which caused a type instability in `polynomial_ring`
in Julia 1.6 (but not in 1.9).
