### PR TITLE
Allow Groups of order > 2^15 in conformance test

### DIFF
--- a/test/Groups-conformance-tests.jl
+++ b/test/Groups-conformance-tests.jl
@@ -57,8 +57,13 @@ function test_Group_interface(G::Group)
 
         @testset "order, rand" begin
             if is_finite(G)
-                @test order(Int16, G) isa Int16
-                @test order(BigInt, G) isa BigInt
+                ord = order(BigInt, G)
+                @test ord isa BigInt
+                if ord < typemax(Int16)
+                    @test order(Int16, G) isa Int16
+                else
+                    @test_throws InexactError order(Int16, G)
+                end
                 @test order(G) >= 1
                 @test is_trivial(G) == (order(G) == 1)
             else

--- a/test/generic/PermGroupAPI-test.jl
+++ b/test/generic/PermGroupAPI-test.jl
@@ -1,7 +1,7 @@
 @testset "GroupsCore API PermGroup" begin
 
     include(joinpath(dirname(dirname(pathof(AbstractAlgebra))), "test", "Groups-conformance-tests.jl"))
-    @testset "Sym($n)" for n in [1,2,5]
+    @testset "Sym($n)" for n in [1,2,5,10]
         G = SymmetricGroup(n)
         test_Group_interface(G)
         test_GroupElem_interface(rand(G, 2)...)


### PR DESCRIPTION
As already pointed out by @fingolfin in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1528#discussion_r1424740679, this leads to `InexactError`s.

When trying to enable the group conformance tests for Weyl groups in https://github.com/oscar-system/Oscar.jl/pull/3351 I stumbled over this and thus made this quick PR.