### PR TITLE
Add missing parentheses in stacked printing of univpolys

### DIFF
--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -338,13 +338,11 @@ function show(io::IO, R::UniversalPolyRing)
    show(io, base_ring(R))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", a::UnivPoly)
-   print(io, AbstractAlgebra.obj_to_string(a.p, context = io))
+function expressify(a::UnivPoly, x = symbols(parent(a)); context = nothing)
+   return expressify(a.p, x, context = context)
 end
 
-function Base.show(io::IO, a::UnivPoly)
-   print(io, AbstractAlgebra.obj_to_string(a.p, context = io))
-end
+@enable_all_show_via_expressify UnivPoly
 
 ###############################################################################
 #

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -137,6 +137,19 @@ end
    test_Ring_interface(S)
 end
 
+@testset "Generic.UnivPoly.printing" begin
+   R = universal_polynomial_ring(QQ)
+   x = gen(R, "x")
+   @test sprint(show, x+1) == "x + 1"
+   @test sprint(show, -1 + x^2 - 2x + 1) == "x^2 - 2*x"
+
+   S, y = polynomial_ring(R, "y")
+   @test_broken sprint(show, (x+1)*y) == "(x + 1)*y"
+
+   z = gen(R, "z")
+   @test_broken sprint(show, x*y*(z-1)) == "(x*z - x)*y"
+end
+
 @testset "Generic.UnivPoly.term_monomial" begin
    for R in [ZZ, QQ]
       for iters = 1:100

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -144,10 +144,10 @@ end
    @test sprint(show, -1 + x^2 - 2x + 1) == "x^2 - 2*x"
 
    S, y = polynomial_ring(R, "y")
-   @test_broken sprint(show, (x+1)*y) == "(x + 1)*y"
+   @test sprint(show, (x+1)*y) == "(x + 1)*y"
 
    z = gen(R, "z")
-   @test_broken sprint(show, x*y*(z-1)) == "(x*z - x)*y"
+   @test sprint(show, x*y*(z-1)) == "(x*z - x)*y"
 end
 
 @testset "Generic.UnivPoly.term_monomial" begin


### PR DESCRIPTION
Consider the following example:
```julia
julia> R = universal_polynomial_ring(QQ)
Universal Polynomial Ring over Rationals

julia> x = gen(R, "x")
x

julia> S, y = polynomial_ring(R, "y")
(Univariate polynomial ring in y over universal Polynomial Ring over Rationals, y)

julia> (x+1)*y
x + 1*y
```
The missing parentheses in the last output are clearly misleading, and create an ambiguity between `(x+1)*y` and `x+1*y`.

This PR addresses this issue by replacing the printing of univ polys by using the expressify output of the underlying MPolyRing. This then fixes the recursive call of expressify on the coefficients of the polyring `S`.

Let's hope that this behavior is not doctested downstream and can be released quickly.