### PR TITLE
fix: remove some unncessary kernel method

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -4101,26 +4101,6 @@ function _kernel(A::MatElem{T}; side::Symbol = :right) where T <: RingElement
    end
 end
  
-################################################################################
-#
-#  Kernel over different rings
-#
-################################################################################
-
-@doc raw"""
-    kernel(A::MatElem{T}; R::Ring, side::Symbol = :right) where T <: RingElement
-
-Return a tuple $(n, M)$, where $n$ is the rank of the kernel of $A$ over $R$ and $M$ is a
-basis for it. If side is `:right` or not specified, the right kernel is
-computed, i.e. the matrix of columns whose span gives the right kernel
-space. If side is `:left`, the left kernel is computed, i.e. the matrix
-of rows whose span is the left kernel space.
-"""
-function kernel(A::MatElem{T}, R::Ring; side::Symbol=:right) where T <: RingElement
-    AR = change_base_ring(R, A)
-    return kernel(AR; side)
-end
-
 ###############################################################################
 #
 #   Hessenberg form

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -283,7 +283,7 @@ function can_solve_with_solution_and_kernel(A::Union{MatElem{T}, SolveCtx{T}}, b
 end
 
 @doc raw"""
-    kernel([R::Ring], A::MatElem; side::Symbol = :left)
+    kernel(A::MatElem; side::Symbol = :left)
     kernel(C::SolveCtx; side::Symbol = :left)
 
 Return a matrix $K$ whose rows generate the left kernel of $A$, that
@@ -294,8 +294,6 @@ is, $AK$ is the zero matrix.
 
 If the base ring is a principal ideal domain, the rows or columns respectively of $K$
 are a basis of the respective kernel.
-
-If a ring $R$ is supplied as a first argument, the kernel is computed over $R$.
 
 If a context object `C` is supplied, then the above applies for `A = matrix(C)`.
 """
@@ -351,11 +349,6 @@ function kernel(C::SolveCtx{<:RingElement}; side::Symbol = :left)
     # X is of type LazyTransposeMatElem
     return data(X)
   end
-end
-
-function kernel(R::Ring, A::MatElem; side::Symbol = :left)
-   AR = change_base_ring(R, A)
-   return kernel(AR; side)
 end
 
 ################################################################################

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -78,17 +78,6 @@
     K = @inferred AbstractAlgebra.Solve.kernel(N, side = :right)
     @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
   end
-
-  M = matrix(ZZ, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
-  K = @inferred AbstractAlgebra.Solve.kernel(QQ, M, side = :right)
-  @test base_ring(K) === QQ
-  @test is_zero(M*K)
-  @test ncols(K) == 2
-
-  K = @inferred AbstractAlgebra.Solve.kernel(QQ, M)
-  @test base_ring(K) === QQ
-  @test is_zero(K*M)
-  @test nrows(K) == 0
 end
 
 @testset "Linear solving context" begin


### PR DESCRIPTION
- the syntax foo(R::Ring, M::Mat) is too valuable to use it only as a
  "shortcut" for foo(R.(M))