### PR TITLE
Export EuclideanRingResidue*Elem as well

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.36.0"
+version = "0.36.1"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -15,13 +15,13 @@ AbstractAlgebra.jl abstract type hierarchy.
 
 ## Generic residue types
 
-AbstractAlgebra.jl implements generic residue rings of Euclidean rings with type `Generic.EuclideanRingResidueRingelem{T}`
-or in the case of residue rings that are known to be fields, `Generic.EuclideanRingResidueField{T}`,
+AbstractAlgebra.jl implements generic residue rings of Euclidean rings with type `EuclideanRingResidueRingElem{T}`
+or in the case of residue rings that are known to be fields, `EuclideanRingResidueFieldElem{T}`,
 where `T` is the type of elements of the base ring. See the file
 `src/generic/GenericTypes.jl` for details.
 
-Parent objects of generic residue ring elements have type `Generic.EuclideanRingResidueRing{T}`
-and those of residue fields have type `Generic.EuclideanRingResidueField{T}`.
+Parent objects of generic residue ring elements have type `EuclideanRingResidueRing{T}`
+and those of residue fields have type `EuclideanRingResidueField{T}`.
 
 The defining modulus of the residue ring is stored in the parent object.
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -679,7 +679,9 @@ import .Generic: dim
 import .Generic: disable_cache!
 import .Generic: downscale
 import .Generic: EuclideanRingResidueField
+import .Generic: EuclideanRingResidueFieldElem
 import .Generic: EuclideanRingResidueRing
+import .Generic: EuclideanRingResidueRingElem
 import .Generic: enable_cache!
 import .Generic: exp_gcd
 import .Generic: exponent
@@ -890,7 +892,9 @@ export echelon_form_with_transformation
 export elem_type
 export enable_cache!
 export EuclideanRingResidueField
+export EuclideanRingResidueFieldElem
 export EuclideanRingResidueRing
+export EuclideanRingResidueRingElem
 export evaluate
 export exp_gcd
 export exponent

--- a/src/NemoStuff.jl
+++ b/src/NemoStuff.jl
@@ -311,23 +311,23 @@ function Base.lcm(a::T, b::T) where {T<:SeriesElem}
     return gen(parent(a))^max(valuation(a), valuation(b))
 end
 
-function gen(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
+function gen(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return R(gen(base_ring(R)))
 end
 
-function characteristic(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
+function characteristic(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return characteristic(base_ring(base_ring(R)))
 end
 
-function size(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:ResElem}
+function size(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:ResElem}
     return size(base_ring(base_ring(R)))^degree(modulus(R))
 end
 
-function size(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
+function size(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     return size(base_ring(base_ring(R)))^degree(R.modulus)
 end
 
-function rand(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
+function rand(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:PolyRingElem}
     r = rand(base_ring(base_ring(R)))
     g = gen(R)
     for i = 1:degree(R.modulus)
@@ -336,7 +336,7 @@ function rand(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRing
     return r
 end
 
-function gens(R::Union{Generic.EuclideanRingResidueRing{T},Generic.EuclideanRingResidueField{T}}) where {T<:PolyRingElem} ## probably needs more cases
+function gens(R::Union{EuclideanRingResidueRing{T},EuclideanRingResidueField{T}}) where {T<:PolyRingElem} ## probably needs more cases
     ## as the other residue functions
     g = gen(R)
     r = Vector{typeof(g)}()

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -453,7 +453,7 @@ function residue_ring(R::Ring, a::RingElement; cached::Bool = true)
    # do matrices over Z/0 using a Z/nZ type. The former is multiprecision, the latter not.
    iszero(a) && throw(DomainError(a, "Modulus must be nonzero"))
    T = elem_type(R)
-   S = Generic.EuclideanRingResidueRing{T}(R(a), cached)
+   S = EuclideanRingResidueRing{T}(R(a), cached)
    return S, Generic.EuclideanRingResidueMap(R, S)
 end
 
@@ -461,7 +461,7 @@ function residue_ring(R::PolyRing, a::RingElement; cached::Bool = true)
    iszero(a) && throw(DomainError(a, "Modulus must be nonzero"))
    !is_unit(leading_coefficient(a)) && throw(DomainError(a, "Non-invertible leading coefficient"))
    T = elem_type(R)
-   S = Generic.EuclideanRingResidueRing{T}(R(a), cached)
+   S = EuclideanRingResidueRing{T}(R(a), cached)
    return S, Generic.EuclideanRingResidueMap(R, S)
 end
 

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -497,7 +497,7 @@ to the constructor with the same base ring $R$ and element $a$.
 function residue_field(R::Ring, a::RingElement; cached::Bool = true)
    iszero(a) && throw(DivideError())
    T = elem_type(R)
-   S = Generic.EuclideanRingResidueField{T}(R(a), cached)
+   S = EuclideanRingResidueField{T}(R(a), cached)
    return S, Generic.EuclideanRingResidueMap(R, S)
 end
 

--- a/test/generic/LaurentMPoly-test.jl
+++ b/test/generic/LaurentMPoly-test.jl
@@ -6,7 +6,7 @@ function test_elem(R::AbstractAlgebra.LaurentMPolyRing{BigInt})
     rand(R, 1:9, -n:n, -99:99)
 end
 
-function test_elem(R::AbstractAlgebra.Generic.LaurentMPolyWrapRing{AbstractAlgebra.Generic.EuclideanRingResidueRingElem{BigInt}})
+function test_elem(R::AbstractAlgebra.Generic.LaurentMPolyWrapRing{AbstractAlgebra.EuclideanRingResidueRingElem{BigInt}})
     n = rand(1:5)
     # R: length between 1 and 9
     # R: exponents between -n and n

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,12 +1,12 @@
-function test_elem(R::AbstractAlgebra.Generic.EuclideanRingResidueRing{BigInt})
+function test_elem(R::AbstractAlgebra.EuclideanRingResidueRing{BigInt})
    return rand(R, 0:characteristic(R))
 end
 
-function test_elem(R::AbstractAlgebra.Generic.EuclideanRingResidueRing{AbstractAlgebra.Generic.Poly{T}}) where T
+function test_elem(R::AbstractAlgebra.EuclideanRingResidueRing{AbstractAlgebra.Generic.Poly{T}}) where T
    return rand(R, 0:100, -100:100)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.conformance_tests" begin
+@testset "EuclideanRingResidueRingElem.conformance_tests" begin
    test_Ring_interface(residue_ring(ZZ, 1)[1])   # is_gen fails on polys
    test_Ring_interface_recursive(residue_ring(ZZ, -4)[1])
 
@@ -27,7 +27,7 @@ end
    @test !occursin("\n", sprint(show, T))
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.constructors" begin
+@testset "EuclideanRingResidueRingElem.constructors" begin
    B = ZZ
 
    R, f = Generic.residue_ring(B, 16453889)
@@ -53,62 +53,62 @@ end
 
    @test_throws DomainError Generic.residue_ring(B, 0)
 
-   @test elem_type(R) == Generic.EuclideanRingResidueRingElem{elem_type(B)}
-   @test elem_type(Generic.EuclideanRingResidueRing{elem_type(B)}) == Generic.EuclideanRingResidueRingElem{elem_type(B)}
-   @test parent_type(Generic.EuclideanRingResidueRingElem{elem_type(B)}) == Generic.EuclideanRingResidueRing{elem_type(B)}
+   @test elem_type(R) == EuclideanRingResidueRingElem{elem_type(B)}
+   @test elem_type(EuclideanRingResidueRing{elem_type(B)}) == EuclideanRingResidueRingElem{elem_type(B)}
+   @test parent_type(EuclideanRingResidueRingElem{elem_type(B)}) == EuclideanRingResidueRing{elem_type(B)}
 
-   @test isa(R, Generic.EuclideanRingResidueRing)
+   @test isa(R, EuclideanRingResidueRing)
 
    a = R(123)
 
-   @test isa(a, Generic.EuclideanRingResidueRingElem)
+   @test isa(a, EuclideanRingResidueRingElem)
 
    b = R(a)
 
-   @test isa(b, Generic.EuclideanRingResidueRingElem)
+   @test isa(b, EuclideanRingResidueRingElem)
 
    c = R(ZZ(12))
 
-   @test isa(c, Generic.EuclideanRingResidueRingElem)
+   @test isa(c, EuclideanRingResidueRingElem)
 
    d = R()
 
-   @test isa(d, Generic.EuclideanRingResidueRingElem)
+   @test isa(d, EuclideanRingResidueRingElem)
 
    S, x = polynomial_ring(R, "x")
    T, = residue_ring(S, x^3 + 3x + 1)
 
-   @test isa(T, Generic.EuclideanRingResidueRing)
+   @test isa(T, EuclideanRingResidueRing)
 
    f = T(x^4)
 
-   @test isa(f, Generic.EuclideanRingResidueRingElem)
+   @test isa(f, EuclideanRingResidueRingElem)
 
    g = T(f)
 
-   @test isa(g, Generic.EuclideanRingResidueRingElem)
+   @test isa(g, EuclideanRingResidueRingElem)
 
    # Poly modulus, invertible lc 
    S, x = polynomial_ring(ZZ, "x")
    T, = residue_ring(S, x^2 + 1)
 
-   @test isa(T, Generic.EuclideanRingResidueRing)
+   @test isa(T, EuclideanRingResidueRing)
 
    f = T(x^4)
 
-   @test isa(f, Generic.EuclideanRingResidueRingElem)
+   @test isa(f, EuclideanRingResidueRingElem)
 
    g = T(f)
 
-   @test isa(g, Generic.EuclideanRingResidueRingElem)
+   @test isa(g, EuclideanRingResidueRingElem)
 
    h = T()
 
-   @test isa(h, Generic.EuclideanRingResidueRingElem)
+   @test isa(h, EuclideanRingResidueRingElem)
 
    k = T(1)
 
-   @test isa(k, Generic.EuclideanRingResidueRingElem)
+   @test isa(k, EuclideanRingResidueRingElem)
 
    S, = Generic.residue_ring(B, 164538890)
    x = R(1)
@@ -121,7 +121,7 @@ end
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.rand" begin
+@testset "EuclideanRingResidueRingElem.rand" begin
    R, = Generic.residue_ring(ZZ, 49)
 
    test_rand(R, 1:9) do f
@@ -135,7 +135,7 @@ end
    test_rand(R, -1:9, -3:3)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.manipulation" begin
+@testset "EuclideanRingmanipulation" begin
    R, = Generic.residue_ring(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -185,7 +185,7 @@ end
    @test isa(lift(S(1)), BigInt)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.unary_ops" begin
+@testset "EuclideanRingResidueRingElem.unary_ops" begin
    R, = Generic.residue_ring(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -202,7 +202,7 @@ end
    @test -T(x + 1) == T(-x - 1)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.binary_ops" begin
+@testset "EuclideanRingResidueRingElem.binary_ops" begin
    R, = Generic.residue_ring(ZZ, 12)
 
    f = R(4)
@@ -241,7 +241,7 @@ end
    @test n*p == T(2x - 2)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.gcd" begin
+@testset "EuclideanRingResidueRingElem.gcd" begin
    R, = Generic.residue_ring(ZZ, 12)
 
    f = R(4)
@@ -269,7 +269,7 @@ end
    @test gcd(T(x + 1), T(x + 1)) == T(1)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.adhoc_binary" begin
+@testset "EuclideanRingResidueRingElem.adhoc_binary" begin
    R, = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -304,7 +304,7 @@ end
    @test f*5 == T(5x + 5)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.comparison" begin
+@testset "EuclideanRingResidueRingElem.comparison" begin
    R, = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -337,7 +337,7 @@ end
    @test isequal(T(x + 2), T(x + 2))
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.adhoc_comparison" begin
+@testset "EuclideanRingResidueRingElem.adhoc_comparison" begin
    R, = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -360,7 +360,7 @@ end
    @test T(x) != 2
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.powering" begin
+@testset "EuclideanRingResidueRingElem.powering" begin
    R, = Generic.residue_ring(ZZ, 7)
 
    a = R(3)
@@ -413,7 +413,7 @@ end
    @test_throws NotInvertibleError R(5)^-1
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.inversion" begin
+@testset "EuclideanRingResidueRingElem.inversion" begin
    R, = Generic.residue_ring(ZZ, 49)
 
    a = R(5)
@@ -429,7 +429,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.EuclideanRingResidueRingElem.exact_division" begin
+@testset "EuclideanRingResidueRingElem.exact_division" begin
    R, = Generic.residue_ring(ZZ, 49)
 
    a = R(5)

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -1,4 +1,4 @@
-@testset "Generic.EuclideanRingResidueFieldElem.constructors" begin
+@testset "EuclideanRingResidueFieldElem.constructors" begin
    B = ZZ
 
    R, = Generic.residue_field(B, 16453889)
@@ -23,40 +23,40 @@
    @test Generic.residue_field(B, 16453889, cached = true)[1] === Generic.residue_field(B, 16453889, cached = true)[1]
    @test Generic.residue_field(B, 16453889, cached = true)[1] !== Generic.residue_field(B, 16453889, cached = false)[1]
 
-   @test elem_type(R) == Generic.EuclideanRingResidueFieldElem{elem_type(B)}
-   @test elem_type(Generic.EuclideanRingResidueField{elem_type(B)}) == Generic.EuclideanRingResidueFieldElem{elem_type(B)}
-   @test parent_type(Generic.EuclideanRingResidueFieldElem{elem_type(B)}) == Generic.EuclideanRingResidueField{elem_type(B)}
+   @test elem_type(R) == EuclideanRingResidueFieldElem{elem_type(B)}
+   @test elem_type(EuclideanRingResidueField{elem_type(B)}) == EuclideanRingResidueFieldElem{elem_type(B)}
+   @test parent_type(EuclideanRingResidueFieldElem{elem_type(B)}) == EuclideanRingResidueField{elem_type(B)}
 
-   @test isa(R, Generic.EuclideanRingResidueField)
+   @test isa(R, EuclideanRingResidueField)
 
    a = R(123)
 
-   @test isa(a, Generic.EuclideanRingResidueFieldElem)
+   @test isa(a, EuclideanRingResidueFieldElem)
 
    b = R(a)
 
-   @test isa(b, Generic.EuclideanRingResidueFieldElem)
+   @test isa(b, EuclideanRingResidueFieldElem)
 
    c = R(ZZ(12))
 
-   @test isa(c, Generic.EuclideanRingResidueFieldElem)
+   @test isa(c, EuclideanRingResidueFieldElem)
 
    d = R()
 
-   @test isa(d, Generic.EuclideanRingResidueFieldElem)
+   @test isa(d, EuclideanRingResidueFieldElem)
 
    S, x = polynomial_ring(R, "x")
    T, = residue_field(S, x^3 + 3x + 1)
 
-   @test isa(T, Generic.EuclideanRingResidueField)
+   @test isa(T, EuclideanRingResidueField)
 
    f = T(x^4)
 
-   @test isa(f, Generic.EuclideanRingResidueFieldElem)
+   @test isa(f, EuclideanRingResidueFieldElem)
 
    g = T(f)
 
-   @test isa(g, Generic.EuclideanRingResidueFieldElem)
+   @test isa(g, EuclideanRingResidueFieldElem)
 
    S, = Generic.residue_ring(B, 2)
    x = R(1)
@@ -69,7 +69,7 @@
    @test !(y in keys(Dict(x => 1)))
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.printing" begin
+@testset "EuclideanRingResidueFieldElem.printing" begin
    R, = Generic.residue_field(ZZ, 16453889)
 
    @test string(zero(R)) == "0"
@@ -83,7 +83,7 @@ end
    @test string(5*x^5+3*x^3+2*x^2+x+1) == "5*x^5 + 3*x^3 + 2*x^2 + x + 1"
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.rand" begin
+@testset "EuclideanRingResidueFieldElem.rand" begin
    R, = Generic.residue_field(ZZ, 16453889)
 
    test_rand(R, 1:9) do f
@@ -91,7 +91,7 @@ end
    end
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.manipulation" begin
+@testset "EuclideanRingResidueFieldElem.manipulation" begin
    R, = Generic.residue_field(ZZ, 16453889)
 
    @test modulus(R) == 16453889
@@ -128,7 +128,7 @@ end
    @test isa(lift(S(1)), BigInt)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.unary_ops" begin
+@testset "EuclideanRingResidueFieldElem.unary_ops" begin
    R, = Generic.residue_field(ZZ, 16453889)
 
    @test -R(12345) == R(16441544)
@@ -139,7 +139,7 @@ end
    @test -T(x^5 + 1) == T(x^2+16453880*x+16453885)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.binary_ops" begin
+@testset "EuclideanRingResidueFieldElem.binary_ops" begin
    R, = Generic.residue_field(ZZ, 13)
 
    f = R(4)
@@ -165,7 +165,7 @@ end
    @test n*p == T(3x^2 + 4x + 4)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.gcd" begin
+@testset "EuclideanRingResidueFieldElem.gcd" begin
    R, = Generic.residue_field(ZZ, 13)
 
    f = R(4)
@@ -183,7 +183,7 @@ end
    @test gcd(n, p) == 1
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.adhoc_binary" begin
+@testset "EuclideanRingResidueFieldElem.adhoc_binary" begin
    R, = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -206,7 +206,7 @@ end
    @test f*5 == T(2*x^2+3*x+6)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.comparison" begin
+@testset "EuclideanRingResidueFieldElem.comparison" begin
    R, = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -232,7 +232,7 @@ end
    @test isequal(f, g)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.adhoc_comparison" begin
+@testset "EuclideanRingResidueFieldElem.adhoc_comparison" begin
    R, = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -248,7 +248,7 @@ end
    @test f != 5
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.powering" begin
+@testset "EuclideanRingResidueFieldElem.powering" begin
    R, = Generic.residue_field(ZZ, 7)
 
    a = R(3)
@@ -263,7 +263,7 @@ end
    @test f^100 == T(x^2 + 2x + 1)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.inversion" begin
+@testset "EuclideanRingResidueFieldElem.inversion" begin
    R, = Generic.residue_field(ZZ, 47)
 
    a = R(5)
@@ -279,7 +279,7 @@ end
    @test inv(f) == T(26*x^2+31*x+10)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.exact_division" begin
+@testset "EuclideanRingResidueFieldElem.exact_division" begin
    R, = Generic.residue_field(ZZ, 47)
 
    a = R(5)
@@ -297,7 +297,7 @@ end
    @test divexact(f, g) == T(7*x^2+25*x+26)
 end
 
-@testset "Generic.EuclideanRingResidueFieldElem.square_root" begin
+@testset "EuclideanRingResidueFieldElem.square_root" begin
    for p in [3, 47, 733, 13913, 168937, 3980299, 57586577]
        R, = Generic.residue_field(ZZ, p)
 

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -127,7 +127,7 @@ end
    end
 end
 
-function test_elem(R::AbstractAlgebra.Generic.UniversalPolyRing{AbstractAlgebra.Generic.EuclideanRingResidueRingElem{BigInt}})
+function test_elem(R::AbstractAlgebra.Generic.UniversalPolyRing{EuclideanRingResidueRingElem{BigInt}})
     return rand(R, 0:4, 0:10, -10:10)
 end
 


### PR DESCRIPTION
We should keep it consistent between parents and their elems. I noticed this in downstream tests, so it would be great to fix it while still adapting downstream.