### PR TITLE
Make base_ring_type work for (M)SeriesRing

### DIFF
--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -42,7 +42,7 @@ symbols(R::MSeriesRing) = R.sym
 
 parent(a::MSeriesElem) = a.parent
 
-base_ring_type(::Type{MSeriesRing{T}}) where T <: RingElement = parent_type(T)
+base_ring_type(::Type{<:MSeriesRing{T}}) where T <: RingElement = parent_type(T)
 
 function base_ring(R::MSeriesRing{T}) where T <: RingElement
     return base_ring(poly_ring(R))::parent_type(T)

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -25,7 +25,7 @@ end
 
 parent(a::SeriesElem) = a.parent
 
-base_ring_type(::Type{SeriesRing{T}}) where T <: RingElement = parent_type(T)
+base_ring_type(::Type{<:SeriesRing{T}}) where T <: RingElement = parent_type(T)
 
 base_ring(R::SeriesRing{T}) where T <: RingElement = R.base_ring::parent_type(T)
 

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -33,9 +33,9 @@ elem_type(::Type{LaurentSeriesRing{T}}) where T <: RingElement = LaurentSeriesRi
 
 elem_type(::Type{LaurentSeriesField{T}}) where T <: FieldElement = LaurentSeriesFieldElem{T}
 
-base_ring_type(::Type{<:LaurentSeriesRing{T}}) where T <: RingElement = parent_type(T)
+base_ring_type(::Type{LaurentSeriesRing{T}}) where T <: RingElement = parent_type(T)
 
-base_ring_type(::Type{<:LaurentSeriesField{T}}) where T <: FieldElement = parent_type(T)
+base_ring_type(::Type{LaurentSeriesField{T}}) where T <: FieldElement = parent_type(T)
 
 base_ring(R::LaurentSeriesRing{T}) where T <: RingElement = R.base_ring::parent_type(T)
 

--- a/test/generic/AbsMSeries-test.jl
+++ b/test/generic/AbsMSeries-test.jl
@@ -1,3 +1,12 @@
+function test_elem(R::AbstractAlgebra.Generic.AbsMSeriesRing{BigInt})
+   rand(R, 0:12, -10:10)
+end
+
+@testset "Generic.AbsMSeries.conformance" begin
+   R, (x, y) = power_series_ring(ZZ, [5, 3], ["x", "y"])
+   test_Ring_interface(R)
+end
+
 @testset "Generic.AbsMSeries.constructors" begin
    S, x = polynomial_ring(ZZ, "x")
 

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -16,6 +16,15 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+function test_elem(R::AbstractAlgebra.Generic.AbsPowerSeriesRing{BigInt})
+   rand(R, 0:12, -10:10)
+end
+
+@testset "Generic.AbsSeries.conformance" begin
+   R, x = power_series_ring(ZZ, 30, "x", model=:capped_absolute)
+   test_Ring_interface(R)
+end
+
 @testset "Generic.AbsSeries.types" begin
    @test abs_series_type(BigInt) == Generic.AbsSeries{BigInt}
    @test abs_series_type(Rational{BigInt}) == Generic.AbsSeries{Rational{BigInt}}

--- a/test/generic/FunctionField-test.jl
+++ b/test/generic/FunctionField-test.jl
@@ -11,6 +11,16 @@ U2, z2 = R2["z2"]
 P2 = [(x2 + 1)*z2 + (x2 + 2), z2 + (x2 + 1)//(x2 + 2), z2^2 + 3z2 + 1,
      (x2^2 + 1)//(x2 + 1)*z2^5 + 4z2^4 + (x2 + 2)*z2^3 + x2//(x2 + 1)*z2 + 1//(x2 + 1)]
 
+# FIXME/TODO: conformance tests run into infinite loop???
+#function test_elem(R::AbstractAlgebra.Generic.FunctionField{Rational{BigInt}})
+#   rand(R, 1:10, -10:10)
+#end
+#
+#@testset "Generic.FunctionField.conformance" begin
+#   S, y = function_field(P1[4], "y")
+#   test_Ring_interface(S)
+#end
+
 @testset "Generic.FunctionField.constructors" begin 
    @test function_field(P1[1], "y")[1] === function_field(P1[1], "y", cached=true)[1]
    @test function_field(P1[1], "y", cached=true)[1] !== function_field(P1[1], "y", cached=false)[1]

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -16,6 +16,15 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+function test_elem(R::AbstractAlgebra.Generic.LaurentSeriesRing{BigInt})
+   rand(R, 0:12, -10:10)
+end
+
+@testset "Generic.LaurentSeries.conformance" begin
+   R, x = laurent_series_ring(ZZ, 10, "x")
+   test_Ring_interface(R)
+end
+
 @testset "Generic.LaurentSeries.constructors" begin
    R, x = laurent_series_ring(ZZ, 30, "x")
 

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -16,6 +16,15 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+function test_elem(R::AbstractAlgebra.Generic.PuiseuxSeriesRing{BigInt})
+   rand(R, -12:12, 1:6, -10:10)
+end
+
+@testset "Generic.PuiseuxSeries.conformance" begin
+   R, x = puiseux_series_ring(ZZ, 10, "x")
+   test_Ring_interface(R)
+end
+
 @testset "Generic.PuiseuxSeries.constructors" begin
    R, x = puiseux_series_ring(ZZ, 30, "x")
 

--- a/test/generic/RationalFunctionField-test.jl
+++ b/test/generic/RationalFunctionField-test.jl
@@ -1,3 +1,12 @@
+function test_elem(R::AbstractAlgebra.Generic.RationalFunctionField{Rational{BigInt}})
+   rand(R, 0:3, -3:3)
+end
+
+@testset "Generic.FunctionField.conformance" begin
+   S, x = rational_function_field(QQ, "x")
+   test_Ring_interface(S)
+end
+
 @testset "Generic.RationalFunctionField.constructors" begin
    # Univariate
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -16,6 +16,15 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
+function test_elem(R::AbstractAlgebra.Generic.RelPowerSeriesRing{BigInt})
+   rand(R, 0:12, -10:10)
+end
+
+@testset "Generic.RelSeries.conformance" begin
+   R, x = power_series_ring(ZZ, 10, "x")
+   test_Ring_interface(R)
+end
+
 @testset "Generic.RelSeries.types" begin
    @test rel_series_type(BigInt) == Generic.RelSeries{BigInt}
    @test rel_series_type(Rational{BigInt}) == Generic.RelSeries{Rational{BigInt}}

--- a/test/generic/SparsePoly-test.jl
+++ b/test/generic/SparsePoly-test.jl
@@ -1,3 +1,15 @@
+# FIXME/TODO: get these conformance tests to work and pass
+#function test_elem(Rx::AbstractAlgebra.Generic.SparsePolyRing)
+#   R = base_ring(Rx)
+#   x = gen(Rx)
+#   return sum(x^(5*i) * test_elem(R) for i in 1:rand(0:6); init=zero(Rx))
+#end
+#
+#@testset "Generic.SparsePoly.conformance" begin
+#   R, x = SparsePolynomialRing(ZZ, "x")
+#   test_Ring_interface(R)
+#end
+
 @testset "Generic.SparsePoly.constructors" begin
    R, x = SparsePolynomialRing(ZZ, "x")
    S, y = SparsePolynomialRing(R, "y")


### PR DESCRIPTION
These signatures were wrong but since we run no conformance tests on
these rings we never noticed...

<s>
Of course there should also be tests. But guess what, rings that
we did not conformance tests are not conformant... plus one has
to add `test_elem` methods in order to run the conformance tests.

So let's get this fix out now and add tests later.</s>

UPDATE: Actually it wasn't so bad to get the conformance tests added, I just made a silly mistake earlier. So I added those tests now and a few extra ones as bonus. Problems only pop up with the "recursive" conformance tests, which I therefore skipped. (Several ring types still are not tested for conformance at all.)