### PR TITLE
Adapt import_exclude list

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -19,7 +19,7 @@ import GroupsCore: gens, ngens, order, mul!, istrivial
 
 # A list of all symbols external packages should not import from AbstractAlgebra
 const import_exclude = [:import_exclude, :QQ, :ZZ,
-                  :RealField, :number_field,
+                  :RealField, :number_field, :NumberField, :GF,
                   :AbstractAlgebra,
                   :inv, :log, :exp, :sqrt, :div, :divrem,
                   :numerator, :denominator,


### PR DESCRIPTION
Nemo skips them separately (see https://github.com/Nemocas/Nemo.jl/blob/37b49d9dc0df0d6d8dfa9ede3b4d12b64d92fa56/src/Nemo.jl#L60-L61). This change makes it possible to refactor that away in Nemo.