### PR TITLE
Some trivial cleanup

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -832,7 +832,6 @@ function addeq!(a::FracElem{T}, b::FracElem{T}) where {T <: RingElem}
    d2 = denominator(b, false)
    n1 = numerator(a, false)
    n2 = numerator(b, false)
-   gd = gcd(d1, d2)
    if d1 == d2
       a.num = addeq!(a.num, b.num)
       if !isone(d1)
@@ -854,6 +853,7 @@ function addeq!(a::FracElem{T}, b::FracElem{T}) where {T <: RingElem}
       a.num = addeq!(a.num, n2*d1)
       a.den = deepcopy(d1)
    else
+      gd = gcd(d1, d2)
       if isone(gd)
          if n1 !== n2
             a.num = mul!(a.num, a.num, d2)
@@ -884,7 +884,6 @@ function add!(c::FracElem{T}, a::FracElem{T}, b::FracElem{T}) where {T <: RingEl
    d2 = denominator(b, false)
    n1 = numerator(a, false)
    n2 = numerator(b, false)
-   gd = gcd(d1, d2)
    if d1 == d2
       c.num = n1 + n2
       if isone(d1)
@@ -905,6 +904,7 @@ function add!(c::FracElem{T}, a::FracElem{T}, b::FracElem{T}) where {T <: RingEl
       c.num = n1 + n2*d1
       c.den = deepcopy(d1)
    else
+      gd = gcd(d1, d2)
       if isone(gd)
          c.num = n1*d2 + n2*d1
          c.den = d1*d2

--- a/src/generic/TotalFraction.jl
+++ b/src/generic/TotalFraction.jl
@@ -200,10 +200,10 @@ end
 
 function *(a::TotFrac{T}, b::TotFrac{T}) where {T <: RingElem}
    check_parent(a, b)
-   n1 = numerator(a, false)
-   d2 = denominator(b, false)
-   n2 = numerator(b, false)
    d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    if n1 == d2
       n = deepcopy(n2)
       d = deepcopy(d1)
@@ -404,10 +404,10 @@ function zero!(c::TotFrac)
 end
 
 function mul!(c::TotFrac{T}, a::TotFrac{T}, b::TotFrac{T}) where {T <: RingElem}
-   n1 = numerator(a, false)
-   d2 = denominator(b, false)
-   n2 = numerator(b, false)
    d1 = denominator(a, false)
+   d2 = denominator(b, false)
+   n1 = numerator(a, false)
+   n2 = numerator(b, false)
    if n1 == d2
       n = deepcopy(n2)
       d = deepcopy(d1)


### PR DESCRIPTION
- delay computation of a gcd until it really is needed in `addeq!`
  and `add!` methods for `FracElem` (thus matching what the `+` and `-`
  methods already are doing)
- reorder some code in `*` and `mul!` methods for `TotFrac` (thus matching
  the order in the `+`, `add!` etc. methods)
