### PR TITLE
Fix handling of line break characters in a string in pretty printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.40.1"
+version = "0.40.2"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1935,7 +1935,7 @@ function _write_line(io::IOCustom, str::AbstractString)
     written += write_indent(io)
     printstr = join(collect(firstiter)[j:end])
     written += write(io.io, printstr)
-    io.printed += textwidth(printstr)
+    io.printed = textwidth(printstr)
   end
   it = Iterators.partition(1:length(restiter), limit)
   restcollect = collect(restiter)
@@ -1992,6 +1992,7 @@ function write(io::IOCustom, str::String)
   for (i, line) in enumerate(split(str, "\n"))
     if i != 1
       written += write(io.io, "\n")
+      io.printed = 0
       io.indented_line = false
     end
 

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1919,13 +1919,10 @@ function _write_line(io::IOCustom, str::AbstractString)
     printstr = ""
     j = 1
     width = 0
-    while width < (limit)
+    while width < limit && j <= length(partcollect)
       printstr *= partcollect[j]
-      j += 1
       width += textwidth(partcollect[j])
-      if j > length(partcollect)
-        break
-      end
+      j += 1
     end
     written += write(io.io, printstr)
     io.printed += width
@@ -1944,7 +1941,7 @@ function _write_line(io::IOCustom, str::AbstractString)
     partcollect = restcollect[i]
     partstr = join(partcollect)
     width = textwidth(partstr)
-    if width < (limit) || length(i) == width
+    if width < limit || length(i) == width
       written += write(io.io, "\n")
       written += write_indent(io)
       written += write(io.io, partstr)


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3515.

The field `io.printed` should keep track of the width already printed in the current line (indentation is not tracked here).
In two places, a newline char was printed, but the field was not reset to 0.

There is unfortunately no way to test this in a doctest, as all of this linebreaking business is skipped for doctests.

In local testing, this both resolves the MWE in https://github.com/oscar-system/Oscar.jl/issues/3515#issuecomment-1997453137, and the printing issues with `MonomialBasis` (at least those that I could observe locally).

cc @benlorenz @lkastner