### PR TITLE
use `check_parent` helper in ring interface example

### DIFF
--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -917,19 +917,19 @@ end
 # Binary operations
 
 function +(f::ConstPoly{T}, g::ConstPoly{T}) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    R = parent(f)
    return R(f.c + g.c)
 end
 
 function -(f::ConstPoly{T}, g::ConstPoly{T}) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    R = parent(f)
    return R(f.c - g.c)
 end
 
 function *(f::ConstPoly{T}, g::ConstPoly{T}) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    R = parent(f)
    return R(f.c*g.c)
 end
@@ -937,12 +937,12 @@ end
 # Comparison
 
 function ==(f::ConstPoly{T}, g::ConstPoly{T}) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    return f.c == g.c
 end
 
 function isequal(f::ConstPoly{T}, g::ConstPoly{T}) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    return isequal(f.c, g.c)
 end
 
@@ -951,7 +951,7 @@ end
 # Exact division
 
 function divexact(f::ConstPoly{T}, g::ConstPoly{T}; check::Bool = true) where T <: RingElement
-   parent(f) != parent(g) && error("Incompatible rings")
+   check_parent(f, g)
    R = parent(f)
    return R(divexact(f.c, g.c, check = check))
 end


### PR DESCRIPTION
Hi!
I don't see any reason against using this helper function in the example.