### PR TITLE
Fix broadcasting of `evaluate`

### DIFF
--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -57,7 +57,7 @@ function _compute_target_size_nonrec(a::NCRingElement)
   return ()
 end
 
-function _compute_target_size_nonrec(a::Ref{<:NCRingElement})
+function _compute_target_size_nonrec(a::Ref)
   return ()
 end
 
@@ -93,7 +93,7 @@ function _compute_elements_nonrec(a::NCRingElement)
   return a
 end
 
-function _compute_elements_nonrec(a::Ref{<:NCRingElement})
+function _compute_elements_nonrec(a::Ref)
   return a.x
 end
 
@@ -121,7 +121,7 @@ end
 # So we end up with a nice expression tree and our aim is to find
 # the shape and coefficient ring of the final output matrix
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{BroadcastDummy}}, ::Type{ElType}) where ElType
-  dest =  _promote_dest_func(bc.f, bc.args)
+  dest = _promote_dest_func(bc.f, bc.args)
   return similar(dest, (length.(axes(bc)))...)
 end
 

--- a/test/broadcasting-test.jl
+++ b/test/broadcasting-test.jl
@@ -14,3 +14,9 @@
   @test_throws ErrorException A .* 2 .* 2 .* [1, 2]
 end
 
+@testset "broadcasting evaluate" begin
+  Qa, (k1, k2, k3, k4) = rational_function_field(QQ, ["k1", "k2", "k3", "k4"])
+  A = matrix(Qa, [k1 k2; k3 k4])
+  @test evaluate.(A, Ref([1, 2, 3, 4])) == QQ[1 2; 3 4]
+end
+


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3204.

I must admit that I don't understand some parts of the broadcasting code, but broadcasting trivially over `Ref`s should always be safe.
The mwe from https://github.com/oscar-system/Oscar.jl/issues/3204 has been added as a test.