### PR TITLE
Cleanup after name printing changes

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -98,7 +98,7 @@ AbstractAlgebra.@show_name
 AbstractAlgebra.get_name
 AbstractAlgebra.set_name!
 AbstractAlgebra.extra_name
-AbstractAlgebra.find_name
+AbstractAlgebra.PrettyPrinting.find_name
 ```
 
 ### Indentation and Decapitalization

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -498,8 +498,6 @@ import .PrettyPrinting: Lowercase
 import .PrettyPrinting: Indent
 import .PrettyPrinting: Dedent
 
-import .PrettyPrinting: find_new_name as find_name # remove once all call-sites use get_name instead
-
 export @enable_all_show_via_expressify
 
 ###############################################################################

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1407,8 +1407,8 @@ If `override` is `false`, the name is only set if there is no name already set.
 This function errors if `obj` does not support attribute storage.
 """
 function set_name!(obj, name::String; override::Bool=true)
-  override || isnothing(get_attribute(obj, :name)) || return
-  set_attribute!(obj, :name => name)
+  override || isnothing(get_attribute(obj, :_name)) || return
+  set_attribute!(obj, :_name => name)
 end
 
 """
@@ -1422,7 +1422,7 @@ If `override` is `false`, the name is only set if there is no name already set.
 This function errors if `obj` does not support attribute storage.
 """
 function set_name!(obj; override::Bool=true)
-  override || isnothing(get_attribute(obj, :name)) || return
+  override || isnothing(get_attribute(obj, :_name)) || return
   sy = find_name(obj)
   isnothing(sy) && return
   set_name!(obj, string(sy); override=true)
@@ -1457,7 +1457,7 @@ For this to work in doctests, one should call
 function find_name(obj, M=Main; all::Bool=false)
   AbstractAlgebra._is_attribute_storing_type(typeof(obj)) || return find_new_name(obj, M; all)
 
-  cached_name = get_attribute(obj, :cached_name)
+  cached_name = get_attribute(obj, :_cached_name)
   if !isnothing(cached_name)
    cached_name_sy = Symbol(cached_name)
     if M === Main && get_current_module() != Main
@@ -1470,7 +1470,7 @@ function find_name(obj, M=Main; all::Bool=false)
     end
   end
   name = find_new_name(obj, M; all)
-  set_attribute!(obj, :cached_name => name)
+  set_attribute!(obj, :_cached_name => name)
   return name
 end
 
@@ -1506,7 +1506,7 @@ This function tries to find a name in the following order:
 """
 function get_name(obj)
   if AbstractAlgebra._is_attribute_storing_type(typeof(obj))
-    name = get_attribute(obj, :name)
+    name = get_attribute(obj, :_name)
     isnothing(name) || return name
   end
 

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1415,7 +1415,7 @@ end
     set_name!(obj; override::Bool=true)
 
 Sets the name of the object `obj` to the name of a variable in global (`Main` module) namespace
-with value bound to the object `obj`, if such a variable exists (see [`AbstractAlgebra.find_name`](@ref)).
+with value bound to the object `obj`, if such a variable exists (see [`AbstractAlgebra.PrettyPrinting.find_name`](@ref)).
 This name is used for printing using [`AbstractAlgebra.@show_name`](@ref).
 If `override` is `false`, the name is only set if there is no name already set.
 
@@ -1501,7 +1501,7 @@ end
 Returns the name of the object `obj` if it is set, or `nothing` otherwise.
 This function tries to find a name in the following order:
 1. The name set by [`AbstractAlgebra.set_name!`](@ref).
-2. The name of a variable in global (`Main` module) namespace with value bound to the object `obj` (see [`AbstractAlgebra.find_name`](@ref)).
+2. The name of a variable in global (`Main` module) namespace with value bound to the object `obj` (see [`AbstractAlgebra.PrettyPrinting.find_name`](@ref)).
 3. The name returned by [`AbstractAlgebra.extra_name`](@ref).
 """
 function get_name(obj)


### PR DESCRIPTION
https://github.com/Nemocas/AbstractAlgebra.jl/pull/1594 defined a new interface but kept everything non-breaking to ease the adaption.
Oscar and Hecke have been adapted in https://github.com/oscar-system/Oscar.jl/pull/3327 and https://github.com/thofma/Hecke.jl/pull/1393 to use the new interface.

This is now the following change, that is technically breaking, but shouldn't need any changes in Hecke and Oscar (let this be verified by CI) due to the earlier adaption.