### PR TITLE
[release-0.41] Bump version to 0.41.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.41.10"
+version = "0.41.11"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
To prepare a release that (compared to 0.41.10) just backports https://github.com/Nemocas/AbstractAlgebra.jl/pull/1758.