### PR TITLE
Add and use generic `check_parent` method

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -203,6 +203,12 @@ import .PrettyPrinting: expressify
 #
 ###############################################################################
 
+function check_parent(a, b, throw::Bool = true)
+   flag = parent(a) === parent(b)
+   flag || !throw || error("parents do not match")
+   return flag
+end
+
 include("algorithms/LaurentPoly.jl")
 include("algorithms/FinField.jl")
 include("algorithms/GenericFunctions.jl")

--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -29,12 +29,6 @@ function characteristic(R::FracField{T}) where T <: RingElem
    return characteristic(base_ring(R))
 end
 
-function check_parent(a::FracElem, b::FracElem, throw::Bool = true)
-   fl = parent(a) != parent(b)
-   fl && throw && error("Incompatible rings in fraction field operation")
-   return !fl
-end
-
 @doc raw"""
     vars(a::FracElem{S}) where {S <: MPolyRingElem{<: RingElement}}
 

--- a/src/Module.jl
+++ b/src/Module.jl
@@ -25,10 +25,6 @@ function check_parent(M::FPModule{T}, N::FPModule{T}) where T <: RingElement
    base_ring(M) !== base_ring(N) && error("Incompatible modules")
 end
 
-function check_parent(M::FPModuleElem{T}, N::FPModuleElem{T}) where T <: RingElement
-   parent(M) !== parent(N) && error("Incompatible modules")
-end
-
 is_finite(M::FPModule{<:FinFieldElem}) = true
 
 function is_sub_with_data(M::FPModule{T}, N::FPModule{T}) where T <: RingElement

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -102,12 +102,6 @@ number_of_variables(a::NCPolyRing) = 1
 
 characteristic(a::NCPolyRing) = characteristic(base_ring(a))
 
-function check_parent(a::NCPolyRingElem{T}, b::NCPolyRingElem{T}, throw::Bool = true) where T<:RingElement
-   c = parent(a) != parent(b)
-   c && throw && error("Incompatible polynomial rings in polynomial operation")
-   return !c
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -130,12 +130,6 @@ Base.:\(y::Union{Integer, Rational, AbstractFloat}, x::NCRingElem) = divexact_le
 
 Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 
-function check_parent(a::NCRingElement, b::NCRingElement, throw::Bool=true)
-   c = parent(a) !== parent(b)
-   c && throw && error("Incompatible polynomial rings in polynomial operation")
-   return !c
-end
-
 function zero!(z::NCRingElem)
    return zero(parent(z))
 end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -49,12 +49,6 @@ number_of_variables(a::PolyRing) = 1
 
 characteristic(a::PolyRing) = characteristic(base_ring(a))
 
-function check_parent(a::PolyRingElem{T}, b::PolyRingElem{T}, throw::Bool = true) where T<:RingElement
-   c = parent(a) != parent(b)
-   c && throw && error("Incompatible polynomial rings in polynomial operation")
-   return !c
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -43,12 +43,6 @@ this is returned as a `Symbol` not a `String`.
 """
 var(a::SeriesRing) = a.S
 
-function check_parent(a::SeriesElem, b::SeriesElem, throw::Bool = true)
-   b = parent(a) != parent(b)
-   b && throw && error("Incompatible power series rings in power series operation")
-   return !b
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/algorithms/LaurentPoly.jl
+++ b/src/algorithms/LaurentPoly.jl
@@ -17,13 +17,6 @@ is_domain_type(::Type{<:LaurentPolyRingElem{T}}) where {T} = is_domain_type(T)
 
 is_exact_type(::Type{<:LaurentPolyRingElem{T}}) where {T} = is_exact_type(T)
 
-function check_parent(a::LaurentPolyRingElem, b::LaurentPolyRingElem, throw::Bool = true)
-   c = parent(a) == parent(b)
-   c || !throw || error("incompatible Laurent polynomial rings")
-   return c
-end
-
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -25,13 +25,6 @@ function elem_type(::Type{AbsMSeriesRing{T, S}}) where {T <: RingElement, S}
     return AbsMSeries{T, S}
 end
 
-function check_parent(a::AbsMSeries, b::AbsMSeries, throw::Bool = true)
-    c = parent(a) != parent(b)
-    c && throw &&
-            error("Incompatible multivariate series rings in series operation")
-    return !c
- end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/FreeAssAlgebra.jl
+++ b/src/generic/FreeAssAlgebra.jl
@@ -38,16 +38,6 @@ function length(a::FreeAssAlgElem)
     return a.length
 end
 
-function check_parent(
-    a::FreeAssAlgElem{T},
-    b::FreeAssAlgElem{T},
-    throw::Bool = true,
-) where T <: RingElement
-    b = parent(a) != parent(b)
-    b & throw && error("Incompatible rings in operation")
-    return !b
-end
-
 ###############################################################################
 #
 # Basic manipulation

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -25,10 +25,6 @@ function rels(M::FreeModule{T}) where T <: RingElement
    return Vector{dense_matrix_type(T)}(undef, 0)
 end
 
-function check_parent(m1::FreeModuleElem{T}, m2::FreeModuleElem{T}) where T <: Union{RingElement, NCRingElem}
-    parent(m1) !== parent(m2) && error("Incompatible free modules")
-end
-
 is_free(M::FreeModule) = true
 
 @doc raw"""

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -555,12 +555,6 @@ symbol.
 """
 var(R::FunctionField) = R.S
 
-function check_parent(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}, throw::Bool = true) where T <: FieldElement
-   fl = parent(a) != parent(b)
-   fl && throw && error("Incompatible function fields in function field operation")
-   return !fl
-end
-
 @doc raw"""
     characteristic(R::FunctionField)
 

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -63,12 +63,6 @@ this is returned as a `Symbol` not a `String`.
 """
 var(a::LaurentSeriesField) = a.S
 
-function check_parent(a::LaurentSeriesElem, b::LaurentSeriesElem, throw::Bool = true)
-   b = parent(a) != parent(b)
-   b && throw && error("Incompatible power series rings in Laurent series operation")
-   return !b
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -111,12 +111,6 @@ function internal_ordering(a::MPolyRing{T}) where {T <: RingElement}
    return a.ord
 end
 
-function check_parent(a::MPoly{T}, b::MPoly{T}, throw::Bool = true) where T <: RingElement
-   b = parent(a) != parent(b)
-   b & throw && error("Incompatible polynomial rings in polynomial operation")
-   return !b
-end
-
 ###############################################################################
 #
 #   Manipulating terms and monomials

--- a/src/generic/Misc/Localization.jl
+++ b/src/generic/Misc/Localization.jl
@@ -124,11 +124,6 @@ base_ring(L::LocalizedEuclideanRing) = L.base_ring::base_ring_type(L)
 
 parent(a::LocalizedEuclideanRingElem) = a.parent
 
-function check_parent(a::LocalizedEuclideanRingElem{T}, b::LocalizedEuclideanRingElem{T})  where {T <: RingElem}
-    parent(a) !== parent(b) && error("Parent objects do not match")
-end
-
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -91,12 +91,6 @@ end
 
 is_exact_type(a::Type{T}) where T <: PuiseuxSeriesElem = false
 
-function check_parent(a::PuiseuxSeriesElem, b::PuiseuxSeriesElem, throw::Bool = true)
-   fl = parent(a) != parent(b)
-   fl && throw && error("Incompatible Puiseux series rings in Puiseux series operation")
-   return !fl
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -38,12 +38,6 @@ function characteristic(R::RationalFunctionField)
    return characteristic(base_ring(R))
 end
 
-function check_parent(a::RationalFunctionFieldElem{T, U}, b::RationalFunctionFieldElem{T, U}, throw::Bool = true) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
-   fl = parent(a) != parent(b)
-   fl && throw && error("Incompatible rings in rational function field operation")
-   return !fl
-end
-
 ###############################################################################
 #
 #   Constructors

--- a/src/generic/TotalFraction.jl
+++ b/src/generic/TotalFraction.jl
@@ -38,12 +38,6 @@ function characteristic(R::TotFracRing{T}) where T <: RingElem
    return characteristic(base_ring(R))
 end
 
-function check_parent(a::TotFrac, b::TotFrac, throw::Bool = true)
-   fl = parent(a) != parent(b)
-   fl && throw && error("Incompatible rings in total ring of fractions operation")
-   return !fl
-end
-
 ###############################################################################
 #
 #   Constructors

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -48,12 +48,6 @@ end
 
 internal_ordering(p::UniversalPolyRing) = internal_ordering(mpoly_ring(p))
 
-function check_parent(a::UnivPoly{T, U}, b::UnivPoly{T, U}, throw::Bool = true) where {T <: RingElement, U <: AbstractAlgebra.MPolyRingElem{T}}
-   flag = parent(a) != parent(b)
-   flag & throw && error("Incompatible polynomial rings in polynomial operation")
-   return !flag
-end
-
 ###############################################################################
 #
 #   Manipulating terms and monomials

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -24,10 +24,6 @@ is_exact_type(::Type{GFElem{T}}) where T <: Integer = true
 
 is_domain_type(::Type{GFElem{T}}) where T <: Integer = true
 
-function check_parent(a::GFElem, b::GFElem)
-   a.parent != b.parent && error("Operations on distinct finite fields not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation


### PR DESCRIPTION
Of course some types may still wish to override this, but most `check_parent` implementations really followed the exact same pattern...