### PR TITLE
chore: bump to 0.37.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.37.4"
+version = "0.37.5"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
To be released once https://github.com/Nemocas/AbstractAlgebra.jl/pull/1586 and https://github.com/Nemocas/AbstractAlgebra.jl/pull/1594 are merged.