### PR TITLE
Export mutating functions from Groups interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.36.5"
+version = "0.36.6"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -123,6 +123,7 @@ import Base: ceil
 import Base: checkbounds
 import Base: cmp
 import Base: conj
+import Base: conj!
 import Base: convert
 import Base: cos
 import Base: cosh
@@ -857,7 +858,9 @@ export coefficients_of_univariate
 export collength
 export combine_like_terms!
 export comm
+export comm!
 export compose
+export conj!
 export constant_coefficient
 export content
 export cycles
@@ -880,7 +883,9 @@ export direct_sum
 export disable_cache!
 export discriminant
 export div_left
+export div_left!
 export div_right
+export div_right!
 export divexact
 export divexact_left
 export divexact_low
@@ -1087,6 +1092,7 @@ export nullspace
 export num_coeff
 export O
 export one
+export one!
 export order
 export ordering
 export parent_type

--- a/test/Groups-conformance-tests.jl
+++ b/test/Groups-conformance-tests.jl
@@ -194,16 +194,6 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
             @test similar(g) isa typeof(g)
         end
 
-        one!, inv!, mul!, conj!, comm!, div_left!, div_right! = (
-            AbstractAlgebra.one!,
-            AbstractAlgebra.inv!,
-            AbstractAlgebra.mul!,
-            AbstractAlgebra.conj!,
-            AbstractAlgebra.comm!,
-            AbstractAlgebra.div_left!,
-            AbstractAlgebra.div_right!,
-        )
-
         @testset "In-place operations" begin
             old_g, old_h = deepcopy(g), deepcopy(h)
             out = similar(g)


### PR DESCRIPTION
These function used to be there in GroupsCore, ignored from AA to Hecke, and Oscar implemented them for GAPGroups and exported. https://github.com/Nemocas/AbstractAlgebra.jl/pull/1528 moved the implementation from GroupsCore to AA.
When I removed the silly overloads in Oscar in https://github.com/oscar-system/Oscar.jl/pull/3231 with the intent to use the fallback in AA, the Oscar Aqua tests complain about functions not being there. Since many similar functions are already exported I think these should propagate to Oscar as well (where they already have been exported for a long time).