### PR TITLE
Use type traits in linear solving

### DIFF
--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -1238,18 +1238,6 @@ function _kernel_of_howell_form(A::MatElem{T}, H::MatElem{T}) where T <: RingEle
   return N
 end
 
-# Copied from Hecke, to be replaced with echelon_form_with_transformation eventually
-# Only used by Nemo
-function _rref_with_transformation(M::MatElem{T}) where T <: FieldElement
-  n = hcat(deepcopy(M), identity_matrix(base_ring(M), nrows(M)))
-  rref!(n)
-  s = nrows(n)
-  while s > 0 && iszero(sub(n, s:s, 1:ncols(M)))
-    s -= 1
-  end
-  return s, sub(n, 1:nrows(M), 1:ncols(M)), sub(n, 1:nrows(M), ncols(M)+1:ncols(n))
-end
-
 ################################################################################
 #
 #  Checks

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -765,6 +765,7 @@ end
 function _can_solve_internal(NF::MatrixNormalFormTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::Vector{T}, task::Symbol; side::Symbol = :left) where T
   check_option(task, [:only_check, :with_solution, :with_kernel], "task")
   check_option(side, [:right, :left], "side")
+  @assert all(x -> parent(x) === base_ring(A), b) "Base rings do not match"
 
   isright = side === :right
 
@@ -788,6 +789,8 @@ end
 function _can_solve_internal(NF::MatrixNormalFormTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where T
   check_option(task, [:only_check, :with_solution, :with_kernel], "task")
   check_option(side, [:right, :left], "side")
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
+
   if side === :right
     check_linear_system_dim_right(A, b)
   else

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -225,7 +225,9 @@ end
 matrix_normal_form_type(C::SolveCtx) = matrix_normal_form_type(base_ring(C))
 
 # Overwrite RREFTrait for fields
-matrix_normal_form_type(C::SolveCtx{<:FieldElement}) = LUTrait()
+matrix_normal_form_type(::SolveCtx{<:FieldElement}) = LUTrait()
+# Set it back for fraction fields
+matrix_normal_form_type(::SolveCtx{<:Union{FracElem, Rational{BigInt}}}) = FFLUTrait()
 
 matrix(C::SolveCtx) = C.A
 

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -692,8 +692,6 @@ end
 function kernel(::RREFTrait, C::SolveCtx; side::Symbol = :left)
   check_option(side, [:right, :left], "side")
 
-  # I don't know how to compute the kernel using a LU factoring, so we call the
-  # "usual" method
   if side === :right
     if !isdefined(C, :kernel_right)
       C.kernel_right = kernel(RREFTrait(), matrix(C), side = :right)

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -206,6 +206,12 @@ function solve_init(NF::MatrixNormalFormTrait, A::MatElem)
   return solve_context_type(NF, base_ring(A))(A)
 end
 
+# For a ring R, the following signatures of `solve_context_type` need to be
+# implemented:
+# 1) solve_context_type(R)
+# 2) solve_context_type(::MatrixNormalFormTrait, elem_type(R))
+# Version 1 should pick a matrix_normal_form_type and call 2
+
 function solve_context_type(R::NCRing)
   return solve_context_type(matrix_normal_form_type(R), elem_type(R))
 end

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -859,10 +859,6 @@ function _can_solve_internal(::NFTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::Ma
 end
 
 # Catch non-matching normal forms in solve context
-function _can_solve_internal_no_check(::NFTrait, C::SolveCtx{T, NFTrait2}, b::Vector{T}, task::Symbol; side::Symbol = :left) where {T, NFTrait <: MatrixNormalFormTrait, NFTrait2 <: MatrixNormalFormTrait}
-  error("Cannot use normal form of type $NFTrait with solve context of type $NFTrait2")
-end
-
 function _can_solve_internal_no_check(::NFTrait, C::SolveCtx{T, NFTrait2}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where {T, NFTrait <: MatrixNormalFormTrait, NFTrait2 <: MatrixNormalFormTrait}
   error("Cannot use normal form of type $NFTrait with solve context of type $NFTrait2")
 end

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -599,6 +599,9 @@ end
 function kernel(::FFLUTrait, A::Union{MatElem, SolveCtx}; side::Symbol = :left)
   return kernel(RREFTrait(), A; side)
 end
+function kernel(::MatrixInterpolateTrait, A::Union{MatElem, SolveCtx}; side::Symbol = :left)
+  return kernel(RREFTrait(), A; side)
+end
 
 function kernel(NF::RREFTrait, A::MatElem; side::Symbol = :left)
   check_option(side, [:right, :left], "side")
@@ -1079,6 +1082,10 @@ function _can_solve_internal_no_check(::MatrixInterpolateTrait, A::MatElem{T}, b
     flag, sol_int, den = _can_solve_with_solution_interpolation(Aint, bint)
   catch
     flag, sol_int, den = _can_solve_with_solution_fflu(Aint, bint)
+  end
+
+  if !flag
+    return flag, zero_matrix(base_ring(A), 0, 0), zero(b, 0, 0)
   end
 
   sol = change_base_ring(base_ring(A), sol_int)

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -783,13 +783,13 @@ end
 
 # We can't compute a kernel using a LU/FFLU factoring, so we have to fall back to RREF
 
-function kernel(::LUTrait, A::Union{MatElem, SolveCtx{T, LUTrait}}; side::Symbol = :left) where T
+function kernel(::LUTrait, A::Union{MatElem, SolveCtx{<: NCRingElement, LUTrait}}; side::Symbol = :left)
   return kernel(RREFTrait(), A; side)
 end
-function kernel(::FFLUTrait, A::Union{MatElem, SolveCtx{T, FFLUTrait}}; side::Symbol = :left) where T
+function kernel(::FFLUTrait, A::Union{MatElem, SolveCtx{<: NCRingElement, FFLUTrait}}; side::Symbol = :left)
   return kernel(RREFTrait(), A; side)
 end
-function kernel(::MatrixInterpolateTrait, A::Union{MatElem, SolveCtx{T, MatrixInterpolateTrait}}; side::Symbol = :left) where T
+function kernel(::MatrixInterpolateTrait, A::Union{MatElem, SolveCtx{<: NCRingElement, MatrixInterpolateTrait}}; side::Symbol = :left)
   return kernel(RREFTrait(), A; side)
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -113,6 +113,7 @@ export addeq!
 export addmul!
 export addmul_delayed_reduction!
 export allow_unicode
+export annihilator
 export base_field
 export base_ring
 export base_ring_type

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -15,6 +15,12 @@
   @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, [ R(1), R(2), R(3) ], side = :test)
   @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
 
+  if R isa AbstractAlgebra.GFField
+    RR = GF(2)
+    @test_throws AssertionError solve(M, [ RR(1), RR(2), RR(3) ])
+    @test_throws AssertionError solve(M, matrix(RR, 3, 1, [1, 2, 3]))
+  end
+
   for b in [ [ R(1), R(2), R(3) ],
              matrix(R, 3, 1, [ R(1), R(2), R(3) ]),
              matrix(R, 3, 2, [ R(1), R(2), R(3), R(4), R(5), R(6) ]) ]
@@ -102,6 +108,12 @@ end
   @test_throws ErrorException AbstractAlgebra.Solve.solve(C, matrix(R, 1, 1, [ R(1) ]), side = :right)
   @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, [ R(1), R(2), R(3) ], side = :test)
   @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
+
+  if R isa AbstractAlgebra.GFField
+    RR = GF(2)
+    @test_throws AssertionError solve(C, [ RR(1), RR(2), RR(3) ])
+    @test_throws AssertionError solve(C, matrix(RR, 3, 1, [1, 2, 3]))
+  end
 
   for b in [ [ R(1), R(2), R(3) ],
              matrix(R, 3, 1, [ R(1), R(2), R(3) ]),

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -210,11 +210,12 @@ end
   @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, [R(1), R(2), R(3), R(4), R(5)])
   @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, matrix(R, 1, 5, [1, 2, 3, 4, 5]))
 
-  # This should work
+  # This should work because we use RREFTrait for the kernel if C uses LUTrait
+  # for solving
   K = kernel(AbstractAlgebra.Solve.RREFTrait(), C)
   @test nrows(K) == 0
 
-  # This should not
+  # This should not work if C uses LUTrait
   @test_throws ErrorException kernel(AbstractAlgebra.Solve.HermiteFormTrait(), C)
 end
 

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -187,6 +187,14 @@ end
   @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
 end
 
+@testset "Linear solving context with non-default normal form" begin
+  R = GF(101)
+  M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
+  C = solve_init(M)
+  @test_throws AssertionError solve(AbstractAlgebra.Solve.RREFTrait(), C, [R(1), R(2), R(3)])
+  @test_throws AssertionError solve(AbstractAlgebra.Solve.RREFTrait(), C, matrix(R, 1, 3, [1, 2, 3]))
+end
+
 @testset "Lazy transpose" begin
   M = matrix(QQ, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   MT = AbstractAlgebra.Solve.lazy_transpose(M)

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -1,5 +1,5 @@
 @testset "Linear solving" begin
-  for R in [ QQ, ZZ, GF(101) ]
+  for R in [ QQ, ZZ, GF(101), residue_ring(ZZ, 16)[1] ]
     M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
 
     @test_throws ErrorException AbstractAlgebra.Solve.solve(M, [ R(1) ])
@@ -82,7 +82,7 @@ end
 
 @testset "Linear solving context" begin
   # QQ, ring, field, fraction field different from QQ to test different implementations
-  for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]) ]
+  for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
     M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
     C = AbstractAlgebra.Solve.solve_init(M)
 

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -91,18 +91,32 @@
   @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
 end
 
-@testset "Linear solving context over $R" for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
+@testset "Linear solving context over $R with $NFTrait" for (R, NFTrait, is_default) in [
+    (QQ, AbstractAlgebra.Solve.FFLUTrait, true),
+    (ZZ, AbstractAlgebra.Solve.HermiteFormTrait, true),
+    (GF(101), AbstractAlgebra.Solve.LUTrait, true),
+    (GF(101), AbstractAlgebra.Solve.RREFTrait, false),
+    (fraction_field(QQ["x"][1]), AbstractAlgebra.Solve.FFLUTrait, true),
+    (residue_ring(ZZ, 16)[1], AbstractAlgebra.Solve.HowellFormTrait, true)
+   ]
   M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
-  C = AbstractAlgebra.Solve.solve_init(M)
 
-  @test C isa AbstractAlgebra.solve_context_type(R)
-  @test C isa AbstractAlgebra.solve_context_type(M)
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), elem_type(R))
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), R(1))
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), typeof(R))
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), R)
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), typeof(M))
-  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), M)
+  if is_default
+    C = solve_init(M)
+    @test AbstractAlgebra.Solve.matrix_normal_form_type(C) === NFTrait()
+    @test C isa AbstractAlgebra.solve_context_type(R)
+    @test C isa AbstractAlgebra.solve_context_type(M)
+  end
+
+  C = solve_init(NFTrait(), M)
+
+  @test AbstractAlgebra.Solve.matrix_normal_form_type(C) === NFTrait()
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), elem_type(R))
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), R(1))
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), typeof(R))
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), R)
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), typeof(M))
+  @test C isa AbstractAlgebra.solve_context_type(NFTrait(), M)
 
   @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ])
   @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ], side = :right)

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -95,12 +95,14 @@ end
   M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = AbstractAlgebra.Solve.solve_init(M)
 
-  @test C isa AbstractAlgebra.solve_context_type(elem_type(R))
-  @test C isa AbstractAlgebra.solve_context_type(zero(R))
-  @test C isa AbstractAlgebra.solve_context_type(typeof(R))
   @test C isa AbstractAlgebra.solve_context_type(R)
-  @test C isa AbstractAlgebra.solve_context_type(typeof(M))
   @test C isa AbstractAlgebra.solve_context_type(M)
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), elem_type(R))
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), R(1))
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), typeof(R))
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), R)
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), typeof(M))
+  @test C isa AbstractAlgebra.solve_context_type(AbstractAlgebra.Solve.matrix_normal_form_type(C), M)
 
   @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ])
   @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ], side = :right)
@@ -191,8 +193,8 @@ end
   R = GF(101)
   M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(M)
-  @test_throws AssertionError solve(AbstractAlgebra.Solve.RREFTrait(), C, [R(1), R(2), R(3)])
-  @test_throws AssertionError solve(AbstractAlgebra.Solve.RREFTrait(), C, matrix(R, 1, 3, [1, 2, 3]))
+  @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, [R(1), R(2), R(3), R(4), R(5)])
+  @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, matrix(R, 1, 5, [1, 2, 3, 4, 5]))
 end
 
 @testset "Lazy transpose" begin

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -209,6 +209,13 @@ end
   C = solve_init(M)
   @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, [R(1), R(2), R(3), R(4), R(5)])
   @test_throws ErrorException solve(AbstractAlgebra.Solve.RREFTrait(), C, matrix(R, 1, 5, [1, 2, 3, 4, 5]))
+
+  # This should work
+  K = kernel(AbstractAlgebra.Solve.RREFTrait(), C)
+  @test nrows(K) == 0
+
+  # This should not
+  @test_throws ErrorException kernel(AbstractAlgebra.Solve.HermiteFormTrait(), C)
 end
 
 @testset "Lazy transpose" begin

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -85,7 +85,7 @@
   @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
 end
 
-@testset "Linear solving over $R" for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
+@testset "Linear solving context over $R" for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
   M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = AbstractAlgebra.Solve.solve_init(M)
 

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -1,176 +1,178 @@
-@testset "Linear solving" begin
-  for R in [ QQ, ZZ, GF(101), residue_ring(ZZ, 16)[1] ]
-    M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
+# We test everything over the following rings
+# * GF(101) -> uses RREFTrait or LUTrait
+# * QQ -> uses FFLUTrait
+# * ZZ -> uses HermiteFormTrait
+# * residue_ring(ZZ, 16) -> uses HowellFormTrait
+# * fraction_field(QQ["x"][1]) -> uses MatrixInterpolateTrait
 
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(M, [ R(1) ])
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(M, [ R(1) ], side = :right)
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(M, matrix(R, 1, 1, [ R(1) ]))
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(M, matrix(R, 1, 1, [ R(1) ]), side = :right)
-    @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, [ R(1), R(2), R(3) ], side = :test)
-    @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
+@testset "Linear solving over $R" for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
+  M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
 
-    for b in [ [ R(1), R(2), R(3) ],
-               matrix(R, 3, 1, [ R(1), R(2), R(3) ]),
-               matrix(R, 3, 2, [ R(1), R(2), R(3), R(4), R(5), R(6) ]) ]
-      @test @inferred AbstractAlgebra.Solve.can_solve(M, b, side = :right)
-      x = @inferred AbstractAlgebra.Solve.solve(M, b, side = :right)
-      @test M*x == b
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b, side = :right)
-      @test fl
-      @test M*x == b
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b, side = :right)
-      @test fl
-      @test M*x == b
-      @test is_zero(M*K)
-      @test ncols(K) == 2
-      K = @inferred AbstractAlgebra.Solve.kernel(M, side = :right)
-      @test is_zero(M*K)
-      @test ncols(K) == 2
-    end
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(M, [ R(1) ])
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(M, [ R(1) ], side = :right)
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(M, matrix(R, 1, 1, [ R(1) ]))
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(M, matrix(R, 1, 1, [ R(1) ]), side = :right)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, [ R(1), R(2), R(3) ], side = :test)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
 
-    for b in [ [ R(1), R(1), R(1), R(1), R(1) ],
-               matrix(R, 1, 5, [ R(1), R(1), R(1), R(1), R(1) ]),
-               matrix(R, 2, 5, [ R(1), R(1), R(1), R(1), R(1),
-                                 R(1), R(1), R(1), R(1), R(1) ]) ]
-      @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, b)
-      @test @inferred !AbstractAlgebra.Solve.can_solve(M, b)
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b)
-      @test !fl
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b)
-      @test !fl
-    end
-
-    for b in [ [ R(1), R(2), R(3), R(4), R(5) ],
-               matrix(R, 1, 5, [ R(1), R(2), R(3), R(4), R(5)]),
-               matrix(R, 2, 5, [ R(1), R(2), R(3), R(4), R(5),
-                                 R(0), R(0), R(8), R(9), R(10) ]) ]
-      @test @inferred AbstractAlgebra.Solve.can_solve(M, b)
-      x = @inferred AbstractAlgebra.Solve.solve(M, b)
-      @test x*M == b
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b)
-      @test fl
-      @test x*M == b
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b)
-      @test fl
-      @test x*M == b
-      @test is_zero(K*M)
-      @test nrows(K) == 0
-      K = @inferred AbstractAlgebra.Solve.kernel(M)
-      @test is_zero(K*M)
-      @test nrows(K) == 0
-    end
-
-    N = zero_matrix(R, 2, 1)
-    b = zeros(R, 2)
-    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
+  for b in [ [ R(1), R(2), R(3) ],
+             matrix(R, 3, 1, [ R(1), R(2), R(3) ]),
+             matrix(R, 3, 2, [ R(1), R(2), R(3), R(4), R(5), R(6) ]) ]
+    @test @inferred AbstractAlgebra.Solve.can_solve(M, b, side = :right)
+    x = @inferred AbstractAlgebra.Solve.solve(M, b, side = :right)
+    @test M*x == b
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b, side = :right)
     @test fl
-    @test N*x == b
-    @test K == identity_matrix(R, 1)
-    K = @inferred AbstractAlgebra.Solve.kernel(N, side = :right)
-    @test K == identity_matrix(R, 1)
-
-    N = zero_matrix(R, 1, 2)
-    b = zeros(R, 1)
-    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
+    @test M*x == b
+    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b, side = :right)
     @test fl
-    @test N*x == b
-    @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
-    K = @inferred AbstractAlgebra.Solve.kernel(N, side = :right)
-    @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
+    @test M*x == b
+    @test is_zero(M*K)
+    @test ncols(K) == 2
+    K = @inferred AbstractAlgebra.Solve.kernel(M, side = :right)
+    @test is_zero(M*K)
+    @test ncols(K) == 2
   end
+
+  for b in [ [ R(1), R(1), R(1), R(1), R(1) ],
+             matrix(R, 1, 5, [ R(1), R(1), R(1), R(1), R(1) ]),
+             matrix(R, 2, 5, [ R(1), R(1), R(1), R(1), R(1),
+                               R(1), R(1), R(1), R(1), R(1) ]) ]
+    @test_throws ArgumentError AbstractAlgebra.Solve.solve(M, b)
+    @test @inferred !AbstractAlgebra.Solve.can_solve(M, b)
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b)
+    @test !fl
+    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b)
+    @test !fl
+  end
+
+  for b in [ [ R(1), R(2), R(3), R(4), R(5) ],
+             matrix(R, 1, 5, [ R(1), R(2), R(3), R(4), R(5)]),
+             matrix(R, 2, 5, [ R(1), R(2), R(3), R(4), R(5),
+                               R(0), R(0), R(8), R(9), R(10) ]) ]
+    @test @inferred AbstractAlgebra.Solve.can_solve(M, b)
+    x = @inferred AbstractAlgebra.Solve.solve(M, b)
+    @test x*M == b
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(M, b)
+    @test fl
+    @test x*M == b
+    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(M, b)
+    @test fl
+    @test x*M == b
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+    K = @inferred AbstractAlgebra.Solve.kernel(M)
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+  end
+
+  N = zero_matrix(R, 2, 1)
+  b = zeros(R, 2)
+  fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(R, 1)
+  K = @inferred AbstractAlgebra.Solve.kernel(N, side = :right)
+  @test K == identity_matrix(R, 1)
+
+  N = zero_matrix(R, 1, 2)
+  b = zeros(R, 1)
+  fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
+  K = @inferred AbstractAlgebra.Solve.kernel(N, side = :right)
+  @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
 end
 
-@testset "Linear solving context" begin
-  # QQ, ring, field, fraction field different from QQ to test different implementations
-  for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
-    M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
-    C = AbstractAlgebra.Solve.solve_init(M)
+@testset "Linear solving over $R" for R in [ QQ, ZZ, GF(101), fraction_field(QQ["x"][1]), residue_ring(ZZ, 16)[1] ]
+  M = matrix(R, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
+  C = AbstractAlgebra.Solve.solve_init(M)
 
-    @test C isa AbstractAlgebra.solve_context_type(elem_type(R))
-    @test C isa AbstractAlgebra.solve_context_type(zero(R))
-    @test C isa AbstractAlgebra.solve_context_type(typeof(R))
-    @test C isa AbstractAlgebra.solve_context_type(R)
-    @test C isa AbstractAlgebra.solve_context_type(typeof(M))
-    @test C isa AbstractAlgebra.solve_context_type(M)
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(R))
+  @test C isa AbstractAlgebra.solve_context_type(zero(R))
+  @test C isa AbstractAlgebra.solve_context_type(typeof(R))
+  @test C isa AbstractAlgebra.solve_context_type(R)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(M))
+  @test C isa AbstractAlgebra.solve_context_type(M)
 
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ])
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ], side = :right)
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(C, matrix(R, 1, 1, [ R(1) ]))
-    @test_throws ErrorException AbstractAlgebra.Solve.solve(C, matrix(R, 1, 1, [ R(1) ]), side = :right)
-    @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, [ R(1), R(2), R(3) ], side = :test)
-    @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ])
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(C, [ R(1) ], side = :right)
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(C, matrix(R, 1, 1, [ R(1) ]))
+  @test_throws ErrorException AbstractAlgebra.Solve.solve(C, matrix(R, 1, 1, [ R(1) ]), side = :right)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, [ R(1), R(2), R(3) ], side = :test)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, matrix(R, 3, 1, [ R(1), R(2), R(3) ]), side = :test)
 
-    for b in [ [ R(1), R(2), R(3) ],
-               matrix(R, 3, 1, [ R(1), R(2), R(3) ]),
-               matrix(R, 3, 2, [ R(1), R(2), R(3), R(4), R(5), R(6) ]) ]
-      @test @inferred AbstractAlgebra.Solve.can_solve(C, b, side = :right)
-      x = @inferred AbstractAlgebra.Solve.solve(C, b, side = :right)
-      @test M*x == b
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b, side = :right)
-      @test fl
-      @test M*x == b
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
-      @test fl
-      @test M*x == b
-      @test is_zero(M*K)
-      @test ncols(K) == 2
-      K = @inferred AbstractAlgebra.Solve.kernel(C, side = :right)
-      @test is_zero(M*K)
-      @test ncols(K) == 2
-    end
-
-    for b in [ [ R(1), R(1), R(1), R(1), R(1) ],
-               matrix(R, 1, 5, [ R(1), R(1), R(1), R(1), R(1) ]),
-               matrix(R, 2, 5, [ R(1), R(1), R(1), R(1), R(1),
-                                 R(1), R(1), R(1), R(1), R(1) ]) ]
-      @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, b)
-      @test @inferred !AbstractAlgebra.Solve.can_solve(C, b)
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b)
-      @test !fl
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
-      @test !fl
-    end
-
-    for b in [ [ R(1), R(2), R(3), R(4), R(5) ],
-               matrix(R, 1, 5, [ R(1), R(2), R(3), R(4), R(5)]),
-               matrix(R, 2, 5, [ R(1), R(2), R(3), R(4), R(5),
-                                 R(0), R(0), R(8), R(9), R(10) ]) ]
-      @test @inferred AbstractAlgebra.Solve.can_solve(C, b)
-      x = @inferred AbstractAlgebra.Solve.solve(C, b)
-      @test x*M == b
-      fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b)
-      @test fl
-      @test x*M == b
-      fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
-      @test fl
-      @test x*M == b
-      @test is_zero(K*M)
-      @test nrows(K) == 0
-      K = @inferred AbstractAlgebra.Solve.kernel(C)
-      @test is_zero(K*M)
-      @test nrows(K) == 0
-    end
-
-    N = zero_matrix(R, 2, 1)
-    C = AbstractAlgebra.Solve.solve_init(N)
-    b = zeros(R, 2)
+  for b in [ [ R(1), R(2), R(3) ],
+             matrix(R, 3, 1, [ R(1), R(2), R(3) ]),
+             matrix(R, 3, 2, [ R(1), R(2), R(3), R(4), R(5), R(6) ]) ]
+    @test @inferred AbstractAlgebra.Solve.can_solve(C, b, side = :right)
+    x = @inferred AbstractAlgebra.Solve.solve(C, b, side = :right)
+    @test M*x == b
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b, side = :right)
+    @test fl
+    @test M*x == b
     fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
     @test fl
-    @test N*x == b
-    @test K == identity_matrix(R, 1)
+    @test M*x == b
+    @test is_zero(M*K)
+    @test ncols(K) == 2
     K = @inferred AbstractAlgebra.Solve.kernel(C, side = :right)
-    @test K == identity_matrix(R, 1)
-
-    N = zero_matrix(R, 1, 2)
-    C = AbstractAlgebra.Solve.solve_init(N)
-    b = zeros(R, 1)
-    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
-    @test fl
-    @test N*x == b
-    @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
-    K = @inferred AbstractAlgebra.Solve.kernel(C, side = :right)
-    @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
+    @test is_zero(M*K)
+    @test ncols(K) == 2
   end
+
+  for b in [ [ R(1), R(1), R(1), R(1), R(1) ],
+             matrix(R, 1, 5, [ R(1), R(1), R(1), R(1), R(1) ]),
+             matrix(R, 2, 5, [ R(1), R(1), R(1), R(1), R(1),
+                               R(1), R(1), R(1), R(1), R(1) ]) ]
+    @test_throws ArgumentError AbstractAlgebra.Solve.solve(C, b)
+    @test @inferred !AbstractAlgebra.Solve.can_solve(C, b)
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b)
+    @test !fl
+    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+    @test !fl
+  end
+
+  for b in [ [ R(1), R(2), R(3), R(4), R(5) ],
+             matrix(R, 1, 5, [ R(1), R(2), R(3), R(4), R(5)]),
+             matrix(R, 2, 5, [ R(1), R(2), R(3), R(4), R(5),
+                               R(0), R(0), R(8), R(9), R(10) ]) ]
+    @test @inferred AbstractAlgebra.Solve.can_solve(C, b)
+    x = @inferred AbstractAlgebra.Solve.solve(C, b)
+    @test x*M == b
+    fl, x = @inferred AbstractAlgebra.Solve.can_solve_with_solution(C, b)
+    @test fl
+    @test x*M == b
+    fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+    @test fl
+    @test x*M == b
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+    K = @inferred AbstractAlgebra.Solve.kernel(C)
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+  end
+
+  N = zero_matrix(R, 2, 1)
+  C = AbstractAlgebra.Solve.solve_init(N)
+  b = zeros(R, 2)
+  fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(R, 1)
+  K = @inferred AbstractAlgebra.Solve.kernel(C, side = :right)
+  @test K == identity_matrix(R, 1)
+
+  N = zero_matrix(R, 1, 2)
+  C = AbstractAlgebra.Solve.solve_init(N)
+  b = zeros(R, 1)
+  fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
+  K = @inferred AbstractAlgebra.Solve.kernel(C, side = :right)
+  @test K == identity_matrix(R, 2) || K == swap_cols!(identity_matrix(R, 2), 1, 2)
 end
 
 @testset "Lazy transpose" begin


### PR DESCRIPTION
So far this does not change the functionality. I open this pull request already now to discuss names and the design.

I will add the new Howell form to the system and try to clean up more of the `_can_solve...` methods in `src/Matrix.jl` (no promises on this though).

Oh, and this will break Nemo in the current state.