### PR TITLE
Clean up the mess I created when I cleaned up `NemoStuff.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.42.3"
+version = "0.42.4"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -58,5 +58,5 @@ import .Generic: is_gen; @deprecate is_gen(x::Generic.MPoly{T}, ::Type{Val{ord}}
 import .Generic: degree; @deprecate degree(f::Generic.MPoly{T}, i::Int, ::Type{Val{ord}}) where {T <: RingElement, ord} degree(f, i, Val(ord))
 
 # deprecated during 0.42.*
-@deprecate change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} map_coefficients(g, p, parent = new_polynomial_ring)
-@deprecate mulmod(a::S, b::S, mod::Vector{S}) where {S <: MPolyRingElem} Base.divrem(a * b, mod)[2]
+change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} = map_coefficients(g, p, parent = new_polynomial_ring)
+mulmod(a::S, b::S, mod::Vector{S}) where {S <: MPolyRingElem} = Base.divrem(a * b, mod)[2]

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -59,3 +59,4 @@ import .Generic: degree; @deprecate degree(f::Generic.MPoly{T}, i::Int, ::Type{V
 
 # deprecated during 0.42.*
 @deprecate change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} map_coefficients(g, p, parent = new_polynomial_ring)
+@deprecate mulmod(a::S, b::S, mod::Vector{S}) where {S <: MPolyRingElem} Base.divrem(a * b, mod)[2]


### PR DESCRIPTION
In #1769, I removed `mulmod(::T, ::T, ::Vector{T}) where T <: MPolyRingElem`; apparently this is used in Hecke though. (I was certain I ran all the tests locally, but apparently I missed the "long" ones?)

I don't like the name of this function (`mod` in the context of several multivariate polynomials sounds like Gröbner stuff to me?) and in the end writing `divrem(a * b, m)[2]` is not much longer.
So, I would only want to introduce this as a deprecation. Is that fine?

Sorry for this.

NEW: I put `mulmod` in `Deprecations.jl` but only as a redirect. I also removed another deprecation introduced in #1769 which is actually used in Hecke.
