### PR TITLE
Overhaul Unicode preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /docs/build/
 Manifest.toml
+LocalPreferences.toml
 .DS_Store

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1386,7 +1386,11 @@ end
 #
 ################################################################################
 
-ALLOW_UNICODE_OVERRIDE_VALUE::Union{Bool,Nothing} = nothing
+@static if VERSION < v"1.8.0-DEV.1465"
+   ALLOW_UNICODE_OVERRIDE_VALUE = nothing
+else
+   ALLOW_UNICODE_OVERRIDE_VALUE::Union{Bool,Nothing} = nothing
+end
 
 @doc """
     allow_unicode(flag::Bool; temporary::Bool=false) -> Bool

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1397,8 +1397,8 @@ function is_unicode_allowed()
   return @load_preference("unicode", default = false)
 end
 
-function with_unicode(f::Function)
-  old_allow_unicode = allow_unicode(true)
+function with_unicode(f::Function, flag::Bool=true)
+  old_allow_unicode = allow_unicode(flag)
   try
     f()
   finally


### PR DESCRIPTION
To be able to disable unicode for tests/doctests etc., see e.g. https://github.com/oscar-system/Oscar.jl/pull/3271

Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/1588.