### PR TITLE
Add `Base.vec(M::MatElem)`

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6789,6 +6789,17 @@ function Base.hvcat(rows::Tuple{Vararg{Int}}, A::MatrixElem{T}...) where T <: NC
   return M
 end
 
+function Base.vec(M::MatElem)
+   r = elem_type(base_ring(M))[]
+   sizehint!(r, nrows(M) * ncols(M))
+   for j=1:ncols(M)
+      for i=1:nrows(M)
+         push!(r, M[i, j])
+      end
+   end
+   return r
+end
+
 ###############################################################################
 #
 #   Change Base Ring

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6789,6 +6789,11 @@ function Base.hvcat(rows::Tuple{Vararg{Int}}, A::MatrixElem{T}...) where T <: NC
   return M
 end
 
+#to bypass the vec(collect(M)) which copies twice
+function Base.vec(M::Generic.Mat)
+  return vec(M.entries)
+end
+
 function Base.vec(M::MatElem)
    r = elem_type(base_ring(M))[]
    sizehint!(r, nrows(M) * ncols(M))


### PR DESCRIPTION
The code originates in https://github.com/oscar-system/Oscar.jl/blob/597398c594796cd2abbd8749977cb3f2a20eefb2/experimental/GModule/GModule.jl#L1451, but I want to use it in other parts of Oscar, that should not depend on experimental. So the cleanest solution is to add it here.
Note that this code currently operates in column-wise fashion (should this be changed?)

To reduce any conflicts in Oscar, it would be easiest to include this in the next breaking release, and then remove the corresponding things in https://github.com/oscar-system/Oscar.jl/blob/597398c594796cd2abbd8749977cb3f2a20eefb2/experimental/GModule/GModule.jl#L1451.