### PR TITLE
Fixes for SparsePolyRing

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -93,7 +93,6 @@ export SetMap
 export SimpleNumField
 export SimpleNumFieldElem
 export SkewDiagram
-export SparsePolynomialRing
 export Strassen
 export SymmetricGroup
 export UniversalPolyRing

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -458,6 +458,7 @@ end
 ###############################################################################
 
 # Q: Why is SparsePolyRing not a subtype of AbstractAlgebra.PolyRing{T} ?
+# A: It is purely internal, and implementing the interface would make it slower.
 
 @attributes mutable struct SparsePolyRing{T <: RingElement} <: AbstractAlgebra.Ring
    base_ring::Ring

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -34,6 +34,14 @@ end
 #
 ###############################################################################
 
+function Base.hash(a::SparsePoly, h::UInt)
+  b = 0x679c879b67bb8385%UInt
+  for i in 1:length(a)
+     b = xor(b, hash(a.exps[i], hash(a.coeffs[i], h)))
+  end
+  return b
+end
+
 function coeff(x::SparsePoly, i::Int)
    i < 0 && throw(DomainError(i, "cannot get the i-th coefficient with i < 0"))
    return x.coeffs[i + 1]

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -366,6 +366,8 @@ end
 ###############################################################################
 
 function divides(a::SparsePoly{T}, b::SparsePoly{T}) where {T <: RingElement}
+   iszero(a) && return true, zero(parent(a))
+   iszero(b) && return false, parent(a)()
    d1 = a.exps[a.length]
    d2 = b.exps[b.length] - b.exps[1]
    q_alloc = b.length

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -821,6 +821,28 @@ function (a::SparsePolyRing{T})(b::Vector{T}, m::Vector{UInt}) where {T <: RingE
    return z
 end
 
+# Functions to remove ambiguities
+function (a::SparsePolyRing{T})(b::T) where {T <: Integer}
+  parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
+  z = SparsePoly{T}(b)
+  z.parent = a
+  return z
+end
+
+function (a::SparsePolyRing{T})(b::T) where {T <: Rational}
+  parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
+  z = SparsePoly{T}(b)
+  z.parent = a
+  return z
+end
+
+function (a::SparsePolyRing{T})(b::T) where {T <: AbstractFloat}
+  parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
+  z = SparsePoly{T}(b)
+  z.parent = a
+  return z
+end
+
 ###############################################################################
 #
 #   SparsePolynomialRing constructor

--- a/test/generic/SparsePoly-test.jl
+++ b/test/generic/SparsePoly-test.jl
@@ -1,15 +1,3 @@
-# FIXME/TODO: get these conformance tests to work and pass
-#function test_elem(Rx::AbstractAlgebra.Generic.SparsePolyRing)
-#   R = base_ring(Rx)
-#   x = gen(Rx)
-#   return sum(x^(5*i) * test_elem(R) for i in 1:rand(0:6); init=zero(Rx))
-#end
-#
-#@testset "Generic.SparsePoly.conformance" begin
-#   R, x = SparsePolynomialRing(ZZ, "x")
-#   test_Ring_interface(R)
-#end
-
 @testset "Generic.SparsePoly.constructors" begin
    SparsePolynomialRing = AbstractAlgebra.SparsePolynomialRing
 

--- a/test/generic/SparsePoly-test.jl
+++ b/test/generic/SparsePoly-test.jl
@@ -11,6 +11,8 @@
 #end
 
 @testset "Generic.SparsePoly.constructors" begin
+   SparsePolynomialRing = AbstractAlgebra.SparsePolynomialRing
+
    R, x = SparsePolynomialRing(ZZ, "x")
    S, y = SparsePolynomialRing(R, "y")
 
@@ -25,6 +27,8 @@
 end
 
 @testset "Generic.SparsePoly.printing" begin
+   SparsePolynomialRing = AbstractAlgebra.SparsePolynomialRing
+
    R, x = SparsePolynomialRing(ZZ, "x")
 
    @test string(zero(R)) == "0"


### PR DESCRIPTION
Contains and thus closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/1691.

Contents:
- Fixes two of the three issues experienced in https://github.com/Nemocas/AbstractAlgebra.jl/issues/1689
- Fixes some ambiguities that arise in running the tests
- Removes the export `SparsePolynomialRing` (technically breaking)