### PR TITLE
`is_finiteorder` -> `is_finite_order`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -876,7 +876,7 @@ export is_diagonal
 export is_divisible_by
 export is_domain_type
 export is_exact_type
-export is_finiteorder
+export is_finite_order
 export is_gen
 export is_hermitian
 export is_hessenberg

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,4 +1,5 @@
 # to be deprecated eventually
+@alias is_finiteorder is_finite_order
 
 # added during 0.40.*
 @alias FreeModule free_module

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -47,7 +47,7 @@ function Base.showerror(io::IO, err::InfiniteOrderError{T}) where T
     f = if T <: Group
         "is_finite(G)"
     elseif T <: GroupElem
-        "is_finiteorder(g)"
+        "is_finite_order(g)"
     end
     print(io, "You should check with `$f` first.")
 end
@@ -69,7 +69,7 @@ end
 
 Return the order of $g$ as an instance of `T`.
 If $g$ is of infinite order, an `InfiniteOrderError` exception will be thrown.
-Use `is_finiteorder(G)` to avoid this kind of exception.
+Use `is_finite_order(G)` to avoid this kind of exception.
 If the order does not fit into type `T`, an `InexactError` exception will be thrown.
 """
 function order(::Type{T}, g::GroupElem) where T
@@ -83,13 +83,13 @@ order(g::GroupElem) = _order(g)
 _order(G) = order(BigInt, G)
 
 """
-    is_finiteorder(g::GroupElem)
+    is_finite_order(g::GroupElem)
 
 Return `true` if `g` is of finite order, possibly without computing it.
 """
-function is_finiteorder(g::GroupElem)
+function is_finite_order(g::GroupElem)
     is_finite(parent(g)) && return true
-    throw(NotImplementedError(:is_finiteorder, g))
+    throw(NotImplementedError(:is_finite_order, g))
 end
 
 

--- a/test/Groups-conformance-tests.jl
+++ b/test/Groups-conformance-tests.jl
@@ -180,9 +180,9 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
             @test isone(g) isa Bool
             @test isone(one(g))
 
-            @test is_finiteorder(g) isa Bool
+            @test is_finite_order(g) isa Bool
 
-            if is_finiteorder(g)
+            if is_finite_order(g)
                 @test order(Int16, g) isa Int16
                 @test order(BigInt, g) isa BigInt
                 @test order(g) >= 1


### PR DESCRIPTION
I think `is_finiteorder` is against the naming conventions? While I'm at it: shouldn't it be `has_finite_order`?
