### PR TITLE
Fix a power series bug

### DIFF
--- a/src/AbsSeries.jl
+++ b/src/AbsSeries.jl
@@ -578,8 +578,9 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 
 Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
-==(x::AbsPowerSeriesRingElem, y::Union{Integer, Rational, AbstractFloat}) = precision(x) == 0 || ((length(x) == 0 && iszero(y))
-                                       || (length(x) == 1 && coeff(x, 0) == y))
+==(x::AbsPowerSeriesRingElem, y::Union{Integer, Rational, AbstractFloat}) = precision(x) == 0 ||
+                     ((length(x) == 0 && iszero(base_ring(x)(y))) ||
+                      (length(x) == 1 && coeff(x, 0) == y))
 
 @doc raw"""
     ==(x::Union{Integer, Rational, AbstractFloat}, y::AbsPowerSeriesRingElem)

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -781,8 +781,8 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 ==(x::RelPowerSeriesRingElem, y::Union{Integer, Rational, AbstractFloat}) = precision(x) == 0 ||
-                  ((pol_length(x) == 0 && iszero(y)) || (pol_length(x) == 1 &&
-                    valuation(x) == 0 && polcoeff(x, 0) == y))
+                    ((pol_length(x) == 0 && iszero(base_ring(x)(y))) ||
+                     (pol_length(x) == 1 && valuation(x) == 0 && polcoeff(x, 0) == y))
 
 @doc raw"""
     ==(x::Union{Integer, Rational, AbstractFloat}, y::RelPowerSeriesRingElem)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -305,10 +305,11 @@ function (a::AbsPowerSeriesRing{T})() where T <: RingElement
 end
 
 function (a::AbsPowerSeriesRing{T})(b::Union{Integer, Rational, AbstractFloat}) where T <: RingElement
-   if b == 0
+   bb = base_ring(a)(b)
+   if is_zero(bb)
       z = AbsSeries{T}(Vector{T}(undef, 0), 0, a.prec_max)
    else
-      z = AbsSeries{T}([base_ring(a)(b)], 1, a.prec_max)
+      z = AbsSeries{T}([bb], 1, a.prec_max)
    end
    z.parent = a
    return z

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -347,10 +347,11 @@ function (R::RelPowerSeriesRing{T})() where T <: RingElement
 end
 
 function (R::RelPowerSeriesRing{T})(b::Union{Integer, Rational, AbstractFloat}) where T <: RingElement
-   if b == 0
+   bb = base_ring(R)(b)
+   if is_zero(bb)
       z = RelSeries{T}(Vector{T}(undef, 0), 0, R.prec_max, R.prec_max)
    else
-      z = RelSeries{T}([base_ring(R)(b)], 1, R.prec_max, 0)
+      z = RelSeries{T}([bb], 1, R.prec_max, 0)
    end
    z.parent = R
    return z

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -106,6 +106,14 @@ end
    @test R === S
    S, x = power_series_ring(ZZ, 30, "x", model=:capped_absolute, cached = false)
    @test R !== S
+
+   # Test whether "things that get zero in the coefficient ring" are handled
+   # correctly
+   R5, x = power_series_ring(GF(5), 30, "x", model = :capped_absolute)
+   f = R5(5)
+   @test isa(f, Generic.AbsSeries)
+   @test is_zero(f)
+   @test valuation(f) == max_precision(R5)
 end
 
 @testset "Generic.AbsSeries.manipulation" begin

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -107,6 +107,14 @@ end
    @test_throws DomainError O(0+O(x^0))
 
    @test !occursin("\n", sprint(show, T))
+
+   # Test whether "things that get zero in the coefficient ring" are handled
+   # correctly
+   R5, x = power_series_ring(GF(5), 30, "x")
+   f = R5(5)
+   @test isa(f, Generic.RelSeries)
+   @test is_zero(f)
+   @test valuation(f) == max_precision(R5)
 end
 
 @testset "Generic.RelSeries.rand" begin


### PR DESCRIPTION
This is not correct:
```
julia> R, x = power_series_ring(GF(5), 10, "x");

julia> is_zero(R(5))
true

julia> valuation(R(5))
0
```

(I'm not sure I like `valuation(R(5)) == 10` either, but at least that appears to be the convention.)
