### PR TITLE
Remove stale code being dead since #1513

### DIFF
--- a/src/misc/VarNames.jl
+++ b/src/misc/VarNames.jl
@@ -73,7 +73,6 @@ variable_names(as::VarNames...) = variable_names(as)
 variable_names(as::Tuple{Vararg{VarNames}}, brackets::Val = Val(true)) =
     Symbol[x for a in as for x in _variable_names(a, brackets)]
 
-_variable_names(s::VarName, ::Any) = [Symbol(s)]
 _variable_names(a::AbstractArray{<:VarName}, ::Any) = Symbol.(a)
 
 _variable_names((s, axe)::Pair{<:Union{Char, Symbol}}, ::Val{true}) = Symbol.(s, '[', axe, ']')
@@ -155,7 +154,6 @@ function _unpeel_reshape_to_varnames(iter, x::Tuple)
     end
 end
 
-_reshape_to_varnames(iter::Iterators.Stateful, ::VarName) = popfirst!(iter)
 _reshape_to_varnames(iter::Iterators.Stateful, a::AbstractArray{<:VarName}) =
     _reshape(iter, size(a))
 _reshape_to_varnames(iter::Iterators.Stateful, (_, shape)::Pair{<:VarName}) =


### PR DESCRIPTION
The two lines deleted here supported `VarName` being in `VarNames` and were overseen in #1513. I just noticed them due to being [the only lines of VarNames.jl not covered by tests](https://app.codecov.io/gh/Nemocas/AbstractAlgebra.jl/blob/master/src%2Fmisc%2FVarNames.jl).