### PR TITLE
Don't default characteristic of fields to 0

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -38,8 +38,6 @@ function gcdx(x::T, y::T) where {T <: FieldElem}
    end
 end
 
-characteristic(R::Field) = 0
-
 function factor(x::FieldElem)
   is_zero(x) && throw(ArgumentError("Element must be non-zero"))
   return Fac(x, Dict{typeof(x), Int}())

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -60,7 +60,7 @@ function denominator(a::Rational, canonicalise::Bool=true)
    return Base.denominator(a) # all other types ignore canonicalise
 end
 
-characteristic(a::Rational{T}) where T <: Integer = 0
+characteristic(a::Rationals{T}) where T <: Integer = 0
 
 ###############################################################################
 #


### PR DESCRIPTION
I'd rather have an error than to get a wrong characteristic by accident because someone forgot to implement a method.

This might be breaking if there are ring implementations that relied on it.