### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+
+[*.jl]
+indent_size = 3
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
Apparently, in AbstractAlgebra its 3 spaces per tab, so this would save me from manually changing my editor settings all the time.
