### PR TITLE
Add `hash` for SparsePoly

### DIFF
--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -34,6 +34,14 @@ end
 #
 ###############################################################################
 
+function Base.hash(a::SparsePoly, h::UInt)
+  b = 0x679c879b67bb8385%UInt
+  for i in 1:length(a)
+     b = xor(b, hash(a.exps[i], hash(a.coeffs[i], h)))
+  end
+  return b
+end
+
 function coeff(x::SparsePoly, i::Int)
    i < 0 && throw(DomainError(i, "cannot get the i-th coefficient with i < 0"))
    return x.coeffs[i + 1]


### PR DESCRIPTION
Resolves one issue described in https://github.com/Nemocas/AbstractAlgebra.jl/issues/1689.

Note that this still not fulfils the contract that `==` objects have the same hash due to the ad-hoc comparisons to the base ring and to Int etc. But since this is the same case for "normal" polys, I would ignore this.