### PR TITLE
feat: Rename Generic.[ResidueRing|ResidueField]

### DIFF
--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -15,13 +15,13 @@ AbstractAlgebra.jl abstract type hierarchy.
 
 ## Generic residue types
 
-AbstractAlgebra.jl implements generic residue rings with type `Generic.ResidueRingElem{T}`
-or in the case of residue rings that are known to be fields, `Generic.ResidueFieldElem{T}`,
+AbstractAlgebra.jl implements generic residue rings of Euclidean rings with type `Generic.EuclideanRingResidueRingelem{T}`
+or in the case of residue rings that are known to be fields, `Generic.EuclideanRingResidueField{T}`,
 where `T` is the type of elements of the base ring. See the file
 `src/generic/GenericTypes.jl` for details.
 
-Parent objects of generic residue ring elements have type `Generic.ResidueRing{T}`
-and those of residue fields have type `GenericResField{T}`.
+Parent objects of generic residue ring elements have type `Generic.EuclideanRingResidueRing{T}`
+and those of residue fields have type `Generic.EuclideanRingResidueField{T}`.
 
 The defining modulus of the residue ring is stored in the parent object.
 
@@ -32,17 +32,6 @@ or `ResFieldElem{T}` in the case of residue fields, and the
 residue ring types belong to the abstract type `ResidueRing{T}` or `ResidueField{T}`
 respectively. This enables one to write generic functions that can accept any
 AbstractAlgebra residue type.
-
-
-!!! note
-
-    Note that both the generic residue ring type `Generic.ResidueRing{T}` and the
-    abstract type it belongs to, `ResidueRing{T}` are both called `ResidueRing`, and
-    similarly for the residue field types. In each case, the  former is a
-    (parameterised) concrete type for a residue ring over a given base ring whose
-    elements have type `T`. The latter is an abstract type representing all
-    residue ring types in AbstractAlgebra.jl, whether generic or very specialised
-    (e.g. supplied by a C library).
 
 ## Residue ring constructors
 

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -345,10 +345,10 @@ include("generic/Misc/Localization.jl")
 
 # TODO/FIXME: deprecate aliases, remove in the future
 import ..AbstractAlgebra: @alias
-Base.@deprecate_binding ResF ResidueFieldElem
-Base.@deprecate_binding ResField ResidueField
-Base.@deprecate_binding Res ResidueRingElem
-Base.@deprecate_binding ResRing ResidueRing
+Base.@deprecate_binding ResF EuclideanRingResidueFieldElem
+Base.@deprecate_binding ResField EuclideanRingResidueField
+Base.@deprecate_binding Res EuclideanRingResidueRingElem
+Base.@deprecate_binding ResRing EuclideanRingResidueRing
 
 Base.@deprecate_binding Rat RationalFunctionFieldElem
 
@@ -360,5 +360,11 @@ Base.@deprecate_binding RelSeriesElem RelPowerSeriesRingElem
 # Deprecated in 0.34.*
 @alias Frac FracFieldElem
 @alias FactoredFrac FactoredFracFieldElem
+
+# Deprecated in 0.35.*
+Base.@deprecate_binding ResidueField EuclideanRingResidueField
+Base.@deprecate_binding ResidueFieldElem EuclideanRingResidueFieldElem
+Base.@deprecate_binding ResidueRing EuclideanRingResidueRing
+Base.@deprecate_binding ResidueRingElem EuclideanRingResidueRingElem
 
 end # generic

--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -311,23 +311,23 @@ function Base.lcm(a::T, b::T) where {T<:SeriesElem}
     return gen(parent(a))^max(valuation(a), valuation(b))
 end
 
-function gen(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:PolyRingElem}
+function gen(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return R(gen(base_ring(R)))
 end
 
-function characteristic(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:PolyRingElem}
+function characteristic(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return characteristic(base_ring(base_ring(R)))
 end
 
-function size(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:ResElem}
+function size(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:ResElem}
     return size(base_ring(base_ring(R)))^degree(modulus(R))
 end
 
-function size(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:PolyRingElem}
+function size(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return size(base_ring(base_ring(R)))^degree(R.modulus)
 end
 
-function rand(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:PolyRingElem}
+function rand(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     r = rand(base_ring(base_ring(R)))
     g = gen(R)
     for i = 1:degree(R.modulus)
@@ -336,7 +336,7 @@ function rand(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T
     return r
 end
 
-function gens(R::Union{Generic.ResidueRing{T},Generic.ResidueField{T}}) where {T<:PolyRingElem} ## probably needs more cases
+function gens(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem} ## probably needs more cases
     ## as the other residue functions
     g = gen(R)
     r = Vector{typeof(g)}()

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -454,7 +454,7 @@ function residue_ring(R::Ring, a::RingElement; cached::Bool = true)
    iszero(a) && throw(DomainError(a, "Modulus must be nonzero"))
    T = elem_type(R)
 
-   return Generic.ResidueRing{T}(R(a), cached)
+   return Generic.EuclideanRingResidueRing{T}(R(a), cached)
 end
 
 function residue_ring(R::PolyRing, a::RingElement; cached::Bool = true)
@@ -462,7 +462,7 @@ function residue_ring(R::PolyRing, a::RingElement; cached::Bool = true)
    !is_unit(leading_coefficient(a)) && throw(DomainError(a, "Non-invertible leading coefficient"))
    T = elem_type(R)
 
-   return Generic.ResidueRing{T}(R(a), cached)
+   return Generic.EuclideanRingResidueRing{T}(R(a), cached)
 end
 
 @doc raw"""

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -498,7 +498,7 @@ function residue_field(R::Ring, a::RingElement; cached::Bool = true)
    iszero(a) && throw(DivideError())
    T = elem_type(R)
 
-   return Generic.ResidueField{T}(R(a), cached)
+   return Generic.EuclideanRingResidueField{T}(R(a), cached)
 end
 
 @doc raw"""

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -576,15 +576,15 @@ end
 
 ###############################################################################
 #
-#   ResidueRing / ResidueRingElem
+#   EuclideanRingResidueRing / EuclideanRingResidueRingElem
 #
 ###############################################################################
 
-mutable struct ResidueRing{T <: RingElement} <: AbstractAlgebra.ResidueRing{T}
+mutable struct EuclideanRingResidueRing{T <: RingElement} <: AbstractAlgebra.ResidueRing{T}
    base_ring::Ring
    modulus::T
 
-   function ResidueRing{T}(modulus::T, cached::Bool = true) where T <: RingElement
+   function EuclideanRingResidueRing{T}(modulus::T, cached::Bool = true) where T <: RingElement
       c = canonical_unit(modulus)
       if !isone(c)
         modulus = divexact(modulus, c)
@@ -593,30 +593,30 @@ mutable struct ResidueRing{T <: RingElement} <: AbstractAlgebra.ResidueRing{T}
 
       return get_cached!(ModulusDict, (R, modulus), cached) do
          new{T}(R, modulus)
-      end::ResidueRing{T}
+      end::EuclideanRingResidueRing{T}
    end
 end
 
 const ModulusDict = CacheDictType{Tuple{Ring, RingElement}, Ring}()
 
-mutable struct ResidueRingElem{T <: RingElement} <: AbstractAlgebra.ResElem{T}
+mutable struct EuclideanRingResidueRingElem{T <: RingElement} <: AbstractAlgebra.ResElem{T}
    data::T
-   parent::ResidueRing{T}
+   parent::EuclideanRingResidueRing{T}
 
-   ResidueRingElem{T}(a::T) where T <: RingElement = new{T}(a)
+   EuclideanRingResidueRingElem{T}(a::T) where T <: RingElement = new{T}(a)
 end
 
 ###############################################################################
 #
-#   ResidueField / ResFieldElem
+#   EuclideanRingResidueField / ResFieldElem
 #
 ###############################################################################
 
-mutable struct ResidueField{T <: RingElement} <: AbstractAlgebra.ResidueField{T}
+mutable struct EuclideanRingResidueField{T <: RingElement} <: AbstractAlgebra.ResidueField{T}
    base_ring::Ring
    modulus::T
 
-   function ResidueField{T}(modulus::T, cached::Bool = true) where T <: RingElement
+   function EuclideanRingResidueField{T}(modulus::T, cached::Bool = true) where T <: RingElement
       c = canonical_unit(modulus)
       if !isone(c)
         modulus = divexact(modulus, c)
@@ -624,17 +624,17 @@ mutable struct ResidueField{T <: RingElement} <: AbstractAlgebra.ResidueField{T}
       R = parent(modulus)
       return get_cached!(ModulusFieldDict, (R, modulus), cached) do
          new{T}(R, modulus)
-      end::ResidueField{T}
+      end::EuclideanRingResidueField{T}
    end
 end
 
 const ModulusFieldDict = CacheDictType{Tuple{Ring, RingElement}, Field}()
 
-mutable struct ResidueFieldElem{T <: RingElement} <: AbstractAlgebra.ResFieldElem{T}
+mutable struct EuclideanRingResidueFieldElem{T <: RingElement} <: AbstractAlgebra.ResFieldElem{T}
    data::T
-   parent::ResidueField{T}
+   parent::EuclideanRingResidueField{T}
 
-   ResidueFieldElem{T}(a::T) where T <: RingElement = new{T}(a)
+   EuclideanRingResidueFieldElem{T}(a::T) where T <: RingElement = new{T}(a)
 end
 
 ###############################################################################

--- a/src/generic/NumberField.jl
+++ b/src/generic/NumberField.jl
@@ -12,7 +12,7 @@ export number_field
 #
 ###############################################################################
 
-function  gen(R::ResidueField{PolyRingElem{Rational{BigInt}}})
+function gen(R::EuclideanRingResidueField{PolyRingElem{Rational{BigInt}}})
    return R(gen(base_ring(R)))
 end
 
@@ -22,7 +22,7 @@ end
 #
 ###############################################################################
 
-function RandomExtensions.make(S::ResidueField{Generic.Poly{Rational{BigInt}}}, vs...)
+function RandomExtensions.make(S::EuclideanRingResidueField{Generic.Poly{Rational{BigInt}}}, vs...)
    R = base_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1])

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -10,9 +10,9 @@
 #
 ###############################################################################
 
-parent_type(::Type{ResidueRingElem{T}}) where T <: RingElement = ResidueRing{T}
+parent_type(::Type{EuclideanRingResidueRingElem{T}}) where T <: RingElement = EuclideanRingResidueRing{T}
 
-elem_type(::Type{ResidueRing{T}}) where {T <: RingElement} = ResidueRingElem{T}
+elem_type(::Type{EuclideanRingResidueRing{T}}) where {T <: RingElement} = EuclideanRingResidueRingElem{T}
 
 ###############################################################################
 #
@@ -20,10 +20,10 @@ elem_type(::Type{ResidueRing{T}}) where {T <: RingElement} = ResidueRingElem{T}
 #
 ###############################################################################
 
-promote_rule(::Type{ResidueRingElem{T}}, ::Type{ResidueRingElem{T}}) where T <: RingElement = ResidueRingElem{T}
+promote_rule(::Type{EuclideanRingResidueRingElem{T}}, ::Type{EuclideanRingResidueRingElem{T}}) where T <: RingElement = EuclideanRingResidueRingElem{T}
 
-function promote_rule(::Type{ResidueRingElem{T}}, ::Type{U}) where {T <: RingElement, U <: RingElement}
-   promote_rule(T, U) == T ? ResidueRingElem{T} : Union{}
+function promote_rule(::Type{EuclideanRingResidueRingElem{T}}, ::Type{U}) where {T <: RingElement, U <: RingElement}
+   promote_rule(T, U) == T ? EuclideanRingResidueRingElem{T} : Union{}
 end
 
 ###############################################################################
@@ -32,30 +32,30 @@ end
 #
 ###############################################################################
 
-function (a::ResidueRing{T})(b::RingElement) where {T <: RingElement}
+function (a::EuclideanRingResidueRing{T})(b::RingElement) where {T <: RingElement}
    return a(base_ring(a)(b))
 end
 
-function (a::ResidueRing{T})() where {T <: RingElement}
-   z = ResidueRingElem{T}(zero(base_ring(a)))
+function (a::EuclideanRingResidueRing{T})() where {T <: RingElement}
+   z = EuclideanRingResidueRingElem{T}(zero(base_ring(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueRing{T})(b::Integer) where {T <: RingElement}
-   z = ResidueRingElem{T}(mod(base_ring(a)(b), modulus(a)))
+function (a::EuclideanRingResidueRing{T})(b::Integer) where {T <: RingElement}
+   z = EuclideanRingResidueRingElem{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueRing{T})(b::T) where {T <: RingElem}
+function (a::EuclideanRingResidueRing{T})(b::T) where {T <: RingElem}
    base_ring(a) != parent(b) && error("Operation on incompatible objects")
-   z = ResidueRingElem{T}(mod(b, modulus(a)))
+   z = EuclideanRingResidueRingElem{T}(mod(b, modulus(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueRing{T})(b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
+function (a::EuclideanRingResidueRing{T})(b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
    a != parent(b) && error("Operation on incompatible objects")
    return b
 end

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -10,9 +10,9 @@
 #
 ###############################################################################
 
-parent_type(::Type{ResidueFieldElem{T}}) where T <: RingElement = ResidueField{T}
+parent_type(::Type{EuclideanRingResidueFieldElem{T}}) where T <: RingElement = EuclideanRingResidueField{T}
 
-elem_type(::Type{ResidueField{T}}) where {T <: RingElement} = ResidueFieldElem{T}
+elem_type(::Type{EuclideanRingResidueField{T}}) where {T <: RingElement} = EuclideanRingResidueFieldElem{T}
 
 ###############################################################################
 #
@@ -20,10 +20,10 @@ elem_type(::Type{ResidueField{T}}) where {T <: RingElement} = ResidueFieldElem{T
 #
 ###############################################################################
 
-promote_rule(::Type{ResidueFieldElem{T}}, ::Type{ResidueFieldElem{T}}) where T <: RingElement = ResidueFieldElem{T}
+promote_rule(::Type{EuclideanRingResidueFieldElem{T}}, ::Type{EuclideanRingResidueFieldElem{T}}) where T <: RingElement = EuclideanRingResidueFieldElem{T}
 
-function promote_rule(::Type{ResidueFieldElem{T}}, ::Type{U}) where {T <: RingElement, U <: RingElement}
-   promote_rule(T, U) == T ? ResidueFieldElem{T} : Union{}
+function promote_rule(::Type{EuclideanRingResidueFieldElem{T}}, ::Type{U}) where {T <: RingElement, U <: RingElement}
+   promote_rule(T, U) == T ? EuclideanRingResidueFieldElem{T} : Union{}
 end
 
 ###############################################################################
@@ -32,30 +32,30 @@ end
 #
 ###############################################################################
 
-function (a::ResidueField{T})(b::RingElement) where {T <: RingElement}
+function (a::EuclideanRingResidueField{T})(b::RingElement) where {T <: RingElement}
    return a(base_ring(a)(b))
 end
 
-function (a::ResidueField{T})() where {T <: RingElement}
-   z = ResidueFieldElem{T}(zero(base_ring(a)))
+function (a::EuclideanRingResidueField{T})() where {T <: RingElement}
+   z = EuclideanRingResidueFieldElem{T}(zero(base_ring(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueField{T})(b::Integer) where {T <: RingElement}
-   z = ResidueFieldElem{T}(mod(base_ring(a)(b), modulus(a)))
+function (a::EuclideanRingResidueField{T})(b::Integer) where {T <: RingElement}
+   z = EuclideanRingResidueFieldElem{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueField{T})(b::T) where {T <: RingElem}
+function (a::EuclideanRingResidueField{T})(b::T) where {T <: RingElem}
    base_ring(a) != parent(b) && error("Operation on incompatible objects")
-   z = ResidueFieldElem{T}(mod(b, modulus(a)))
+   z = EuclideanRingResidueFieldElem{T}(mod(b, modulus(a)))
    z.parent = a
    return z
 end
 
-function (a::ResidueField{T})(b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
+function (a::EuclideanRingResidueField{T})(b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
    a != parent(b) && error("Operation on incompatible objects")
    return b
 end

--- a/test/generic/LaurentMPoly-test.jl
+++ b/test/generic/LaurentMPoly-test.jl
@@ -6,7 +6,7 @@ function test_elem(R::AbstractAlgebra.LaurentMPolyRing{BigInt})
     rand(R, 1:9, -n:n, -99:99)
 end
 
-function test_elem(R::AbstractAlgebra.Generic.LaurentMPolyWrapRing{AbstractAlgebra.Generic.ResidueRingElem{BigInt}})
+function test_elem(R::AbstractAlgebra.Generic.LaurentMPolyWrapRing{AbstractAlgebra.Generic.EuclideanRingResidueRingElem{BigInt}})
     n = rand(1:5)
     # R: length between 1 and 9
     # R: exponents between -n and n

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,12 +1,12 @@
-function test_elem(R::AbstractAlgebra.Generic.ResidueRing{BigInt})
+function test_elem(R::AbstractAlgebra.Generic.EuclideanRingResidueRing{BigInt})
    return rand(R, 0:characteristic(R))
 end
 
-function test_elem(R::AbstractAlgebra.Generic.ResidueRing{AbstractAlgebra.Generic.Poly{T}}) where T
+function test_elem(R::AbstractAlgebra.Generic.EuclideanRingResidueRing{AbstractAlgebra.Generic.Poly{T}}) where T
    return rand(R, 0:100, -100:100)
 end
 
-@testset "Generic.ResidueRingElem.conformance_tests" begin
+@testset "Generic.EuclideanRingResidueRingElem.conformance_tests" begin
    test_Ring_interface(residue_ring(ZZ, 1))   # is_gen fails on polys
    test_Ring_interface_recursive(residue_ring(ZZ, -4))
 
@@ -27,7 +27,7 @@ end
    @test !occursin("\n", sprint(show, T))
 end
 
-@testset "Generic.ResidueRingElem.constructors" begin
+@testset "Generic.EuclideanRingResidueRingElem.constructors" begin
    B = ZZ
 
    R = Generic.residue_ring(B, 16453889)
@@ -51,62 +51,62 @@ end
 
    @test_throws DomainError Generic.residue_ring(B, 0)
 
-   @test elem_type(R) == Generic.ResidueRingElem{elem_type(B)}
-   @test elem_type(Generic.ResidueRing{elem_type(B)}) == Generic.ResidueRingElem{elem_type(B)}
-   @test parent_type(Generic.ResidueRingElem{elem_type(B)}) == Generic.ResidueRing{elem_type(B)}
+   @test elem_type(R) == Generic.EuclideanRingResidueRingElem{elem_type(B)}
+   @test elem_type(Generic.EuclideanRingResidueRing{elem_type(B)}) == Generic.EuclideanRingResidueRingElem{elem_type(B)}
+   @test parent_type(Generic.EuclideanRingResidueRingElem{elem_type(B)}) == Generic.EuclideanRingResidueRing{elem_type(B)}
 
-   @test isa(R, Generic.ResidueRing)
+   @test isa(R, Generic.EuclideanRingResidueRing)
 
    a = R(123)
 
-   @test isa(a, Generic.ResidueRingElem)
+   @test isa(a, Generic.EuclideanRingResidueRingElem)
 
    b = R(a)
 
-   @test isa(b, Generic.ResidueRingElem)
+   @test isa(b, Generic.EuclideanRingResidueRingElem)
 
    c = R(ZZ(12))
 
-   @test isa(c, Generic.ResidueRingElem)
+   @test isa(c, Generic.EuclideanRingResidueRingElem)
 
    d = R()
 
-   @test isa(d, Generic.ResidueRingElem)
+   @test isa(d, Generic.EuclideanRingResidueRingElem)
 
    S, x = polynomial_ring(R, "x")
    T = residue_ring(S, x^3 + 3x + 1)
 
-   @test isa(T, Generic.ResidueRing)
+   @test isa(T, Generic.EuclideanRingResidueRing)
 
    f = T(x^4)
 
-   @test isa(f, Generic.ResidueRingElem)
+   @test isa(f, Generic.EuclideanRingResidueRingElem)
 
    g = T(f)
 
-   @test isa(g, Generic.ResidueRingElem)
+   @test isa(g, Generic.EuclideanRingResidueRingElem)
 
    # Poly modulus, invertible lc 
    S, x = polynomial_ring(ZZ, "x")
    T = residue_ring(S, x^2 + 1)
 
-   @test isa(T, Generic.ResidueRing)
+   @test isa(T, Generic.EuclideanRingResidueRing)
 
    f = T(x^4)
 
-   @test isa(f, Generic.ResidueRingElem)
+   @test isa(f, Generic.EuclideanRingResidueRingElem)
 
    g = T(f)
 
-   @test isa(g, Generic.ResidueRingElem)
+   @test isa(g, Generic.EuclideanRingResidueRingElem)
 
    h = T()
 
-   @test isa(h, Generic.ResidueRingElem)
+   @test isa(h, Generic.EuclideanRingResidueRingElem)
 
    k = T(1)
 
-   @test isa(k, Generic.ResidueRingElem)
+   @test isa(k, Generic.EuclideanRingResidueRingElem)
 
    S = Generic.residue_ring(B, 164538890)
    x = R(1)
@@ -119,7 +119,7 @@ end
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.ResidueRingElem.rand" begin
+@testset "Generic.EuclideanRingResidueRingElem.rand" begin
    R = Generic.residue_ring(ZZ, 49)
 
    test_rand(R, 1:9) do f
@@ -133,7 +133,7 @@ end
    test_rand(R, -1:9, -3:3)
 end
 
-@testset "Generic.ResidueRingElem.manipulation" begin
+@testset "Generic.EuclideanRingResidueRingElem.manipulation" begin
    R = Generic.residue_ring(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -183,7 +183,7 @@ end
    @test isa(lift(S(1)), BigInt)
 end
 
-@testset "Generic.ResidueRingElem.unary_ops" begin
+@testset "Generic.EuclideanRingResidueRingElem.unary_ops" begin
    R = Generic.residue_ring(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -200,7 +200,7 @@ end
    @test -T(x + 1) == T(-x - 1)
 end
 
-@testset "Generic.ResidueRingElem.binary_ops" begin
+@testset "Generic.EuclideanRingResidueRingElem.binary_ops" begin
    R = Generic.residue_ring(ZZ, 12)
 
    f = R(4)
@@ -239,7 +239,7 @@ end
    @test n*p == T(2x - 2)
 end
 
-@testset "Generic.ResidueRingElem.gcd" begin
+@testset "Generic.EuclideanRingResidueRingElem.gcd" begin
    R = Generic.residue_ring(ZZ, 12)
 
    f = R(4)
@@ -267,7 +267,7 @@ end
    @test gcd(T(x + 1), T(x + 1)) == T(1)
 end
 
-@testset "Generic.ResidueRingElem.adhoc_binary" begin
+@testset "Generic.EuclideanRingResidueRingElem.adhoc_binary" begin
    R = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -302,7 +302,7 @@ end
    @test f*5 == T(5x + 5)
 end
 
-@testset "Generic.ResidueRingElem.comparison" begin
+@testset "Generic.EuclideanRingResidueRingElem.comparison" begin
    R = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -335,7 +335,7 @@ end
    @test isequal(T(x + 2), T(x + 2))
 end
 
-@testset "Generic.ResidueRingElem.adhoc_comparison" begin
+@testset "Generic.EuclideanRingResidueRingElem.adhoc_comparison" begin
    R = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -358,7 +358,7 @@ end
    @test T(x) != 2
 end
 
-@testset "Generic.ResidueRingElem.powering" begin
+@testset "Generic.EuclideanRingResidueRingElem.powering" begin
    R = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -411,7 +411,7 @@ end
    @test_throws NotInvertibleError R(5)^-1
 end
 
-@testset "Generic.ResidueRingElem.inversion" begin
+@testset "Generic.EuclideanRingResidueRingElem.inversion" begin
    R = Generic.residue_ring(ZZ, 49)
 
    a = R(5)
@@ -427,7 +427,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.ResidueRingElem.exact_division" begin
+@testset "Generic.EuclideanRingResidueRingElem.exact_division" begin
    R = Generic.residue_ring(ZZ, 49)
 
    a = R(5)

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.ResidueFieldElem.constructors" begin
+@testset "Generic.EuclideanRingResidueFieldElem.constructors" begin
    B = ZZ
 
    R = Generic.residue_field(B, 16453889)
@@ -20,40 +20,40 @@
    @test Generic.residue_field(B, 16453889, cached = true) === Generic.residue_field(B, 16453889, cached = true)
    @test Generic.residue_field(B, 16453889, cached = true) !== Generic.residue_field(B, 16453889, cached = false)
 
-   @test elem_type(R) == Generic.ResidueFieldElem{elem_type(B)}
-   @test elem_type(Generic.ResidueField{elem_type(B)}) == Generic.ResidueFieldElem{elem_type(B)}
-   @test parent_type(Generic.ResidueFieldElem{elem_type(B)}) == Generic.ResidueField{elem_type(B)}
+   @test elem_type(R) == Generic.EuclideanRingResidueFieldElem{elem_type(B)}
+   @test elem_type(Generic.EuclideanRingResidueField{elem_type(B)}) == Generic.EuclideanRingResidueFieldElem{elem_type(B)}
+   @test parent_type(Generic.EuclideanRingResidueFieldElem{elem_type(B)}) == Generic.EuclideanRingResidueField{elem_type(B)}
 
-   @test isa(R, Generic.ResidueField)
+   @test isa(R, Generic.EuclideanRingResidueField)
 
    a = R(123)
 
-   @test isa(a, Generic.ResidueFieldElem)
+   @test isa(a, Generic.EuclideanRingResidueFieldElem)
 
    b = R(a)
 
-   @test isa(b, Generic.ResidueFieldElem)
+   @test isa(b, Generic.EuclideanRingResidueFieldElem)
 
    c = R(ZZ(12))
 
-   @test isa(c, Generic.ResidueFieldElem)
+   @test isa(c, Generic.EuclideanRingResidueFieldElem)
 
    d = R()
 
-   @test isa(d, Generic.ResidueFieldElem)
+   @test isa(d, Generic.EuclideanRingResidueFieldElem)
 
    S, x = polynomial_ring(R, "x")
    T = residue_field(S, x^3 + 3x + 1)
 
-   @test isa(T, Generic.ResidueField)
+   @test isa(T, Generic.EuclideanRingResidueField)
 
    f = T(x^4)
 
-   @test isa(f, Generic.ResidueFieldElem)
+   @test isa(f, Generic.EuclideanRingResidueFieldElem)
 
    g = T(f)
 
-   @test isa(g, Generic.ResidueFieldElem)
+   @test isa(g, Generic.EuclideanRingResidueFieldElem)
 
    S = Generic.residue_ring(B, 2)
    x = R(1)
@@ -66,7 +66,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.ResidueFieldElem.printing" begin
+@testset "Generic.EuclideanRingResidueFieldElem.printing" begin
    R = Generic.residue_field(ZZ, 16453889)
 
    @test string(zero(R)) == "0"
@@ -80,7 +80,7 @@ end
    @test string(5*x^5+3*x^3+2*x^2+x+1) == "5*x^5 + 3*x^3 + 2*x^2 + x + 1"
 end
 
-@testset "Generic.ResidueFieldElem.rand" begin
+@testset "Generic.EuclideanRingResidueFieldElem.rand" begin
    R = Generic.residue_field(ZZ, 16453889)
 
    test_rand(R, 1:9) do f
@@ -88,7 +88,7 @@ end
    end
 end
 
-@testset "Generic.ResidueFieldElem.manipulation" begin
+@testset "Generic.EuclideanRingResidueFieldElem.manipulation" begin
    R = Generic.residue_field(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -125,7 +125,7 @@ end
    @test isa(lift(S(1)), BigInt)
 end
 
-@testset "Generic.ResidueFieldElem.unary_ops" begin
+@testset "Generic.EuclideanRingResidueFieldElem.unary_ops" begin
    R = Generic.residue_field(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -136,7 +136,7 @@ end
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
 end
 
-@testset "Generic.ResidueFieldElem.binary_ops" begin
+@testset "Generic.EuclideanRingResidueFieldElem.binary_ops" begin
    R = Generic.residue_field(ZZ, 13)
 
    f = R(4)
@@ -162,7 +162,7 @@ end
    @test n*p == T(3x^2 + 4x + 4)
 end
 
-@testset "Generic.ResidueFieldElem.gcd" begin
+@testset "Generic.EuclideanRingResidueFieldElem.gcd" begin
    R = Generic.residue_field(ZZ, 13)
 
    f = R(4)
@@ -180,7 +180,7 @@ end
    @test gcd(n, p) == 1
 end
 
-@testset "Generic.ResidueFieldElem.adhoc_binary" begin
+@testset "Generic.EuclideanRingResidueFieldElem.adhoc_binary" begin
    R = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -203,7 +203,7 @@ end
    @test f*5 == T(2*x^2+3*x+6)
 end
 
-@testset "Generic.ResidueFieldElem.comparison" begin
+@testset "Generic.EuclideanRingResidueFieldElem.comparison" begin
    R = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -229,7 +229,7 @@ end
    @test isequal(f, g)
 end
 
-@testset "Generic.ResidueFieldElem.adhoc_comparison" begin
+@testset "Generic.EuclideanRingResidueFieldElem.adhoc_comparison" begin
    R = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -245,7 +245,7 @@ end
    @test f != 5
 end
 
-@testset "Generic.ResidueFieldElem.powering" begin
+@testset "Generic.EuclideanRingResidueFieldElem.powering" begin
    R = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -260,7 +260,7 @@ end
    @test f^100 == T(x^2 + 2x + 1)
 end
 
-@testset "Generic.ResidueFieldElem.inversion" begin
+@testset "Generic.EuclideanRingResidueFieldElem.inversion" begin
    R = Generic.residue_field(ZZ, 47)
 
    a = R(5)
@@ -276,7 +276,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.ResidueFieldElem.exact_division" begin
+@testset "Generic.EuclideanRingResidueFieldElem.exact_division" begin
    R = Generic.residue_field(ZZ, 47)
 
    a = R(5)
@@ -294,7 +294,7 @@ end
    @test divexact(f, g) == T(7*x^2+25*x+26)
 end
 
-@testset "Generic.ResidueFieldElem.square_root" begin
+@testset "Generic.EuclideanRingResidueFieldElem.square_root" begin
    for p in [3, 47, 733, 13913, 168937, 3980299, 57586577]
        R = Generic.residue_field(ZZ, p)
 

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -127,7 +127,7 @@ end
    end
 end
 
-function test_elem(R::AbstractAlgebra.Generic.UniversalPolyRing{AbstractAlgebra.Generic.ResidueRingElem{BigInt}})
+function test_elem(R::AbstractAlgebra.Generic.UniversalPolyRing{AbstractAlgebra.Generic.EuclideanRingResidueRingElem{BigInt}})
     return rand(R, 0:4, 0:10, -10:10)
 end
 


### PR DESCRIPTION
These implementations only make sense if the underyling ring is an
Euclidean ring. Thus we rename the types to `EuclideanRingResidueRing`
and `EuclideanRingResidueField` respectively.
