### PR TITLE
Replace most remaining supercompact uses by terse

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -61,7 +61,7 @@ set_attribute!
 We provide macros `@show_name`, `@show_special` and `@show_special_elem` to 
 change the way certain objects are printed.
 
-In compact and supercompact printing mode, `@show_name` tries to determine
+In compact and terse printing mode, `@show_name` tries to determine
 a suitable name to print instead of the object (see [`AbstractAlgebra.get_name`](@ref)).
 
 `@show_special` checks if an attribute `:show` is present. If so, it has to be

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -26,8 +26,10 @@ function check_composable(a::Map, b::Map)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", M::AbstractAlgebra.Map)
-   # the "header" is identical to the supercompact output; this
-   # allows other map types to reuse this method
+   # the "header" printed for most map types is identical: the terse output
+   # followed by "from DOMAIN" and "to CODOMAIN" lines.. We implement this
+   # generically here. If desired, map types can provide a custom
+   # show_map_data method to add additional data after this initial "header".
    println(terse(io), M)
    io = pretty(io)
    println(io, Indent(), "from ", Lowercase(), domain(M))
@@ -36,7 +38,7 @@ function Base.show(io::IO, mime::MIME"text/plain", M::AbstractAlgebra.Map)
 end
 
 function show_map_data(io::IO, M::AbstractAlgebra.Map)
-   # no extra data by default; specific Map subtypes can overload this
+   # no extra data by default; Map subtypes may overload this
 end
 
 function Base.show(io::IO, M::AbstractAlgebra.Map)

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -1566,10 +1566,10 @@ end
 """
     @show_name(io::IO, obj)
 
-If either property `:compact` or `:supercompact` is set to `true` for `io`
+If either `is_terse(io)` is true or property `:compact` is set to `true` for `io`
 (see [`IOContext`](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext)),
-print the name [`get_name(obj)`](@ref AbstractAlgebra.get_name) of the object `obj` to the `io` stream.
-This macro either prints the name and returns from the current scope, or does nothing.
+print the name [`get_name(obj)`](@ref AbstractAlgebra.get_name) of the object `obj` to
+the `io` stream, then return from the current scope. Otherwise, do nothing.
 
 It is supposed to be used at the start of `show` methods as shown in the documentation.
 """
@@ -2086,31 +2086,23 @@ pretty(io::IO; force_newlines = false) = IOCustom(io, force_newlines)
 
 pretty(io::IOContext; force_newlines = false) = io.io isa IOCustom ? io : IOCustom(io, force_newlines)
 
-# helpers for testing the pretty printing
-function detailed(x)
-  io = IOBuffer()
-  show(io, MIME"text/plain"(), x)
-  return String(take!(io))
-end
+# helpers for testing the pretty printing modes
+repr_detailed(x) = repr(MIME"text/plain"(), x)
+repr_oneline(x) = repr(x)
+repr_terse(x) = repr(x, context = :supercompact => true)
 
-function oneline(x)
-  io = IOBuffer()
-  print(io, x)
-  return String(take!(io))
-end
-
-function supercompact(x)
-  io = IOBuffer()
-  print(terse(io), x)
-  return String(take!(io))
-end
+# for backwards compatibility
+# FIXME/TODO: remove these again
+detailed(x) = repr_detailed(x)
+oneline(x) = repr_oneline(x)
+supercompact(x) = repr_terse(x)
 
 
 #
 """
     terse(io::IO) -> IO
 
-Return a new IO objects derived from `io` for which "supercompact" printing
+Return a new IO objects derived from `io` for which "terse" printing
 mode has been enabled.
 
 See <https://docs.oscar-system.org/stable/DeveloperDocumentation/printing_details/>
@@ -2134,7 +2126,7 @@ terse(io::IO) = IOContext(io, :supercompact => true)
 """
     is_terse(io::IO) -> Bool
 
-Test whether "supercompact" printing mode is enabled for `io`.
+Test whether "terse" printing mode is enabled for `io`.
 
 See <https://docs.oscar-system.org/stable/DeveloperDocumentation/printing_details/>
 for details.

--- a/test/PrettyPrinting-test.jl
+++ b/test/PrettyPrinting-test.jl
@@ -344,21 +344,21 @@ end
   function Base.show(io::IO, R::NewRing)
     if PrettyPrinting.is_terse(io)
       # no nested printing
-      print(io, "supercompact printing of newring ")
+      print(io, "terse printing of newring ")
     else
-      # nested printing allowed, preferably supercompact
+      # nested printing allowed, preferably terse
       print(io, "one line printing of newring with ")
-      print(PrettyPrinting.terse(io), "supercompact ", base_ring(R))
+      print(PrettyPrinting.terse(io), "terse ", base_ring(R))
     end
   end
 
   R = NewRing(QQ)
-  @test PrettyPrinting.detailed(R) ==
+  @test PrettyPrinting.repr_detailed(R) ==
         """I am a new ring
            I print with newlines
            Rationals"""
-  @test PrettyPrinting.oneline(R) == "one line printing of newring with supercompact Rationals"
-  @test PrettyPrinting.supercompact(R) == "supercompact printing of newring "
+  @test PrettyPrinting.repr_oneline(R) == "one line printing of newring with terse Rationals"
+  @test PrettyPrinting.repr_terse(R) == "terse printing of newring "
 
   #
   #
@@ -386,26 +386,26 @@ end
   y = """
       Something of type A
         over 2"""
-  @test PrettyPrinting.detailed(x) == y
-  @test PrettyPrinting.oneline(x) == y
-  @test PrettyPrinting.supercompact(x) == y
+  @test PrettyPrinting.repr_detailed(x) == y
+  @test PrettyPrinting.repr_oneline(x) == y
+  @test PrettyPrinting.repr_terse(x) == y
 
   x = A(A(2))
   y = """
       Something of type A
         over something of type A
           over 2"""
-  @test PrettyPrinting.detailed(x) == y
-  @test PrettyPrinting.oneline(x) == y
-  @test PrettyPrinting.supercompact(x) == y
+  @test PrettyPrinting.repr_detailed(x) == y
+  @test PrettyPrinting.repr_oneline(x) == y
+  @test PrettyPrinting.repr_terse(x) == y
 
   x = A(B())
   y = """
       Something of type A
         over Hilbert thing"""
-  @test PrettyPrinting.detailed(x) == y
-  @test PrettyPrinting.oneline(x) == y
-  @test PrettyPrinting.supercompact(x) == y
+  @test PrettyPrinting.repr_detailed(x) == y
+  @test PrettyPrinting.repr_oneline(x) == y
+  @test PrettyPrinting.repr_terse(x) == y
 
 end
 

--- a/test/generic/Map-test.jl
+++ b/test/generic/Map-test.jl
@@ -114,18 +114,18 @@ end
   str = """
         Identity map
           of integers"""
-  @test PrettyPrinting.detailed(id) == str
-  @test PrettyPrinting.oneline(id) == "Identity map of integers"
-  @test PrettyPrinting.supercompact(id) == "Identity map"
+  @test PrettyPrinting.repr_detailed(id) == str
+  @test PrettyPrinting.repr_oneline(id) == "Identity map of integers"
+  @test PrettyPrinting.repr_terse(id) == "Identity map"
 
   u = map_from_func(x -> QQ(x + 1), ZZ, QQ)
   str = """
         Map defined by a Julia function
           from integers
           to rationals"""
-  @test PrettyPrinting.detailed(u) == str
-  @test PrettyPrinting.oneline(u) == "Map: integers -> rationals"
-  @test PrettyPrinting.supercompact(u) == "Map defined by a Julia function"
+  @test PrettyPrinting.repr_detailed(u) == str
+  @test PrettyPrinting.repr_oneline(u) == "Map: integers -> rationals"
+  @test PrettyPrinting.repr_terse(u) == "Map defined by a Julia function"
 
   f = map_from_func(x -> x + 1, ZZ, ZZ)
   g = map_from_func(x -> QQ(x), ZZ, QQ)
@@ -137,9 +137,9 @@ end
         which is the composite of
           Map: integers -> integers
           Map: integers -> rationals"""
-  @test PrettyPrinting.detailed(v) == str
-  @test PrettyPrinting.oneline(v) == "Map: integers -> integers -> rationals"
-  @test PrettyPrinting.supercompact(v) == "Functional composite map"
+  @test PrettyPrinting.repr_detailed(v) == str
+  @test PrettyPrinting.repr_oneline(v) == "Map: integers -> integers -> rationals"
+  @test PrettyPrinting.repr_terse(v) == "Functional composite map"
 
   f = map_from_func(x -> x + 1, ZZ, ZZ)
   s = MyMapMod.MyMap(2)
@@ -151,9 +151,9 @@ end
         which is the composite of
           Map: integers -> integers
           Map: integers -> integers"""
-  @test PrettyPrinting.detailed(t) == str
-  @test PrettyPrinting.oneline(t) == "Map: integers -> integers -> integers"
-  @test PrettyPrinting.supercompact(t) == "Composite map"
+  @test PrettyPrinting.repr_detailed(t) == str
+  @test PrettyPrinting.repr_oneline(t) == "Map: integers -> integers -> integers"
+  @test PrettyPrinting.repr_terse(t) == "Composite map"
 
 end
 

--- a/test/generic/MapWithInverse-test.jl
+++ b/test/generic/MapWithInverse-test.jl
@@ -96,16 +96,16 @@ end
         Map with section
           from integers
           to finite field F_5"""
-  @test PrettyPrinting.detailed(u) == str
-  @test PrettyPrinting.oneline(u) == "Map: integers -> finite field F_5"
-  @test PrettyPrinting.supercompact(u) == "Map with section"
+  @test PrettyPrinting.repr_detailed(u) == str
+  @test PrettyPrinting.repr_oneline(u) == "Map: integers -> finite field F_5"
+  @test PrettyPrinting.repr_terse(u) == "Map with section"
 
   v = map_with_retraction_from_func(x -> QQ(x + 1), x -> ZZ(x - 1), ZZ, QQ)
   str = """
         Map with retraction
           from integers
           to rationals"""
-  @test PrettyPrinting.detailed(v) == str
-  @test PrettyPrinting.oneline(v) == "Map: integers -> rationals"
-  @test PrettyPrinting.supercompact(v) == "Map with retraction"
+  @test PrettyPrinting.repr_detailed(v) == str
+  @test PrettyPrinting.repr_oneline(v) == "Map: integers -> rationals"
+  @test PrettyPrinting.repr_terse(v) == "Map with retraction"
 end

--- a/test/generic/ModuleHomomorphism-test.jl
+++ b/test/generic/ModuleHomomorphism-test.jl
@@ -154,9 +154,9 @@ end
         Module homomorphism
           from free module of rank 2 over integers
           to free module of rank 2 over integers"""
-  @test PrettyPrinting.detailed(f) == str
-  @test PrettyPrinting.oneline(f) == "Hom: free module of rank 2 over integers -> free module of rank 2 over integers"
-  @test PrettyPrinting.supercompact(f) == "Module homomorphism"
+  @test PrettyPrinting.repr_detailed(f) == str
+  @test PrettyPrinting.repr_oneline(f) == "Hom: free module of rank 2 over integers -> free module of rank 2 over integers"
+  @test PrettyPrinting.repr_terse(f) == "Module homomorphism"
 end
 
 @testset "Generic.ModuleIsomorphism" begin
@@ -192,7 +192,7 @@ end
         Module isomorphism
           from free module of rank 2 over integers
           to free module of rank 2 over integers"""
-  @test PrettyPrinting.detailed(f) == str
-  @test PrettyPrinting.oneline(f) == "Hom: free module of rank 2 over integers -> free module of rank 2 over integers"
-  @test PrettyPrinting.supercompact(f) == "Module isomorphism"
+  @test PrettyPrinting.repr_detailed(f) == str
+  @test PrettyPrinting.repr_oneline(f) == "Hom: free module of rank 2 over integers -> free module of rank 2 over integers"
+  @test PrettyPrinting.repr_terse(f) == "Module isomorphism"
 end


### PR DESCRIPTION
We retain the name  `:supercompact` for the IOContext property for now to maximize compatibility while some of our downstream packages still use it.

Moreover, we retain the `PrettyPrinting.supercompact` helper for now as it is used by Nemo.

Also, while replacing a reference to `supercompact` in a comment to the detailed `show` method for maps, I've decided to fully rewrite that comment.


There is one issue with the new `PrettyPrinting.terse` helper which replaces `PrettyPrinting.supercompact`: it has the same name as the function we use to activate terse mode for IO objects... the only impact of this I can think of is that we can't use it to "terse print" IO objects -- which seems perfectly fine by me given that this function is only meant for use in test suites anyway, and we don't have reason to test the "terse printing" of IO objects (and even if we did, one could use a separate helper for that specific use case).

That said, I am open to alternative names -- e.g. `terse_repr` or `repr_terse` (then one should think about using a similar scheme for the `PrettyPrinting.detailed` and `PrettyPrinting.oneline` helpers -- or alternatively consider dropping them as one could just use `repr` directly)