### PR TITLE
Cover `@varnames_interface` options with explicit tests

### DIFF
--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -183,7 +183,7 @@
    @test_logs (:warn, """The variable name "x-1" sadly is no Julia identifier. You can still access it as `var"x-1"`."""
       ) @macroexpand @polynomial_ring(QQ, :x => -1:1)
    @test_logs (:error, "Inconveniently, you may only use literals and variables from the global scope of the current module (`Main`) when using variable name constructor macros"
-      ) @test_throws (VERSION <= v"1.7" ? LoadError : UndefVarError) let local_name = 3
+      ) @test_throws (VERSION < v"1.7" ? LoadError : UndefVarError) let local_name = 3
          @macroexpand @polynomial_ring(QQ, :x => 1:local_name)
       end
 end

--- a/test/misc-test.jl
+++ b/test/misc-test.jl
@@ -43,16 +43,28 @@ module VarNamesTest
     @test f("A", 3) == ("A", ["Ax1", "Ax2", "Ax3"])
 
     @f("A", :y => 1:3)
+    @f("B", 3, "z")
+
     @test [y1, y2, y3] == ["Ay1", "Ay2", "Ay3"]
+    @test [z1, z2, z3] == ["Bz1", "Bz2", "Bz3"]
     @test ! @isdefined x1
     @test ! @isdefined y4
+    @test ! @isdefined z4
 
     @testset "VarNames.options" begin
       @test uses_n("A", 3) == ("A", ["Ax1", "Ax2", "Ax3"])
       @test projective("A", 3) == ("A", ["Ax0", "Ax1", "Ax2", "Ax3"])
 
+      @projective("A", 3)
+      @test [x0, x1, x2, x3] == ["Ax0", "Ax1", "Ax2", "Ax3"]
+
+      @uses_n("B", 3, 'y')
+      @test [y1, y2, y3] == ["By1", "By2", "By3"]
+
       @test ! @isdefined var"@no_macros"
       @test_throws MethodError no_n_variant("A", 3)
+      @test_throws ArgumentError @macroexpand @no_n_variant("A", 3, :q)
+      @test ! @isdefined q1
     end
   end
 end

--- a/test/misc-test.jl
+++ b/test/misc-test.jl
@@ -15,7 +15,44 @@
 end
 
 @testset "rising_factorial" begin
-
   @test_throws OverflowError rising_factorial(10,30)
   @test_throws OverflowError rising_factorial2(10,30)
+end
+
+### Test options to @varnames_interface ###
+# For tests under default options, see doctests and test/generic/MPoly-test.jl
+
+# note: macro definition not allowed inside a local scope
+# hence using a module instead:
+module VarNamesTest
+  using AbstractAlgebra
+  using Test
+
+  f(a, s::Vector{Symbol}) = a, string.((a,), s)
+  projective(a, s::Vector{Symbol}) = f(a, s)
+  uses_n(n, s::Vector{Symbol}) = f(n, s)
+  no_n_variant(a, s::Vector{Symbol}) = f(a, s)
+  no_macros(a, s::Vector{Symbol}) = f(a, s)
+  AbstractAlgebra.@varnames_interface f(a, s)
+  AbstractAlgebra.@varnames_interface projective(a, s) range=0:n
+  AbstractAlgebra.@varnames_interface uses_n(n, s) n=m range=1:m
+  AbstractAlgebra.@varnames_interface no_n_variant(a, s) n=:no
+  AbstractAlgebra.@varnames_interface no_macros(a, s) macros=:no
+
+  @testset "VarNames" begin
+    @test f("A", 3) == ("A", ["Ax1", "Ax2", "Ax3"])
+
+    @f("A", :y => 1:3)
+    @test [y1, y2, y3] == ["Ay1", "Ay2", "Ay3"]
+    @test ! @isdefined x1
+    @test ! @isdefined y4
+
+    @testset "VarNames.options" begin
+      @test uses_n("A", 3) == ("A", ["Ax1", "Ax2", "Ax3"])
+      @test projective("A", 3) == ("A", ["Ax0", "Ax1", "Ax2", "Ax3"])
+
+      @test ! @isdefined var"@no_macros"
+      @test_throws MethodError no_n_variant("A", 3)
+    end
+  end
 end

--- a/test/misc-test.jl
+++ b/test/misc-test.jl
@@ -63,7 +63,7 @@ module VarNamesTest
 
       @test ! @isdefined var"@no_macros"
       @test_throws MethodError no_n_variant("A", 3)
-      @test_throws ArgumentError @macroexpand @no_n_variant("A", 3, :q)
+      @test_throws (VERSION < v"1.7" ? LoadError : ArgumentError) @macroexpand @no_n_variant("A", 3, :q)
       @test ! @isdefined q1
     end
   end


### PR DESCRIPTION
Previously, I tested the various options to `@varnames_interface` only implicitly. Here, I add some explicit tests, demonstrating all the options. A handful more lines can easily be added, if we accept proposal #1762.