### PR TITLE
Use @show_name, @show_special for (M)PolyRing

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -577,6 +577,9 @@ function show(io::IO, ::MIME"text/plain", p::MPolyRing)
 end
 
 function show(io::IO, p::MPolyRing)
+  @show_name(io, p)
+  @show_special(io, p)
+
   if get(io, :supercompact, false)
     # no nested printing
     print(io, "Multivariate polynomial ring")

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -481,6 +481,9 @@ end
 @enable_all_show_via_expressify Union{PolynomialElem, NCPolyRingElem}
 
 function show(io::IO, p::PolyRing)
+   @show_name(io, p)
+   @show_special(io, p)
+
    if get(io, :supercompact, false)
       print(io, "Univariate polynomial ring")
    else


### PR DESCRIPTION
I suspect this will be breaking in the sense that it'll cause mismatches in docstrings.

It might also affect the book?