### PR TITLE
Make GroupElem broadcastable

### DIFF
--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -304,3 +304,11 @@ function comm!(out::T, g::T, h::T) where {T<:GroupElem}
     tmp = (out === g) ? conj(g, h) : conj!(out, g, h)
     return div_left!(out, tmp, g)
 end
+
+###############################################################################
+#
+#   Scalar for broadcasting
+#
+###############################################################################
+
+Base.broadcastable(x::GroupElem) = Ref(x)

--- a/test/Groups-conformance-tests.jl
+++ b/test/Groups-conformance-tests.jl
@@ -316,5 +316,13 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
                 g = deepcopy(old_g)
             end
         end
+
+        @testset "Broadcasting" begin
+            @test g .* [g, h] == [g * g, g * h]
+            G = parent(g)
+            if has_gens(G)
+                @test g .* gens(G) == [g * x for x in gens(G)]
+            end
+        end
     end
 end


### PR DESCRIPTION
Replaces and thus closes https://github.com/oscar-system/Oscar.jl/pull/3787.

We already have the analogous thing for NCRingElem, so I see no reason not to have it for GroupElem.

cc @ThomasBreuer 