### PR TITLE
Add `PermGroupRing` for group ring functionality

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -249,6 +249,7 @@ include("UnivPoly.jl")
 include("FreeAssociativeAlgebra.jl")
 include("LaurentMPoly.jl")
 include("MatrixNormalForms.jl")
+include("GroupRing.jl")
 
 
 include("Groups.jl")

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -99,6 +99,8 @@ abstract type MatRing{T} <: NCRing end
 
 abstract type FreeAssociativeAlgebra{T} <: NCRing end
 
+abstract type PermGroupRing{T} <: NCRing end
+
 # Abstract types for number fields, parmeterised by the element type of
 # the base field.
 abstract type NumField{T} <: Field end
@@ -149,6 +151,8 @@ abstract type FreeAssociativeAlgebraElem{T} <: NCRingElem end
 abstract type NumFieldElem{T} <: FieldElem end
 
 abstract type SimpleNumFieldElem{T} <: NumFieldElem{T} end
+
+abstract type PermGroupRingElem{T} <: NCRingElem end
 
 # additional abstract types for parents, added ad hoc to form
 # collections of types as needed by applications

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -94,6 +94,8 @@ include("generic/FreeAssociativeAlgebraGroebner.jl")
 
 include("generic/PolyRingHom.jl")
 
+include("generic/GroupRing.jl")
+
 ###############################################################################
 #
 #   Temporary miscellaneous files being moved from Hecke.jl

--- a/src/GroupRing.jl
+++ b/src/GroupRing.jl
@@ -1,0 +1,8 @@
+@doc raw"""
+Permutation group ring constructor.
+
+See also: [`perm_group_ring`](@ref).
+"""
+function perm_group_ring(R::Ring, l::Int, cached::Bool=true)
+    Generic.perm_group_ring(R, l, cached)
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -72,6 +72,8 @@ export NumFieldElem
 export O
 export Partition
 export Perm
+export PermGroupRing
+export PermGroupRingElem
 export PolyCoeffs
 export PolyRing
 export PolyRingElem
@@ -418,6 +420,7 @@ export parity
 export partitionseq
 export perm
 export permtype
+export perm_group_ring
 export pfaffian
 export pfaffians
 export pluralize

--- a/src/generic/GroupRing.jl
+++ b/src/generic/GroupRing.jl
@@ -1,0 +1,203 @@
+# Data type and parent object methods
+
+parent_type(::Type{PermGroupRingElem{T}}) where {T<:RingElement} = PermGroupRing{T}
+
+elem_type(::Type{PermGroupRing{T}}) where {T<:RingElement} = PermGroupRingElem{T}
+
+base_ring_type(::Type{PermGroupRing{T}}) where {T<:RingElement} = parent_type(T)
+
+base_ring(R::PermGroupRing) = R.base_ring::base_ring_type(R)
+
+parent(f::PermGroupRingElem) = f.parent
+
+is_domain_type(::Type{PermGroupRingElem{T}}) where {T<:RingElement} = is_domain_type(T)
+
+is_exact_type(::Type{PermGroupRingElem{T}}) where {T<:RingElement} = is_exact_type(T)
+
+function deepcopy_internal(f::PermGroupRingElem{T}, dict::IdDict) where {T<:RingElement}
+    r = PermGroupRingElem{T}(deepcopy_internal(f.coeffs, dict))
+    r.parent = f.parent # parent should not be deepcopied
+    return r
+end
+
+# Basic manipulation
+
+zero(R::PermGroupRing) = R()
+
+one(R::PermGroupRing) = R(1)
+
+iszero(f::PermGroupRingElem) = f == 0
+
+isone(f::PermGroupRingElem) = f == 1
+
+# String I/O
+
+function show(io::IO, R::PermGroupRing)
+    print(io, "Permutation group ring over ")
+    show(io, base_ring(R))
+ end
+
+ function show(io::IO, f::PermGroupRingElem)
+    print(io, f.coeffs)
+ end
+
+# Arithmetic functions
+
+function -(a::PermGroupRingElem{T}) where {T<:RingElement}
+    r = parent(a)()
+    for (k, v) in a.coeffs
+        r.coeffs[k] = -v
+    end
+    return r
+end
+
+function +(a::PermGroupRingElem{T}, b::PermGroupRingElem{T}) where {T<:RingElement}
+    r = parent(a)()
+    for (k, v) in a.coeffs
+        r.coeffs[k] = v
+    end
+    for (k, v) in b.coeffs
+        if haskey(r.coeffs, k)
+            r.coeffs[k] += v
+            if r.coeffs[k] == 0
+                delete!(r.coeffs, k)
+            end
+        else
+            r.coeffs[k] = v
+        end
+    end
+    return r
+end
+
+-(a::PermGroupRingElem{T}, b::PermGroupRingElem{T}) where {T<:RingElement} = a + (-b)
+
+function *(a::PermGroupRingElem{T}, b::PermGroupRingElem{T}) where {T<:RingElement}
+    r = parent(a)()
+    for (k1, v1) in a.coeffs
+        for (k2, v2) in b.coeffs
+            k = k1 * k2
+            if haskey(r.coeffs, k)
+                r.coeffs[k] += v1 * v2
+            else
+                r.coeffs[k] = v1 * v2
+            end
+        end
+    end
+    filter!(x -> x[2] != 0, r.coeffs)
+    return r
+end
+
+function ^(a::PermGroupRingElem{T}, n::Int) where {T<:RingElement}
+    if n == 0
+        return one(parent(a))
+    elseif n == 1
+        return a
+    elseif n < 0
+        DomainError(n)
+    end
+    r = *(repeat([a], n)...)
+    return r
+end
+
+# Ad hoc arithmetic functions
+
+*(a::PermGroupRingElem{T}, n::T) where {T<:RingElement} = a * parent(a)(n)
+
+*(n::T, a::PermGroupRingElem{T}) where {T<:RingElement} = a * n
+
++(a::PermGroupRingElem{T}, n::T) where {T<:RingElement} = a + parent(a)(n)
+
++(n::T, a::PermGroupRingElem{T}) where {T<:RingElement} = a + n
+
+*(a::PermGroupRingElem{T}, p::Perm) where {T<:RingElement} = a * parent(a)(p)
+
+*(p::Perm, a::PermGroupRingElem{T}) where {T<:RingElement} = parent(a)(p) * a
+
++(a::PermGroupRingElem{T}, p::Perm) where {T<:RingElement} = a + parent(a)(p)
+
++(p::Perm, a::PermGroupRingElem{T}) where {T<:RingElement} = a + p
+
+# Comparison
+
+function ==(a::PermGroupRingElem{T}, b::PermGroupRingElem{T}) where {T<:RingElement}
+    if length(a.coeffs) != length(b.coeffs)
+        return false
+    end
+    for (k, v) in a.coeffs
+        if !haskey(b.coeffs, k) || b.coeffs[k] != v
+            return false
+        end
+    end
+    return true
+end
+
+# Ad hoc comparison
+
+==(a::PermGroupRingElem{T}, n::T) where {T<:RingElement} = length(a.coeffs) == 1 && a.coeffs[Perm(parent(a).l)] == n
+
+==(n::T, a::PermGroupRingElem{T}) where {T<:RingElement} = a == n
+
+==(a::PermGroupRingElem{T}, p::Perm) where {T<:RingElement} = length(a.coeffs) == 1 && a.coeffs[p] == base_ring(parent(a))(1)
+
+==(p::Perm, a::PermGroupRingElem{T}) where {T<:RingElement} = a == p
+
+# TODO Some functionality are expected by ring interfaces but not necessary for ECC construction,
+# including hash, exact division, random generation, promotion rules
+
+# Constructors by overloading the call syntax for parent objects
+
+function (R::PermGroupRing{T})() where {T<:RingElement}
+    r = PermGroupRingElem{T}()
+    r.parent = R
+    return r
+end
+
+function (R::PermGroupRing{T})(coeffs::Dict{<:Perm,<:Union{T,Integer,Rational,AbstractFloat}}) where {T<:RingElement}
+    if valtype(coeffs) == T
+        for (k,v) in coeffs
+            length(k.d) == R.l || error("Invalid permutation length")
+            parent(v) == R || error("Unable to coerce a group ring element")
+        end
+    else
+        coeffs = Dict(k => base_ring(R)(v) for (k, v) in coeffs)
+    end
+    r = PermGroupRingElem{T}(coeffs)
+    r.parent = R
+    return r
+end
+
+function (R::PermGroupRing{T})(n::Union{Integer,Rational,AbstractFloat}) where {T<:RingElement}
+    coeffs = iszero(n) ? Dict{Perm,T}() : Dict(Perm(R.l) => base_ring(R)(n))
+    r = PermGroupRingElem{T}(coeffs)
+    r.parent = R
+    return r
+end
+
+function (R::PermGroupRing{T})(n::T) where {T<:RingElement}
+    base_ring(R) == parent(n) || error("Unable to coerce a group ring element")
+    r = PermGroupRingElem{T}(Dict(Perm(R.l) => n))
+    r.parent = R
+    return r
+end
+
+function (R::PermGroupRing{T})(p::Perm) where {T<:RingElement}
+    length(p.d) == R.l || error("Invalid permutation length")
+    r = PermGroupRingElem{T}(Dict(p => one(base_ring(R))))
+    r.parent = R
+    return r
+end
+
+function (R::PermGroupRing{T})(f::PermGroupRingElem{T}) where {T<:RingElement}
+    parent(f) == R || error("Unable to coerce a group ring element")
+    return f
+end
+
+@doc raw"""
+Permutation group ring constructor.
+
+See also: [`perm_group_ring`](@ref).
+"""
+function perm_group_ring(R::Ring, l::Int, cached::Bool=true)
+    T = elem_type(R)
+    return PermGroupRing{T}(R, l, cached)
+end


### PR DESCRIPTION
I have implemented group rings (also known as group algebra), where permutation groups represent the groups. https://en.wikipedia.org/wiki/Group_ring In brief, group rings are constructed from a given group and a given ring, and they generalize groups by giving coefficients (from the given ring) to group elements.

I have implemented core functionality via the new type `PermGroupRing`, including data types, basic manipulation, string I/O, arithmetic functions, comparisons, and constructors. The interfaces are designed in accordance with `NCRing`, of which `PermGroupRing` is a subtype.

In the current draft PR, some `NCRing` functionalities are not implemented: hash, exact division, random generation, and promotion rules.

These codes were initially written for another project about error-correcting codes, `QuantumClifford.jl`. After some discussion with @Krastanov, we think it might better belong to a package specific to algebra, like here. We would like to hear what you think about this.