### PR TITLE
new: matrix(::NCRing, ::MatSpaceElem)

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6444,7 +6444,7 @@ function matrix(R::NCRing, arr::AbstractMatrix{T}) where {T}
 end
 
 function matrix(R::NCRing, arr::MatElem)
-    return map_entries(R,arr)
+    return map_entries(R, arr)
 end
 
 function matrix(arr::AbstractMatrix{T}) where {T<:NCRingElem}

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6443,6 +6443,10 @@ function matrix(R::NCRing, arr::AbstractMatrix{T}) where {T}
    end
 end
 
+function matrix(R::NCRing, arr::MatElem)
+    return map_entries(R,arr)
+end
+
 function matrix(arr::AbstractMatrix{T}) where {T<:NCRingElem}
    r, c = size(arr)
    (r < 0 || c < 0) && error("Array must be non-empty")

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -325,6 +325,7 @@ end
 
    M = matrix(ZZ, M1)
    N = matrix(ZZ, N1)
+   K = matrix(ZZ, K1)
 
    @test matrix(ZZ, M) == M
    @test matrix(ZZ, N) == N

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -326,8 +326,8 @@ end
    M = matrix(ZZ, M1)
    N = matrix(ZZ, N1)
 
-   @test matrix(ZZ, M1) == M1
-   @test matrix(ZZ, N1) == N1
+   @test matrix(ZZ, M) == M
+   @test matrix(ZZ, N) == N
 
    @test block_diagonal_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
    @test block_diagonal_matrix([K]) == matrix(ZZ, 2, 0, [])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -325,7 +325,9 @@ end
 
    M = matrix(ZZ, M1)
    N = matrix(ZZ, N1)
-   K = matrix(ZZ, K1)
+
+   @test matrix(ZZ,M1) == M1
+   @test matrix(ZZ,N1) == N1
 
    @test block_diagonal_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
    @test block_diagonal_matrix([K]) == matrix(ZZ, 2, 0, [])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -326,7 +326,7 @@ end
    M = matrix(ZZ, M1)
    N = matrix(ZZ, N1)
 
-   @test matrix(ZZ,M1) == M1
+   @test matrix(ZZ, M1) == M1
    @test matrix(ZZ, N1) == N1
 
    @test block_diagonal_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -327,7 +327,7 @@ end
    N = matrix(ZZ, N1)
 
    @test matrix(ZZ,M1) == M1
-   @test matrix(ZZ,N1) == N1
+   @test matrix(ZZ, N1) == N1
 
    @test block_diagonal_matrix([M, N, K]) == matrix(ZZ, [1 2 0 0 0; 3 4 0 0 0; 0 0 5 6 7; 0 0 8 9 10; 0 0 0 0 0; 0 0 0 0 0])
    @test block_diagonal_matrix([K]) == matrix(ZZ, 2, 0, [])


### PR DESCRIPTION
Not sure whether the implementation is okay, but it would be very useful if `matrix(_, _)` would accept a `MatSpaceElem` as second argument:

```
using AbstractAlgebra
R,_ = polynomial_ring(QQ,2)
M = [one(R) one(R); one(R) one(R)]
M = matrix(R,M)
M = matrix(R,M) # this currently does not work
```

I generally convert all matrices into `MatSpaceElem`s to avoid problems such as  https://github.com/Nemocas/AbstractAlgebra.jl/issues/1730,  and `matrix(_, _)` is my go-to method for doing so.