### PR TITLE
Add `terse` and `is_terse` helpers, and use them

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -172,3 +172,8 @@ AbstractAlgebra.Dedent
 AbstractAlgebra.Lowercase
 AbstractAlgebra.LowercaseOff
 ```
+
+```@docs
+AbstractAlgebra.terse
+AbstractAlgebra.is_terse
+```

--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -132,10 +132,8 @@ end
 
 function show(io::IO, p::MSeriesRing)
   if is_terse(io)
-    # no nested printing
     print(io, "Multivariate power series ring")
   else
-    # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate power series ring in ", ItemQuantity(nvars(p), "variable"))
     print(terse(io), " over ", Lowercase(), base_ring(p))

--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -131,14 +131,14 @@ function show(io::IO, ::MIME"text/plain", p::MSeriesRing)
 end
 
 function show(io::IO, p::MSeriesRing)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     # no nested printing
     print(io, "Multivariate power series ring")
   else
     # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate power series ring in ", ItemQuantity(nvars(p), "variable"))
-    print(IOContext(io, :supercompact => true), " over ", Lowercase(), base_ring(p))
+    print(terse(io), " over ", Lowercase(), base_ring(p))
   end
 end
 

--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -139,12 +139,12 @@ function show(io::IO, ::MIME"text/plain", a::FracField)
 end
 
 function show(io::IO, a::FracField)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Fraction field")
   else
     io = pretty(io)
     print(io, "Fraction field of ")
-    print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+    print(terse(io), Lowercase(), base_ring(a))
   end
 end
 

--- a/src/FreeAssAlgebra.jl
+++ b/src/FreeAssAlgebra.jl
@@ -77,14 +77,14 @@ function show(io::IO, ::MIME"text/plain", a::FreeAssAlgebra)
 end
 
 function show(io::IO, a::FreeAssAlgebra)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     # no nested printing
     print(io, "Free associative algebra")
   else
     # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Free associative algebra on ", ItemQuantity(nvars(a), "indeterminate"))
-    print(IOContext(io, :supercompact => true), " over ", Lowercase(), base_ring(a))
+    print(terse(io), " over ", Lowercase(), base_ring(a))
   end
 end
 

--- a/src/FreeAssAlgebra.jl
+++ b/src/FreeAssAlgebra.jl
@@ -78,10 +78,8 @@ end
 
 function show(io::IO, a::FreeAssAlgebra)
   if is_terse(io)
-    # no nested printing
     print(io, "Free associative algebra")
   else
-    # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Free associative algebra on ", ItemQuantity(nvars(a), "indeterminate"))
     print(terse(io), " over ", Lowercase(), base_ring(a))

--- a/src/LaurentMPoly.jl
+++ b/src/LaurentMPoly.jl
@@ -51,10 +51,8 @@ end
 
 function show(io::IO, p::LaurentMPolyRing)
   if is_terse(io)
-    # no nested printing
     print(io, "Multivariate Laurent polynomial ring")
   else
-    # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate Laurent polynomial ring in ", ItemQuantity(nvars(p), "variable"))
     print(terse(io), " over ", Lowercase(), base_ring(p))

--- a/src/LaurentMPoly.jl
+++ b/src/LaurentMPoly.jl
@@ -50,14 +50,14 @@ function show(io::IO, ::MIME"text/plain", p::LaurentMPolyRing)
 end
 
 function show(io::IO, p::LaurentMPolyRing)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     # no nested printing
     print(io, "Multivariate Laurent polynomial ring")
   else
     # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate Laurent polynomial ring in ", ItemQuantity(nvars(p), "variable"))
-    print(IOContext(io, :supercompact => true), " over ", Lowercase(), base_ring(p))
+    print(terse(io), " over ", Lowercase(), base_ring(p))
   end
 end
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -578,10 +578,8 @@ end
 
 function show(io::IO, p::MPolyRing)
   if is_terse(io)
-    # no nested printing
     print(io, "Multivariate polynomial ring")
   else
-    # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate polynomial ring in ", ItemQuantity(nvars(p), "variable"))
     print(terse(io), " over ", Lowercase(), base_ring(p))

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -577,14 +577,14 @@ function show(io::IO, ::MIME"text/plain", p::MPolyRing)
 end
 
 function show(io::IO, p::MPolyRing)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     # no nested printing
     print(io, "Multivariate polynomial ring")
   else
     # nested printing allowed, preferably supercompact
     io = pretty(io)
     print(io, "Multivariate polynomial ring in ", ItemQuantity(nvars(p), "variable"))
-    print(IOContext(io, :supercompact => true), " over ", Lowercase(), base_ring(p))
+    print(terse(io), " over ", Lowercase(), base_ring(p))
   end
 end
 

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -24,7 +24,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", M::AbstractAlgebra.Map)
    # the "header" is identical to the supercompact output; this
    # allows other map types to reuse this method
-   println(IOContext(io, :supercompact => true), M)
+   println(terse(io), M)
    io = pretty(io)
    println(io, Indent(), "from ", Lowercase(), domain(M))
    print(io, "to ", Lowercase(), codomain(M), Dedent())
@@ -36,15 +36,15 @@ function show_map_data(io::IO, M::AbstractAlgebra.Map)
 end
 
 function Base.show(io::IO, M::AbstractAlgebra.Map)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Map")
    else
       # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
-      print(IOContext(io, :supercompact => true), Lowercase(), domain(M), " -> ")
-      print(IOContext(io, :supercompact => true), Lowercase(), codomain(M))
+      print(terse(io), Lowercase(), domain(M), " -> ")
+      print(terse(io), Lowercase(), codomain(M))
    end
 end
 

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -37,10 +37,8 @@ end
 
 function Base.show(io::IO, M::AbstractAlgebra.Map)
    if is_terse(io)
-      # no nested printing
       print(io, "Map")
    else
-      # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
       print(terse(io), Lowercase(), domain(M), " -> ")

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -171,13 +171,13 @@ function show(io::IO, ::MIME"text/plain", a::MatRing)
 end
 
 function show(io::IO, a::MatRing)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Matrix ring")
    else
       io = pretty(io)
       print(io, "Matrix ring of ")
       print(io, "degree ", a.n, " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+      print(terse(io), Lowercase(), base_ring(a))
    end
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -716,13 +716,13 @@ function show(io::IO, ::MIME"text/plain", a::MatSpace)
 end
 
 function show(io::IO, a::MatSpace)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Matrix space")
    else
       io = pretty(io)
       print(io, "Matrix space of ")
       print(io, ItemQuantity(nrows(a), "row"), " and ", ItemQuantity(ncols(a), "column"))
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+      print(terse(io), Lowercase(), base_ring(a))
    end
 end
 

--- a/src/ModuleHomomorphism.jl
+++ b/src/ModuleHomomorphism.jl
@@ -19,7 +19,7 @@ matrix(f::Map(FPModuleHomomorphism)) = f.matrix
 ###############################################################################
 
 function show(io::IO, f::Map(FPModuleHomomorphism))
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Module homomorphism")
   else
     io = pretty(io)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -466,12 +466,12 @@ end
 @enable_all_show_via_expressify Union{PolynomialElem, NCPolyRingElem}
 
 function show(io::IO, p::PolyRing)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Univariate polynomial ring")
    else
       io = pretty(io)
       print(io, "Univariate polynomial ring in ", var(p), " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+      print(terse(io), Lowercase(), base_ring(p))
    end
 end
 

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -43,6 +43,7 @@ export get_syntactic_sign_abs
 export indent_string!
 export is_syntactic_one
 export is_syntactic_zero
+export is_terse
 export is_unicode_allowed
 export obj_to_latex_string
 export obj_to_string
@@ -56,6 +57,7 @@ export set_html_as_latex
 export set_name!
 export show_obj
 export show_via_expressify
+export terse
 export with_unicode
 
 
@@ -2111,5 +2113,54 @@ function supercompact(x)
   print(IOContext(io, :supercompact => true), x)
   return String(take!(io))
 end
+
+
+#
+"""
+    terse(io::IO) -> IO
+
+Return a new IO objects derived from `io` for which "supercompact" printing
+mode has been enabled.
+
+See <https://docs.oscar-system.org/stable/DeveloperDocumentation/printing_details/>
+for details.
+
+# Examples
+
+```repl
+julia> AbstractAlgebra.is_terse(stdout)
+false
+
+julia> io = AbstractAlgebra.terse(stdout);
+
+julia> AbstractAlgebra.is_terse(io)
+true
+```
+"""
+terse(io::IO) = IOContext(io, :supercompact => true)
+
+
+"""
+    is_terse(io::IO) -> Bool
+
+Test whether "supercompact" printing mode is enabled for `io`.
+
+See <https://docs.oscar-system.org/stable/DeveloperDocumentation/printing_details/>
+for details.
+
+# Examples
+
+```repl
+julia> AbstractAlgebra.is_terse(stdout)
+false
+
+julia> io = AbstractAlgebra.terse(stdout);
+
+julia> AbstractAlgebra.is_terse(io)
+true
+```
+"""
+is_terse(io::IO) = get(io, :supercompact, false)::Bool
+
 
 end # PrettyPrinting

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -2110,7 +2110,7 @@ end
 
 function supercompact(x)
   io = IOBuffer()
-  print(IOContext(io, :supercompact => true), x)
+  print(terse(io), x)
   return String(take!(io))
 end
 

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -284,12 +284,12 @@ function show(io::IO, ::MIME"text/plain", a::SeriesRing)
 end
 
 function show(io::IO, a::SeriesRing)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Univariate power series ring")
   else
     io = pretty(io)
     print(io, "Univariate power series ring over " )
-    print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+    print(terse(io), Lowercase(), base_ring(a))
   end
 end
 ###############################################################################

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -142,12 +142,12 @@ end
 @enable_all_show_via_expressify ResElem
 
 function show(io::IO, a::ResidueRing)
-   if get(io, :supercompact, false)
+   if is_terse(io)
      print(io, "Residue ring")
    else
      io = pretty(io)
      print(io, "Residue ring of ",)
-     print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+     print(terse(io), Lowercase(), base_ring(a))
      print(io, " modulo ", modulus(a))
    end
 end

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -132,12 +132,12 @@ end
 @enable_all_show_via_expressify ResFieldElem
 
 function show(io::IO, a::ResidueField)
-   if get(io, :supercompact, false)
+   if is_terse(io)
      print(io, "Residue field")
    else
      io = pretty(io)
      print(io, "Residue field of ",)
-     print(IOContext(io, :supercompact => true), Lowercase(), base_ring(a))
+     print(terse(io), Lowercase(), base_ring(a))
      print(io, " modulo ", modulus(a))
    end
 end

--- a/src/algorithms/LaurentPoly.jl
+++ b/src/algorithms/LaurentPoly.jl
@@ -212,12 +212,12 @@ function show(io::IO, ::MIME"text/plain", p::LaurentPolyRing)
 end
 
 function show(io::IO, p::LaurentPolyRing)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Univariate Laurent polynomial ring")
   else
     io = pretty(io)
     print(io, "Univariate Laurent polynomial ring in ", var(p), " over ")
-    print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+    print(terse(io), Lowercase(), base_ring(p))
   end
 end
 

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -44,7 +44,7 @@ summands(M::DirectSumModule{T}) where T <: RingElement = M.m
 ###############################################################################
 
 function show(io::IO, N::DirectSumModule{T}) where T <: RingElement
-   if get(io, :supercompact, false)
+   if is_terse(io)
      io = pretty(io)
      print(io, LowercaseOff(), "DirectSumModule")
    else

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -517,22 +517,22 @@ function Base.show(io::IO, a::LaurentSeriesElem)
 end
 
 function show(io::IO, p::LaurentSeriesRing)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Laurent series ring")
    else
       io = pretty(io)
       print(io, "Laurent series ring in ", var(p), " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+      print(terse(io), Lowercase(), base_ring(p))
    end
 end
 
 function show(io::IO, p::LaurentSeriesField)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Laurent series field")
    else
       io = pretty(io)
       print(io, "Laurent series field in ", var(p), " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+      print(terse(io), Lowercase(), base_ring(p))
    end
 end
 

--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -109,10 +109,8 @@ end
 
 function Base.show(io::IO, M::FunctionalMap)
    if is_terse(io)
-      # no nested printing
       print(io, "Map defined by a Julia function")
    else
-      # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
       print(terse(io), Lowercase(), domain(M), " -> ")

--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -31,7 +31,7 @@ function AbstractAlgebra.show_map_data(io::IO, M::Union{CompositeMap, Functional
 end
 
 function show(io::IO, M::CompositeMap)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Composite map")
    else
@@ -64,7 +64,7 @@ function show(io::IO, ::MIME"text/plain", M::IdentityMap)
 end
 
 function show(io::IO, M::IdentityMap)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Identity map")
    else
@@ -108,15 +108,15 @@ end
 
 
 function Base.show(io::IO, M::FunctionalMap)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Map defined by a Julia function")
    else
       # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
-      print(IOContext(io, :supercompact => true), Lowercase(), domain(M), " -> ")
-      print(IOContext(io, :supercompact => true), Lowercase(), codomain(M))
+      print(terse(io), Lowercase(), domain(M), " -> ")
+      print(terse(io), Lowercase(), codomain(M))
    end
 end
 
@@ -165,7 +165,7 @@ function (f::FunctionalCompositeMap{D, C})(a) where {D, C}
 end
 
 function show(io::IO, M::FunctionalCompositeMap)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Functional composite map")
    else

--- a/src/generic/MapWithInverse.jl
+++ b/src/generic/MapWithInverse.jl
@@ -24,10 +24,8 @@ section_map(f::MapWithSection) = f.section
 
 function Base.show(io::IO, M::MapWithSection)
    if is_terse(io)
-      # no nested printing
       print(io, "Map with section")
    else
-      # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
       print(terse(io), Lowercase(), domain(M), " -> ")
@@ -69,10 +67,8 @@ retraction_map(f::MapCache) = retraction_map(f.map)
 
 function Base.show(io::IO, M::MapWithRetraction)
    if is_terse(io)
-      # no nested printing
       print(io, "Map with retraction")
    else
-      # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
       print(terse(io), Lowercase(), domain(M), " -> ")

--- a/src/generic/MapWithInverse.jl
+++ b/src/generic/MapWithInverse.jl
@@ -23,15 +23,15 @@ section_map(f::MapWithSection) = f.section
 
 
 function Base.show(io::IO, M::MapWithSection)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Map with section")
    else
       # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
-      print(IOContext(io, :supercompact => true), Lowercase(), domain(M), " -> ")
-      print(IOContext(io, :supercompact => true), Lowercase(), codomain(M))
+      print(terse(io), Lowercase(), domain(M), " -> ")
+      print(terse(io), Lowercase(), codomain(M))
    end
 end
 
@@ -68,15 +68,15 @@ retraction_map(f::MapCache) = retraction_map(f.map)
 (f::MapWithRetraction{D, C})(a) where {D, C} = (f.map)(a)::elem_type(C)
 
 function Base.show(io::IO, M::MapWithRetraction)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       # no nested printing
       print(io, "Map with retraction")
    else
       # nested printing allowed, preferably supercompact
       io = pretty(io)
       print(io, "Map: ")
-      print(IOContext(io, :supercompact => true), Lowercase(), domain(M), " -> ")
-      print(IOContext(io, :supercompact => true), Lowercase(), codomain(M))
+      print(terse(io), Lowercase(), domain(M), " -> ")
+      print(terse(io), Lowercase(), codomain(M))
    end
 end
 

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -29,7 +29,7 @@ inverse_image_fn(f::Map(ModuleIsomorphism)) = f.inverse_image_fn
 ###############################################################################
 
 function show(io::IO, f::Map(ModuleIsomorphism))
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Module isomorphism")
   else
     io = pretty(io)

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -313,22 +313,22 @@ function Base.show(io::IO, a::PuiseuxSeriesElem)
 end
 
 function show(io::IO, p::PuiseuxSeriesRing)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Puiseux series ring")
    else
       io = pretty(io)
       print(io, "Puiseux series ring in ", var(laurent_ring(p)), " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+      print(terse(io), Lowercase(), base_ring(p))
    end
 end
 
 function show(io::IO, p::PuiseuxSeriesField)
-   if get(io, :supercompact, false)
+   if is_terse(io)
       print(io, "Puiseux series field")
    else
       io = pretty(io)
       print(io, "Puiseux series field in ", var(laurent_ring(p)), " over ")
-      print(IOContext(io, :supercompact => true), Lowercase(), base_ring(p))
+      print(terse(io), Lowercase(), base_ring(p))
    end
 end
 

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -155,12 +155,12 @@ function show(io::IO, ::MIME"text/plain", a::RationalFunctionField)
 end
 
 function show(io::IO, a::RationalFunctionField)
-  if get(io, :supercompact, false)
+  if is_terse(io)
     # no nested printing
     print(io, "Rational function field")
   else
     io = pretty(io) # we need this to allow printing lowercase
-    print(IOContext(io, :supercompact => true),
+    print(terse(io),
           "Rational function field over ", Lowercase(), base_ring(a))
   end
 end

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -342,13 +342,13 @@ end
   end
 
   function Base.show(io::IO, R::NewRing)
-    if get(io, :supercompact, false)
+    if is_terse(io)
       # no nested printing
       print(io, "supercompact printing of newring ")
     else
       # nested printing allowed, preferably supercompact
       print(io, "one line printing of newring with ")
-      print(IOContext(io, :supercompact => true), "supercompact ", base_ring(R))
+      print(terse(io), "supercompact ", base_ring(R))
     end
   end
 


### PR DESCRIPTION
I deliberately did not yet try to convert any uses of `:compact`, to make this non-breaking.

This will conflict with PR #1671 but so be it, I can rebase that one.