### PR TITLE
chore: Bump to 0.40.0-DEV

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.39.1"
+version = "0.40.0-DEV"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
I already merged something breaking (didn't notice the label), so we should bump the version immediately.