### PR TITLE
Fix `change_base_ring` for `UnivPoly` when Nemo is loaded

### DIFF
--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -900,7 +900,7 @@ end
 ################################################################################
 
 function _change_univ_poly_ring(R, Rx, cached::Bool)
-   P, _ = polynomial_ring(R, map(string, symbols(Rx)), internal_ordering=internal_ordering(Rx), cached=cached)
+   P = MPolyRing{elem_type(R)}(R, symbols(Rx), internal_ordering(Rx), cached)
    S = universal_polynomial_ring(R; internal_ordering=internal_ordering(Rx), cached=cached)
    S.S = deepcopy(symbols(Rx))
    S.mpoly_ring = P


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3921.

The problem here seems to be that https://github.com/Nemocas/AbstractAlgebra.jl/blob/d6cf779c45185cf354fd048210e87af41f05a460/src/generic/UnivPoly.jl#L903 uses `polynomial_ring` (and thus possibly creates some Nemo mpoly ring), but the rest of the implementation of `UniversalPolyRing` directly calls `Generic.MPoly`.

I verified manually that the problem described in https://github.com/oscar-system/Oscar.jl/issues/3921 no longer exists in a session with both AA and Oscar loaded. I cannot add tests here, as there is no issue with AA alone.
