### PR TITLE
Move aliases for minpoly and charpoly from Oscar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.41.0"
+version = "0.41.1"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -26,11 +26,15 @@ const is_upper_triangular = istriu
 
 
 # predeclare some functions to allow defining aliases for some of our own functions
+function charpoly end
+function minpoly end
 function number_of_columns end
 function number_of_generators end
 function number_of_rows end
 function number_of_variables end
 
+@alias characteristic_polynomial charpoly
+@alias minimal_polynomial minpoly
 @alias ncols number_of_columns
 @alias ngens number_of_generators
 @alias nrows number_of_rows


### PR DESCRIPTION
Since Oscar is not adapted to 0.41 yet, we can move this now easily without getting precompilation errors.