### PR TITLE
Fix and document `AbstractAlgebra.ispower_moduli`

### DIFF
--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -377,15 +377,12 @@ end
 #
 #  [ a for a in 0:q-1 if a == 0 || powermod(a, divexact(q-1,p), q) == 1]
 
-# p = 3, q = 7 or q = 13
-const moduli3 = [7, 13]
-const residues3 = [[0, 1, 6], [0, 1, 5, 8, 12]]
-
-const moduli5 = [11, 31]
-const residues5 = [[0, 1, 10], [0, 1, 5, 6, 25, 26, 30]]
-
-const moduli7 = [29, 43]
-const residues7 = [[0, 1, 12, 17, 28], [0, 1, 6, 7, 36, 37, 42]]
+const _p_q_residues = (
+    #p => [q1 => residues,  q2 => residues, .... ]
+    3 => ( 7 => [0, 1, 6], 13 => [0, 1, 5, 8, 12] ),
+    5 => ( 11 => [0, 1, 10], 31 => [0, 1, 5, 6, 25, 26, 30] ),
+    7 => ( 29 => [0, 1, 12, 17, 28], 43 => [0, 1, 6, 7, 36, 37, 42] ),
+  )
 
 # helper which returns false if a definitely is not an n-th power,
 # otherwise return true (indicating we don't know)
@@ -399,25 +396,16 @@ function ispower_moduli(a::Integer, n::Int)
       return false
    end
 
-   if (n % 3) == 0
-      for i = 1:length(moduli3)
-         if !(mod(a, moduli3[i]) in residues3[i])
-            return false
-         end
-      end
-   elseif (n % 5) == 0
-      for i = 1:length(moduli5)
-         if !(mod(a, moduli5[i]) in residues5[i])
-            return false
-         end
-      end
-   elseif (n % 7) == 0
-      for i = 1:length(moduli7)
-         if !(mod(a, moduli7[i]) in residues7[i])
-            return false
-         end
-      end
+   for (p, q_residues) in _p_q_residues
+     if (n % p) == 0
+        for (q, residues) in q_residues
+           if !(mod(a, q) in residues)
+              return false
+           end
+        end
+     end
    end
+
    return true
 end
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -366,17 +366,40 @@ function root(a::T, n::Int; check::Bool=true) where T <: Integer
    end
 end
 
-const moduli3 = [7, 8, 13]
-const residues3 = [[0, 1, 6], [0, 1, 3, 5, 7], [0, 1, 5, 8, 12]]
+# Suppose a = b^n, and let p be a prime divisor of n, i.e. n=m*p. Let q
+# be a prime such that p divides q-1. Then by Fermat's little theorem
+# either q divides a and hence b, or else b^(q-1) \equiv 1 mod q holds.
+# But we also have that a = b^n = b^(m*p) = (b^m)^p mod q. Thus in fact
+# we have   a^{(q-1)/p} \equiv 1 mod q.
+#
+# So below are some tables for various values of p and q and the allowed
+# residue classes for a. They could be recomputed via
+#
+#  [ a for a in 0:q-1 if a == 0 || powermod(a, divexact(q-1,p), q) == 1]
 
-const moduli5 = [8, 11, 31]
-const residues5 = [[0, 1, 3, 5, 7], [0, 1, 10], [0, 1, 5, 6, 25, 26, 30]]
+# p = 3, q = 7 or q = 13
+const moduli3 = [7, 13]
+const residues3 = [[0, 1, 6], [0, 1, 5, 8, 12]]
 
-const moduli7 = [8, 29, 43]
-const residues7 = [[0, 1, 3, 5, 7], [0, 1, 12, 17, 28], [0, 1, 6, 7, 36, 37, 42]]
+const moduli5 = [11, 31]
+const residues5 = [[0, 1, 10], [0, 1, 5, 6, 25, 26, 30]]
 
+const moduli7 = [29, 43]
+const residues7 = [[0, 1, 12, 17, 28], [0, 1, 6, 7, 36, 37, 42]]
+
+# helper which returns false if a definitely is not an n-th power,
+# otherwise return true (indicating we don't know)
 function ispower_moduli(a::Integer, n::Int)
-   if mod(n, 3) == 0
+   @assert n >= 2
+   n == 2 && return true
+
+   # If a is even and an n-th power then it must be divisible by 2^n
+   # and hence by 8 (as n >= 3 at this point).
+   if iseven(a) && mod(a, 8) != 0
+      return false
+   end
+
+   if (n % 3) == 0
       for i = 1:length(moduli3)
          if !(mod(a, moduli3[i]) in residues3[i])
             return false
@@ -388,15 +411,11 @@ function ispower_moduli(a::Integer, n::Int)
             return false
          end
       end
-   elseif (n % 3) == 0
+   elseif (n % 7) == 0
       for i = 1:length(moduli7)
          if !(mod(a, moduli7[i]) in residues7[i])
             return false
          end
-      end
-   elseif isodd(n)
-      if !(mod(a, moduli5[1]) in residues5[1])
-            return false
       end
    end
    return true
@@ -414,7 +433,7 @@ function is_power(a::T, n::Int) where T <: Integer
       return (true, a)
    elseif a == -1
       return isodd(n) ? (true, a) : (false, zero(T))
-   elseif mod(n, 2) == 0 && a < 0
+   elseif iseven(n) && a < 0
       return false, zero(T)
    elseif !ispower_moduli(a, n)
       return (false, zero(T))


### PR DESCRIPTION
The prior code did not do any wrong computations, it just neglected to actually use the third set of moduli/residues tables for the prime 7 due to a typo, which this patch fixes.

This patch also cleans up the handling of even 'a' and adds a bunch of comments to explain what is going on.

Finally, it also extends the check mod 8 to even n. The prior check here was a bit hackish in that it hardcoded the assumption that `moduli5[1]` is 8.

The second commit also consolidates the code.

Some quick microbenchmarking suggests that the new code is actually a little bit more efficient than the old, but I don't think this will matter too much in practice. (Well, it is also a bit slower if the exponent is a multiple of 7 -- but that's due to the "bug" this PR fixed, where it doesn't actually use the checks in that case).

Resolves #1750