### PR TITLE
Revert "Fix `@alias` test on nightly (#1612)"

### DIFF
--- a/test/AliasMacro-test.jl
+++ b/test/AliasMacro-test.jl
@@ -1,5 +1,3 @@
-using REPL # needed due to https://github.com/JuliaLang/julia/issues/53349
-
 module Bla
     using AbstractAlgebra
     const sfsdf = 1

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.2"
 Pkg = "1.6"
-REPL = "1.6"
 Test = "1.6"


### PR DESCRIPTION
Reverts #1612.

The underlying issue has been fixed in https://github.com/JuliaLang/julia/pull/54499 and should be available in tomorrows nightly and 1.11.0-beta2.