### PR TITLE
fix: force specialization for map arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.35.1"
+version = "0.35.2"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/src/AbsSeries.jl
+++ b/src/AbsSeries.jl
@@ -1012,7 +1012,7 @@ end
 #
 ################################################################################
 
-function _make_parent(g, p::AbsPowerSeriesRingElem, cached::Bool)
+function _make_parent(g::T, p::AbsPowerSeriesRingElem, cached::Bool) where T
    R = parent(g(zero(base_ring(p))))
    S = parent(p)
    sym = var(S)
@@ -1029,13 +1029,13 @@ If the optional `parent` keyword is provided, the polynomial will be an
 element of `parent`. The caching of the parent object can be controlled
 via the `cached` keyword argument.
 """
-function map_coefficients(g, p::AbsPowerSeriesRingElem{<:RingElement};
+function map_coefficients(g::T, p::AbsPowerSeriesRingElem{<:RingElement};
                     cached::Bool = true,
-                    parent::Ring = _make_parent(g, p, cached))
+		    parent::Ring = _make_parent(g, p, cached)) where {T}
    return _map(g, p, parent)
 end
 
-function _map(g, p::AbsPowerSeriesRingElem, Rx)
+function _map(g::T, p::AbsPowerSeriesRingElem, Rx) where {T}
    R = base_ring(Rx)
    new_coefficients = elem_type(R)[let c = coeff(p, i)
                                      iszero(c) ? zero(R) : R(g(c))

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1259,11 +1259,11 @@ If the optional `parent` keyword is provided, the polynomial will be an
 element of `parent`. The caching of the parent object can be controlled
 via the `cached` keyword argument.
 """
-function map_coefficients(f, p::MPolyRingElem; cached = true, parent::MPolyRing = _change_mpoly_ring(parent(f(zero(base_ring(p)))), parent(p), cached))
+function map_coefficients(f::T, p::MPolyRingElem; cached = true, parent::MPolyRing = _change_mpoly_ring(parent(f(zero(base_ring(p)))), parent(p), cached)) where {T}
    return _map(f, p, parent)
 end
 
-function _map(g, p::MPolyRingElem, Rx)
+function _map(g::T, p::MPolyRingElem, Rx) where {T}
    cvzip = zip(coefficients(p), exponent_vectors(p))
    M = Generic.MPolyBuildCtx(Rx)
    for (c, v) in cvzip

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6831,7 +6831,7 @@ end
 
 Like `map_entries`, but stores the result in `dst` rather than a new matrix.
 """
-function map_entries!(f, dst::MatrixElem{T}, src::MatrixElem{U}) where {T <: NCRingElement, U <: NCRingElement}
+function map_entries!(f::S, dst::MatrixElem{T}, src::MatrixElem{U}) where {S, T <: NCRingElement, U <: NCRingElement}
    for i = 1:nrows(src), j = 1:ncols(src)
       dst[i, j] = f(src[i, j])
    end
@@ -6844,14 +6844,14 @@ end
 Like `map`, but stores the result in `dst` rather than a new matrix.
 This is equivalent to `map_entries!(f, dst, src)`.
 """
-Base.map!(f, dst::MatrixElem{T}, src::MatrixElem{U}) where {T <: NCRingElement, U <: NCRingElement} = map_entries!(f, dst, src)
+Base.map!(f::S, dst::MatrixElem{T}, src::MatrixElem{U}) where {S, T <: NCRingElement, U <: NCRingElement} = map_entries!(f, dst, src)
 
 @doc raw"""
     map_entries(f, a::MatrixElem{T}) where T <: NCRingElement
 
 Transform matrix `a` by applying `f` on each element.
 """
-function map_entries(f, a::MatrixElem{T}) where T <: NCRingElement
+function map_entries(f::S, a::MatrixElem{T}) where {S, T <: NCRingElement}
    isempty(a) && return _change_base_ring(parent(f(zero(base_ring(a)))), a)
    b11 = f(a[1, 1])
    b = _change_base_ring(parent(b11), a)
@@ -6869,7 +6869,7 @@ end
 Transform matrix `a` by applying `f` on each element.
 This is equivalent to `map_entries(f, a)`.
 """
-Base.map(f, a::MatrixElem{T}) where T <: NCRingElement = map_entries(f, a)
+Base.map(f::S, a::MatrixElem{T}) where {S, T <: NCRingElement} = map_entries(f, a)
 
 ###############################################################################
 #

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -643,17 +643,17 @@ end
 #
 ################################################################################
 
-_make_parent(g, p::NCPolyRingElem, cached::Bool) =
+_make_parent(g::T, p::NCPolyRingElem, cached::Bool) where {T} =
    _change_poly_ring(parent(g(zero(base_ring(p)))),
                      parent(p), cached)
 
-function map_coefficients(g, p::NCPolyRingElem{<:NCRingElement};
+function map_coefficients(g::T, p::NCPolyRingElem{<:NCRingElement};
                     cached::Bool = true,
-                    parent::NCPolyRing = _make_parent(g, p, cached))
+		    parent::NCPolyRing = _make_parent(g, p, cached)) where {T}
    return _map(g, p, parent)
 end
 
-function _map(g, p::NCPolyRingElem, Rx)
+function _map(g::T, p::NCPolyRingElem, Rx) where {T}
    R = base_ring(Rx)
    new_coefficients = elem_type(R)[let c = coeff(p, i)
                                      iszero(c) ? zero(R) : R(g(c))

--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -262,7 +262,7 @@ end
 #       lift(FracField, Series)
 #       (to be in line with lift(ZZ, padic) and lift(QQ, padic)
 #TODO: some of this would only work for Abs, not Rel, however, this should be fine here
-function map_coefficients(f, a::RelPowerSeriesRingElem; parent::SeriesRing)
+function map_coefficients(f::T, a::RelPowerSeriesRingElem; parent::SeriesRing) where T
     c = typeof(f(coeff(a, 0)))[]
     for i = 0:pol_length(a)-1
         push!(c, f(polcoeff(a, i)))

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3154,7 +3154,7 @@ end
 #
 ################################################################################
 
-_make_parent(g, p::PolyRingElem, cached::Bool) =
+_make_parent(g::T, p::PolyRingElem, cached::Bool) where T =
    _change_poly_ring(parent(g(zero(base_ring(p)))),
                      parent(p), cached)
 
@@ -3167,13 +3167,13 @@ If the optional `parent` keyword is provided, the polynomial will be an
 element of `parent`. The caching of the parent object can be controlled
 via the `cached` keyword argument.
 """
-function map_coefficients(g, p::PolyRingElem{<:RingElement};
+function map_coefficients(g::T, p::PolyRingElem{<:RingElement};
                     cached::Bool = true,
-                    parent::PolyRing = _make_parent(g, p, cached))
+                    parent::PolyRing = _make_parent(g, p, cached)) where T
    return _map(g, p, parent)
 end
 
-function _map(g, p::PolyRingElem, Rx)
+function _map(g::T, p::PolyRingElem, Rx) where T
    R = base_ring(Rx)
    new_coefficients = elem_type(R)[let c = coeff(p, i)
                                      iszero(c) ? zero(R) : R(g(c))

--- a/src/generic/FreeAssAlgebra.jl
+++ b/src/generic/FreeAssAlgebra.jl
@@ -687,7 +687,7 @@ function change_base_ring(
 end
 
 function map_coefficients(
-    f,
+    f::S,
     a::FreeAssAlgElem{T};
     cached::Bool = true,
     parent::AbstractAlgebra.FreeAssAlgebra = _change_freeassalg_ring(
@@ -695,11 +695,11 @@ function map_coefficients(
         parent(a),
         cached,
     ),
-) where T <: RingElement
+) where {S, T <: RingElement}
     return _map(f, a, parent)
 end
 
-function _map(g, a::FreeAssAlgElem{T}, Rx) where T <: RingElement
+function _map(g::S, a::FreeAssAlgElem{T}, Rx) where {S, T <: RingElement}
     cvzip = zip(coefficients(a), exponent_words(a))
     M = MPolyBuildCtx(Rx)
     for (c, v) in cvzip

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -607,7 +607,7 @@ end
 #
 ################################################################################
 
-function AbstractAlgebra._map(g, p::LaurentMPolyWrap, R::LaurentMPolyWrapRing)
+function AbstractAlgebra._map(g::T, p::LaurentMPolyWrap, R::LaurentMPolyWrapRing) where T
    return LaurentMPolyWrap(R, AbstractAlgebra._map(g, p.mpoly, R.mpolyring),
                               p.mindegs)
 end
@@ -621,10 +621,10 @@ function change_base_ring(
    return AbstractAlgebra._map(R, p, parent)
 end
 
-function map_coefficients(g, p::LaurentMPolyWrap; cached::Bool = true,
+function map_coefficients(g::T, p::LaurentMPolyWrap; cached::Bool = true,
                        parent::LaurentMPolyWrapRing = LaurentMPolyWrapRing(
                         AbstractAlgebra._change_mpoly_ring(AbstractAlgebra.parent(g(zero(base_ring(p.mpoly)))), AbstractAlgebra.parent(p.mpoly), cached),
-                            cached))
+                            cached)) where T
    return AbstractAlgebra._map(g, p, parent)
 end
 

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -473,7 +473,7 @@ end
 #
 ################################################################################
 
-function AbstractAlgebra._map(g, p::LaurentPolyWrap, Rx::LaurentPolyWrapRing)
+function AbstractAlgebra._map(g::T, p::LaurentPolyWrap, Rx::LaurentPolyWrapRing) where T
    return LaurentPolyWrap(Rx,
                         AbstractAlgebra._map(g, p.poly, Rx.polyring), p.mindeg)
 end
@@ -485,9 +485,9 @@ function change_base_ring(R::Ring, p::LaurentPolyWrap; cached::Bool = true,
    return AbstractAlgebra._map(R, p, parent)
 end
 
-function map_coefficients(g, p::LaurentPolyWrap; cached::Bool = true,
+function map_coefficients(g::T, p::LaurentPolyWrap; cached::Bool = true,
                        parent::LaurentPolyWrapRing = LaurentPolyWrapRing(
-                      AbstractAlgebra._make_parent(g, p.poly, cached), cached))
+                      AbstractAlgebra._make_parent(g, p.poly, cached), cached)) where T
    return AbstractAlgebra._map(g, p, parent)
 end
 

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -542,7 +542,7 @@ end
 #
 ###############################################################################
 
-function _make_parent(g, p::LaurentSeriesElem, cached::Bool)
+function _make_parent(g::T, p::LaurentSeriesElem, cached::Bool) where T
    R = parent(g(zero(base_ring(p))))
    S = parent(p)
    sym = var(S)
@@ -550,13 +550,13 @@ function _make_parent(g, p::LaurentSeriesElem, cached::Bool)
    return AbstractAlgebra.laurent_series_ring(R, max_prec, sym; cached=cached)[1]
 end
 
-function map_coefficients(g, p::LaurentSeriesElem{<:RingElement};
+function map_coefficients(g::T, p::LaurentSeriesElem{<:RingElement};
                     cached::Bool = true,
-                    parent::Ring = _make_parent(g, p, cached))
+		    parent::Ring = _make_parent(g, p, cached)) where {T}
    return _map(g, p, parent)
 end
 
-function _map(g, p::LaurentSeriesElem, Rx)
+function _map(g::T, p::LaurentSeriesElem, Rx) where T
    R = base_ring(Rx)
    new_coefficients = elem_type(R)[let c = polcoeff(p, i)
                                      iszero(c) ? zero(R) : R(g(c))

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -338,7 +338,7 @@ end
 #
 ###############################################################################
 
-function _make_parent(g, p::PuiseuxSeriesElem, cached::Bool)
+function _make_parent(g::T, p::PuiseuxSeriesElem, cached::Bool) where T
    R = parent(g(zero(base_ring(p))))
    S = parent(p)
    sym = var(S)
@@ -346,13 +346,13 @@ function _make_parent(g, p::PuiseuxSeriesElem, cached::Bool)
    return AbstractAlgebra.puiseux_series_ring(R, max_prec, sym; cached=cached)[1]
 end
 
-function map_coefficients(g, p::PuiseuxSeriesElem{<:RingElement};
+function map_coefficients(g::T, p::PuiseuxSeriesElem{<:RingElement};
                     cached::Bool = true,
-                    parent::Ring = _make_parent(g, p, cached))
+                    parent::Ring = _make_parent(g, p, cached)) where T
    return _map(g, p, parent)
 end
 
-function _map(g, p::PuiseuxSeriesElem, Rx)
+function _map(g::T, p::PuiseuxSeriesElem, Rx) where T
    R = base_ring(Rx)
    res = Rx(map_coefficients(g, p.data), scale(p))
    res = rescale!(res)

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -926,11 +926,11 @@ end
 #
 ################################################################################
 
-function map_coefficients(f, p::UnivPoly; cached::Bool=true, parent::UniversalPolyRing = _change_univ_poly_ring(parent(f(zero(base_ring(p)))), parent(p), cached))
+function map_coefficients(f::T, p::UnivPoly; cached::Bool=true, parent::UniversalPolyRing = _change_univ_poly_ring(parent(f(zero(base_ring(p)))), parent(p), cached)) where T
    return _map(f, p, parent)
 end
 
-function _map(g, p::UnivPoly, Rx)
+function _map(g::T, p::UnivPoly, Rx) where T
    cvzip = zip(coefficients(p), exponent_vectors(p))
    M = MPolyBuildCtx(Rx)
    for (c, v) in cvzip


### PR DESCRIPTION
Julia has a heuristic, to pass through arguments of type `Type` or
`Function`, which results in degraded performance and inference problems.

Avoid this by introducing auxilliary type parameter.
