### PR TITLE
Revert "Revert "Streamline `is_power` for julia and AA types...""

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -173,8 +173,7 @@ iroot(a::BigInt)
 ```
 
 ```@docs
-is_power(a::BigInt)
-is_power_with_root(a::BigInt)
+is_power(a::T, n::Int) where T <: Integer
 ```
 
 ```@docs

--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -144,7 +144,7 @@ The functionality below supplements that provided by Julia itself for its
 ### Square and n-th root
 
 The functions `sqrt`, `is_square`, `is_square_with_sqrt` are all provided, as are
-`root`, `is_power` and `is_power_with_root`.
+`root` and `is_power`.
 
 **Examples**
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -676,6 +676,7 @@ import .Generic: invmod
 import .Generic: is_compatible
 import .Generic: is_divisible_by
 import .Generic: is_homogeneous
+import .Generic: is_power
 import .Generic: is_rimhook
 import .Generic: is_submodule
 import .Generic: is_unit

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -19,7 +19,6 @@ Base.@deprecate_binding ismonomial_recursive is_monomial_recursive
 Base.@deprecate_binding isnegative is_negative
 Base.@deprecate_binding ispopov is_popov
 Base.@deprecate_binding ispower is_power
-Base.@deprecate_binding ispower_with_root is_power_with_root
 Base.@deprecate_binding isprobable_prime is_probable_prime
 Base.@deprecate_binding isreverse is_reverse
 Base.@deprecate_binding isrimhook is_rimhook

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export iroot, is_power, is_power_with_root, root, is_square_with_sqrt,
+export iroot, is_power, root, is_square_with_sqrt,
        is_probable_prime
 
 ###############################################################################
@@ -394,12 +394,12 @@ function ispower_moduli(a::Integer, n::Int)
 end
 
 @doc raw"""
-    is_power_with_root(a::T, n::Int) where T <: Integer
+    is_power(a::T, n::Int) where T <: Integer
 
 Return `true, q` if $a$ is a perfect $n$-th power with $a = q^n$. Otherwise
 return `false, 0`. We require $n > 0$.
 """
-function is_power_with_root(a::T, n::Int) where T <: Integer
+function is_power(a::T, n::Int) where T <: Integer
    n <= 0 && throw(DomainError(n, "exponent n must be positive"))
    if n == 1 || a == 0 || a == 1
       return (true, a)
@@ -416,32 +416,6 @@ function is_power_with_root(a::T, n::Int) where T <: Integer
    ccall((:__gmpz_rootrem, :libgmp), Nothing,
                      (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}, Int), q, r, a, n)
    return iszero(r) ? (true, T(q)) : (false, zero(T))
-end
-
-@doc raw"""
-    is_power(a::T, n::Int) where T <: Integer
-
-Return `true` if $a$ is a perfect $n$-th power, i.e. if there is a $b$
-such that $a = b^n$. We require $n > 0$.
-"""
-function is_power(a::T, n::Int) where T <: Integer
-   n <= 0 && throw(DomainError(n, "n is not positive"))
-   if n == 1 || a == 0 || a == 1
-      return true
-   elseif a == -1
-      return isodd(n) ? true : false
-   elseif mod(n, 2) == 0 && a < 0
-      return false
-   elseif !ispower_moduli(a, n)
-      return false
-   end
-   
-   q = BigInt()
-   r = BigInt()
-   ccall((:__gmpz_rootrem, :libgmp), Nothing,
-                     (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}, Int), q, r, BigInt(a), n)
-
-   return r == 0
 end
 
 function iroot(a::BigInt, n::Int)

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -165,15 +165,11 @@ function root(a::Rational{T}, n::Int; check::Bool=true) where T <: Integer
 end
 
 function is_power(a::Rational{T}, n::Int) where T <: Integer
-   return is_power(numerator(a), n) && is_power(denominator(a), n)
-end
-
-function is_power_with_root(a::Rational{T}, n::Int) where T <: Integer
-   f1, r1 = is_power_with_root(numerator(a), n)
+   f1, r1 = is_power(numerator(a), n)
    if !f1
       return false, zero(T)
    end
-   f2, r2 = is_power_with_root(denominator(a), n)
+   f2, r2 = is_power(denominator(a), n)
    if !f2
       return false, zero(T)
    end

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -263,16 +263,14 @@ end
          if T == BigInt || ndigits(p; base=2) < ndigits(typemax(T); base=2)
             p = T(p)
 
-            @test is_power(p, n)
-
-            flag, q = is_power_with_root(p, n)
+            flag, q = is_power(p, n)
 
             @test flag && q == a
          end
       end
 
       @test_throws DomainError is_power(T(5), -1)
-      @test_throws DomainError is_power_with_root(T(5), 0)
+      @test_throws DomainError is_power(T(5), 0)
    end
 end
 

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -175,16 +175,14 @@ end
             p = T(p)
             q = T(q)
 
-            @test is_power(p//q, n)
-
-            flag, r = is_power_with_root(p//q, n)
+            flag, r = is_power(p//q, n)
 
             @test flag && r == a//b
          end
       end
 
       @test_throws DomainError is_power(Rational{T}(5//3), -1)
-      @test_throws DomainError is_power_with_root(Rational{T}(5//3), 0)
+      @test_throws DomainError is_power(Rational{T}(5//3), 0)
    end
 end
 


### PR DESCRIPTION
Reverts Nemocas/AbstractAlgebra.jl#1535.

Second shot of https://github.com/Nemocas/AbstractAlgebra.jl/pull/1529, now marked as a breaking change. 