### PR TITLE
Remove self-qualified accesses

### DIFF
--- a/src/Map.jl
+++ b/src/Map.jl
@@ -25,7 +25,7 @@ function check_composable(a::Map, b::Map)
    codomain(a) !== domain(b) && error("Incompatible maps")
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", M::AbstractAlgebra.Map)
+function Base.show(io::IO, mime::MIME"text/plain", M::Map)
    # the "header" printed for most map types is identical: the terse output
    # followed by "from DOMAIN" and "to CODOMAIN" lines.. We implement this
    # generically here. If desired, map types can provide a custom
@@ -37,11 +37,11 @@ function Base.show(io::IO, mime::MIME"text/plain", M::AbstractAlgebra.Map)
    show_map_data(io, M)
 end
 
-function show_map_data(io::IO, M::AbstractAlgebra.Map)
+function show_map_data(io::IO, M::Map)
    # no extra data by default; Map subtypes may overload this
 end
 
-function Base.show(io::IO, M::AbstractAlgebra.Map)
+function Base.show(io::IO, M::Map)
    if is_terse(io)
       print(io, "Map")
    else
@@ -53,7 +53,7 @@ function Base.show(io::IO, M::AbstractAlgebra.Map)
    end
 end
 
-Base.broadcastable(M::AbstractAlgebra.Map) = Ref(M)
+Base.broadcastable(M::Map) = Ref(M)
 
 ###############################################################################
 #
@@ -112,7 +112,7 @@ julia> f(t)
 t
 ```
 """
-identity_map(R::D) where D <: AbstractAlgebra.Set = Generic.IdentityMap{D}(R)
+identity_map(R::D) where D <: Set = Generic.IdentityMap{D}(R)
 
 ################################################################################
 #

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -672,8 +672,7 @@ function Base.show(io::IO, a::MatrixElem{T}) where T <: NCRingElement
 end
 
 function Base.show(io::IO, mi::MIME"text/html", a::MatrixElem{T}) where T <: NCRingElement
-   if isdefined(Main, :IJulia) && Main.IJulia.inited &&
-         !AbstractAlgebra.get_html_as_latex()
+   if isdefined(Main, :IJulia) && Main.IJulia.inited && !get_html_as_latex()
       error("Dummy error for jupyter")
    end
    show_via_expressify(io, mi, a)

--- a/src/ModuleHomomorphism.jl
+++ b/src/ModuleHomomorphism.jl
@@ -67,7 +67,7 @@ function kernel(f::Map(FPModuleHomomorphism))
       N = vcat(N, NN)
    end
    # compute the kernel
-   K = AbstractAlgebra.kernel(N)
+   K = kernel(N)
    V = [D(K[j:j, 1:nrows(M)]) for j in 1:nrows(K)]
    return sub(D, V)
 end

--- a/src/generic/FactoredFraction.jl
+++ b/src/generic/FactoredFraction.jl
@@ -53,7 +53,7 @@ function (F::FactoredFracField{T})(a::Rational) where T <: RingElem
     return F(numerator(a), denominator(a))
 end
 
-function (F::FactoredFracField{T})(a::AbstractAlgebra.Generic.FracFieldElem{T}) where T <: RingElement
+function (F::FactoredFracField{T})(a::Generic.FracFieldElem{T}) where T <: RingElement
     base_ring(F) == base_ring(a) || error("Could not coerce into $F")
     return _append_pow!(_make_base_elem(F, numerator(a)), denominator(a), -1)
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -154,7 +154,7 @@ function (a::MatSpace{T})() where {T <: NCRingElement}
 end
 
 # create a matrix with b on the diagonal
-function (a::AbstractAlgebra.Generic.MatSpace)(b::NCRingElement)
+function (a::MatSpace)(b::NCRingElement)
    M = a()  # zero matrix
    R = base_ring(a)
    rb = R(b)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -48,14 +48,14 @@ dense_matrix_type(::Type{T}) where T <: NCRingElement = MatSpaceElem{T}
 
 Return the number of rows of the given matrix space.
 """
-number_of_rows(a::MatSpace) = a.nrows
+number_of_rows(a::Generic.MatSpace) = a.nrows
 
 @doc raw"""
     number_of_columns(a::MatSpace)
 
 Return the number of columns of the given matrix space.
 """
-number_of_columns(a::MatSpace) = a.ncols
+number_of_columns(a::Generic.MatSpace) = a.ncols
 
 number_of_rows(a::Union{Mat, MatRingElem}) = size(a.entries, 1)
 
@@ -149,12 +149,12 @@ end
 ###############################################################################
 
 # create a zero matrix
-function (a::MatSpace{T})() where {T <: NCRingElement}
+function (a::Generic.MatSpace{T})() where {T <: NCRingElement}
    return zero_matrix(base_ring(a), nrows(a), ncols(a))::dense_matrix_type(T)
 end
 
 # create a matrix with b on the diagonal
-function (a::MatSpace)(b::NCRingElement)
+function (a::Generic.MatSpace)(b::NCRingElement)
    M = a()  # zero matrix
    R = base_ring(a)
    rb = R(b)
@@ -165,7 +165,7 @@ function (a::MatSpace)(b::NCRingElement)
 end
 
 # convert a Julia matrix
-function (a::MatSpace{T})(b::AbstractMatrix{S}) where {T <: NCRingElement, S}
+function (a::Generic.MatSpace{T})(b::AbstractMatrix{S}) where {T <: NCRingElement, S}
    _check_dim(nrows(a), ncols(a), b)
    R = base_ring(a)
 
@@ -183,7 +183,7 @@ function (a::MatSpace{T})(b::AbstractMatrix{S}) where {T <: NCRingElement, S}
 end
 
 # convert a Julia vector
-function (a::MatSpace{T})(b::AbstractVector) where T <: NCRingElement
+function (a::Generic.MatSpace{T})(b::AbstractVector) where T <: NCRingElement
    _check_dim(nrows(a), ncols(a), b)
    return a(transpose(reshape(b, a.ncols, a.nrows)))
 end
@@ -199,7 +199,7 @@ function matrix_space(R::AbstractAlgebra.NCRing, r::Int, c::Int; cached::Bool = 
    # (and perhaps future compatibility, in case we need it again)
    (r < 0 || c < 0) && error("Dimensions must be non-negative")
    T = elem_type(R)
-   return MatSpace{T}(R, r, c)
+   return Generic.MatSpace{T}(R, r, c)
 end
 
 function AbstractAlgebra.sub!(A::Mat{T}, B::Mat{T}, C::Mat{T}) where T

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -560,7 +560,7 @@ end
 #
 ###############################################################################
 
-RandomExtensions.maketype(R::AbstractAlgebra.Integers{T}, _) where {T} = T
+RandomExtensions.maketype(R::Integers{T}, _) where {T} = T
 
 # define rand(make(ZZ, n:m))
 rand(rng::AbstractRNG,


### PR DESCRIPTION
Some refactoring found using ExplicitImports.jl

In most cases, the removed qualification was used inconsistently in the surrounding code anyway. 