### PR TITLE
Enhance evaluate for FracElem to support 3-arg variants

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -635,7 +635,11 @@ end
 function evaluate(f::FracElem{T}, v::U) where {T <: PolyRingElem, U <: Integer}
     return evaluate(numerator(f), v)//evaluate(denominator(f), v)
 end
- 
+
+function evaluate(f::FracElem{T}, vars::Vector{Int}, vals::Vector{U}) where {T <: RingElement, U <: RingElement}
+     return evaluate(numerator(f), vars, vals)//evaluate(denominator(f), vars, vals)
+end
+
 ###############################################################################
 #
 #   Powering

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -294,6 +294,20 @@ end
 
    @test evaluate(f, [1, 2]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [1, 2], [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [2, 1], [ZZ(2), ZZ(1)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [1], [ZZ(2)]) == (y + 4)//(y + 2)
+
+   R = universal_polynomial_ring(ZZ)
+   x, y = gens(R, [:x, :y])
+
+   f = (x^2 + y)//(y + 2)
+
+   @test evaluate(f, [1, 2]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [1, 2], [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [2, 1], [ZZ(2), ZZ(1)]) == ZZ(3)//ZZ(4)
+   @test evaluate(f, [1], [ZZ(2)]) == (y + 4)//(y + 2)
 end
 
 @testset "Generic.FracFieldElem.derivative" begin


### PR DESCRIPTION
... which MPolyRing and UniversalPolyRing use to allow specifying a list of variable indices followed by a list of values.

Requested by @SoongNoonien 