### PR TITLE
Enforce `@attr` uses to always provide a return type

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -274,7 +274,7 @@ end
 
 
 """
-    @attr [RetType] funcdef
+    @attr RetType funcdef
 
 This macro is applied to the definition of a unary function, and enables
 caching ("memoization") of its return values based on the argument. This
@@ -323,21 +323,10 @@ julia> myattr(obj) # second time uses the cached result
 
 ```
 """
-macro attr(ex1, exs...)
-   if length(exs) == 0
-      rettype = Any
-      expr = ex1
-   elseif length(exs) == 1
-      rettype = ex1
-      expr = exs[1]
-   else
-      throw(ArgumentError("too many macro arguments"))
-   end
+macro attr(rettype, expr::Expr)
    d = MacroTools.splitdef(expr)
    length(d[:args]) == 1 || throw(ArgumentError("Only unary functions are supported"))
    length(d[:kwargs]) == 0 || throw(ArgumentError("Keyword arguments are not supported"))
-
-# TODO: handle optional ::RetType
 
    # store the original function name
    name = d[:name]

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -57,6 +57,7 @@ import .Generic: set_exponent_vector!; @deprecate set_exponent_vector!(a::Generi
 import .Generic: is_gen; @deprecate is_gen(x::Generic.MPoly{T}, ::Type{Val{ord}}) where {T <: RingElement, ord} is_gen(x, Val(ord))
 import .Generic: degree; @deprecate degree(f::Generic.MPoly{T}, i::Int, ::Type{Val{ord}}) where {T <: RingElement, ord} degree(f, i, Val(ord))
 
-# deprecated during 0.42.*
+# will become deprecated in 0.43.0
 change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} = map_coefficients(g, p, parent = new_polynomial_ring)
 mulmod(a::S, b::S, mod::Vector{S}) where {S <: MPolyRingElem} = Base.divrem(a * b, mod)[2]
+var"@attr"(__source__::LineNumberNode, __module__::Base.Module, expr::Expr) = var"@attr"(__source__, __module__, :Any, expr)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -60,4 +60,4 @@ import .Generic: degree; @deprecate degree(f::Generic.MPoly{T}, i::Int, ::Type{V
 # will become deprecated in 0.43.0
 change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} = map_coefficients(g, p, parent = new_polynomial_ring)
 mulmod(a::S, b::S, mod::Vector{S}) where {S <: MPolyRingElem} = Base.divrem(a * b, mod)[2]
-var"@attr"(__source__::LineNumberNode, __module__::Base.Module, expr::Expr) = var"@attr"(__source__, __module__, :Any, expr)
+var"@attr"(__source__::LineNumberNode, __module__::Base.Module, expr::Expr) = var"@attr"(__source__, __module__, :Any, expr) # delegate `@attr functionexpression` to `@attr Any functionexpression` (macros are just functions with this weird extra syntax)

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -178,8 +178,8 @@ A cached attribute.
 """
 @attr Tuple{T,DataType,Vector{Any}} cached_attr(obj::T) where T = (obj,T,[])
 
-# cached attribute without return type specification
-@attr cached_attr2(obj::T) where T = (obj,T,[])
+# cached attribute with bad return type specification
+@attr Any cached_attr2(obj::T) where T = (obj,T,[])
 
 # cached attribute with return type specification depending on the input type
 my_derived_type(::Type{Tmp.Container{T}}) where T = T
@@ -201,7 +201,7 @@ my_derived_type(::Type{Tmp.Container{T}}) where T = T
     @test cached_attr(x) == y
     @test cached_attr(x) === y
 
-    # check cached without type specification is not inferring return types correctly
+    # check cached with bad type specification is not inferring return types correctly
     @test_throws ErrorException @inferred cached_attr2(x)
 
     # check when return type is derived via a function from input type
@@ -225,7 +225,7 @@ my_derived_type(::Type{Tmp.Container{T}}) where T = T
     @test functionloc(uncached_attr)[2] < functionloc(cached_attr)[2]
 end
 
-if VERSION >= v"1.7"
+@static if VERSION >= v"1.7"
     # the following tests need the improved `@macroexpand` from Julia 1.7
     @testset "@attr error handling" begin
         # wrong number of arguments
@@ -233,8 +233,8 @@ if VERSION >= v"1.7"
         @test_throws ArgumentError @macroexpand @attr foo(x::Int, y::Int) = 1
         @test_throws ArgumentError @macroexpand @attr Int foo() = 1
         @test_throws ArgumentError @macroexpand @attr Int foo(x::Int, y::Int) = 1
-        @test_throws ArgumentError @macroexpand @attr Int foo(x::Int) = 1 Any
-        @test_throws ArgumentError @macroexpand @attr Int Int Int
+        @test_throws MethodError @macroexpand @attr Int foo(x::Int) = 1 Any
+        @test_throws MethodError @macroexpand @attr Int Int Int
 
         # wrong kind of arguments
         #@test_throws ArgumentError @macroexpand @attr Int Int


### PR DESCRIPTION
We have a lot of places in our codebases where people use `@attr` without specifying a return type, even though in many of these cases they are very easy too deduce (see e.g. all of the `dim` and `is_*` cases in https://github.com/oscar-system/Oscar.jl/pull/4059). I don't know if this is due to people not knowing about the possibility, forget it, or just don't care. But at least for me, it is usually the second one (see e.g. the Lie algebra changes in https://github.com/oscar-system/Oscar.jl/pull/4059).

Thus I propose to deprecate (in the next breaking release) the use of 1-arg `@attr` (with only a method expression) in favor of explicitly requiring people to write `@attr Any` if they don't want to think of the return type. I think this would be a good measure for enforcing better inferrable code (by just making it harder to shadow inference by accident). And this is something that can be easily adapted by a search-and-replace when doing the AA compat bump downstream.

As always, the change in `deprecations.jl` does not deprecate anything right now, it just provides `Any` as the return type to the 2-arg version, and makes it easy to deprecate it in a future breaking version bump.