### PR TITLE
Move FracField methods for concrete type to right place

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -10,12 +10,6 @@
 #
 ###############################################################################
 
-base_ring_type(::Type{FracField{T}}) where T <: RingElem = parent_type(T)
-
-base_ring(a::FracField{T}) where T <: RingElem = a.base_ring::parent_type(T)
-
-parent(a::FracElem) = a.parent
-
 function is_domain_type(::Type{T}) where {S <: RingElement, T <: FracElem{S}}
    return is_domain_type(S)
 end

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -10,9 +10,15 @@
 #
 ###############################################################################
 
+parent(a::FracFieldElem) = a.parent
+
 parent_type(::Type{FracFieldElem{T}}) where T <: RingElem = FracField{T}
 
 elem_type(::Type{FracField{T}}) where {T <: RingElem} = FracFieldElem{T}
+
+base_ring_type(::Type{FracField{T}}) where T <: RingElem = parent_type(T)
+
+base_ring(a::FracField{T}) where T <: RingElem = a.base_ring::parent_type(T)
 
 ###############################################################################
 #


### PR DESCRIPTION
The moved methods were defined for arguments of an *abstract* type
but accessed specific struct fields, which doesn't make sense in
this setting. So instead move them to the file defining the concrete
type, and change them to apply to just that.
