### PR TITLE
Fixed jldoctest of groebner_basis section in free_associative_algebra.md

### DIFF
--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -253,4 +253,4 @@ julia> g = Generic.groebner_basis([u*(x*y)^3 + u*(x*y)^2 + u + v, (y*x)^3*t + (y
 
 julia> normal_form(u*(x*y)^3*s*t + u*(x*y)^2*s*t +u*s*t + v*s*t, g)
 0
- ```
+```


### PR DESCRIPTION
fixed the Example not displaying correctly

_edit:_ at the bottom of https://nemocas.github.io/AbstractAlgebra.jl/dev/free_associative_algebra/#Groebner-bases