### PR TITLE
Adapt Groups interface for `div_left` and `div_right`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.36.2"
+version = "0.36.3"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -879,6 +879,8 @@ export dim
 export direct_sum
 export disable_cache!
 export discriminant
+export div_left
+export div_right
 export divexact
 export divexact_left
 export divexact_low

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -26,8 +26,8 @@ Base.inv(g::GroupElem) = throw(NotImplementedError(:inv, g))
 # ... and many more of course (among those below and beyond), such as
 #   gens(::Group)
 #   ngens(::Group)
-#   order(::Group)
-#   order(::GroupElem)
+#   order(::Type{T}, ::Group)
+#   order(::Type{T}, ::GroupElem)
 
 
 ###############################################################################

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -166,6 +166,20 @@ Alias for [`conj`](@ref conj).
 Base.:(^)(g::T, h::T) where {T<:GroupElem} = conj(g, h)
 
 """
+    /(g::T, h::T) where {T <: GroupElem}
+
+Alias for [`div_right`](@ref div_right).
+"""
+Base.:/(g::T, h::T) where {T<:GroupElem} = div_right(g, h)
+
+"""
+    \\(g::T, h::T) where {T <: GroupElem}
+
+Alias for [`div_left`](@ref div_left).
+"""
+Base.:\(g::T, h::T) where {T<:GroupElem} = div_left(g, h)
+
+"""
     comm(g::T, h::T, k::T...) where {T <: GroupElem}
 
 Return the left associative iterated commutator ``[[g, h], ...]``, where
@@ -179,11 +193,21 @@ function comm(g::T, h::T, k::T...) where {T<:GroupElem}
     return res
 end
 
-function Base.:(/)(g::T, h::T) where {T<:GroupElem}
+"""
+    div_right(g::T, h::T) where {T<:GroupElem}
+
+Return `g*inv(h)`.
+"""
+function div_right(g::T, h::T) where {T<:GroupElem}
     return g*inv(h)
 end
 
-function Base.:(\)(g::T, h::T) where {T<:GroupElem}
+"""
+    div_left(g::T, h::T) where {T<:GroupElem}
+
+Return `inv(g)*h`.
+"""
+function div_left(g::T, h::T) where {T<:GroupElem}
     return inv(g)*h
 end
 

--- a/test/Groups-conformance-tests.jl
+++ b/test/Groups-conformance-tests.jl
@@ -157,6 +157,15 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
 
             @test g / h == g * inv(h)
             @test (g, h) == (old_g, old_h)
+
+            @test div_right(g, h) == g * inv(h)
+            @test (g, h) == (old_g, old_h)
+
+            @test g \ h == inv(g) * h
+            @test (g, h) == (old_g, old_h)
+
+            @test div_left(g, h) == inv(g) * h
+            @test (g, h) == (old_g, old_h)
         end
 
         @testset "Misc GroupElem methods" begin


### PR DESCRIPTION
So downstream only needs to implement `div_left/right` if they want to change stuff, and not the `/` or `\` functions. (to be consistent with `^` and `conj`)