### PR TITLE
Revise check_parent for ResElem and ResFieldElem

### DIFF
--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -22,17 +22,14 @@ function is_exact_type(a::Type{T}) where {S <: RingElement, T <: ResElem{S}}
    return is_exact_type(S)
 end
 
-function check_parent_type(a::ResidueRing{T}, b::ResidueRing{T}) where {T <: RingElement}
-   # exists only to check types of parents agree
-end
-
 function check_parent(a::ResElem, b::ResElem, throw::Bool = true)
-   if parent(a) != parent(b)
-      check_parent_type(parent(a), parent(b))
-      fl = modulus(parent(a)) != modulus(parent(b))
-      fl && throw && error("Incompatible moduli in residue operation")
-      return !fl
+   Ra = parent(a)
+   Rb = parent(b)
+   if Ra != Rb
+      fl = typeof(Ra) == typeof(Rb) && modulus(Ra) == modulus(Rb)
+      !fl && throw && error("Incompatible moduli in residue operation")
       #CF: maybe extend to divisibility?
+      return fl
    end
    return true
 end

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -22,16 +22,14 @@ function is_exact_type(a::Type{T}) where {S <: RingElement, T <: ResFieldElem{S}
    return is_exact_type(S)
 end
 
-function check_parent_type(a::ResidueField{T}, b::ResidueField{T}) where {T <: RingElement}
-   # exists only to check types of parents agree
-end
-
 function check_parent(a::ResFieldElem, b::ResFieldElem, throw::Bool = true)
-   if parent(a) != parent(b)
-      check_parent_type(parent(a), parent(b))
-      fl = modulus(parent(a)) != modulus(parent(b))
-      fl && throw && error("Incompatible moduli in residue operation") #CF: maybe extend to divisibility?
-      return !fl
+   Ra = parent(a)
+   Rb = parent(b)
+   if Ra != Rb
+      fl = typeof(Ra) == typeof(Rb) && modulus(Ra) == modulus(Rb)
+      !fl && throw && error("Incompatible moduli in residue operation")
+      #CF: maybe extend to divisibility?
+      return fl
    end
    return true
 end


### PR DESCRIPTION
Also remove check_parent_type.

Previously, we allowed binary operations involving two ResElem instances of *different type*, with the type of the result depending on the argument order. For example, this (requires https://github.com/Nemocas/Nemo.jl/pull/1819):

    julia> using Nemo

    julia> R = quo(ZZ, 2)[1]
    Integers modulo 2

    julia> S = Nemo.AbstractAlgebra.EuclideanRingResidueRing{UInt}(UInt(2))
    Residue ring of integers modulo 2

    julia> typeof(R)
    zzModRing

    julia> typeof(S)
    EuclideanRingResidueRing{UInt64}

    julia> S(1) + R(1)
    0

    julia> typeof(S(1) + R(1))
    EuclideanRingResidueRingElem{UInt64}

    julia> typeof(R(1) + S(1))
    zzModRingElem

But this seems questionable at best. I think we are better of forbidding this -- which this PR effectively does.



However, I am sure people had a reason to add the code I am modifying here in the first place. So this definitely shouldn't be merged before hearing from at least @fieker and @thofma who probably know more about the background of this than I do.


Like https://github.com/Nemocas/Nemo.jl/pull/1819 this also fixes the "introduction" notebook of the OSCAR book.