### PR TITLE
Unbreak Oscar docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.34.6"
+version = "0.34.7"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/docs/src/ring.md
+++ b/docs/src/ring.md
@@ -204,9 +204,15 @@ following optional functions may be implemented.
 ```@docs
 is_irreducible(a::T) where T <: RingElement
 is_squarefree(a::T) where T <: RingElement
+```
+
+```julia
 factor(a::T) where T <: RingElement
 factor_squarefree(a::T) where T <: RingElement
 ```
+
+Return a factorization into irreducible or squarefree elements, respectively.
+The return is an object of type `Fac{T}`.
 
 ```@docs
 Fac


### PR DESCRIPTION
Oscar includes the AA manual into its own manual. Unfortunatel the
'factor' function in Oscar is different from that in AA (it gets replace
by Hecke), and the alternative 'factor' has no method matching the
signature here.

To unbreak building of the Oscar docs, revert the 'factor' documentation
to a handcrafted block instead of using @docs.
