### PR TITLE
Add `is_nilpotent(::MatrixElem)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.42.4"
+version = "0.42.5"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -916,6 +916,12 @@ det{T <: RingElem}(::MatElem{T})
 rank{T <: RingElem}(::MatElem{T})
 ```
 
+### Nilpotency
+
+```@docs
+is_nilpotent(::MatrixElem{T}) where {T <: RingElement}
+```
+
 ### Minors
 
 ```@docs

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -3699,6 +3699,7 @@ Return if `A` is nilpotent, i.e. if there exists a natural number $k$
 such that $A^k = 0$. If `A` is not square an exception is raised.
 """
 function is_nilpotent(A::MatrixElem{T}) where {T <: RingElement}
+  is_domain_type(T) || error("Only supported over integral domains")
   !is_square(A) && error("Dimensions don't match in is_nilpotent")
   is_zero(tr(A)) || return false
   n = nrows(A)

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -3688,6 +3688,32 @@ end
 
 ###############################################################################
 #
+#   Nilpotency
+#
+###############################################################################
+
+@doc raw"""
+    is_nilpotent(A::MatrixElem{T}) where {T <: RingElement}
+
+Return if `A` is nilpotent, i.e. if there exists a natural number $k$
+such that $A^k = 0$. If `A` is not square an exception is raised.
+"""
+function is_nilpotent(A::MatrixElem{T}) where {T <: RingElement}
+  !is_square(A) && error("Dimensions don't match in is_nilpotent")
+  A = deepcopy(A)
+  n = nrows(A)
+  i = 1
+  is_zero(A) && return true
+  while i < n
+    i *= 2
+    A = mul!(A, A, A)
+    is_zero(A) && return true
+  end
+  return false
+end
+
+###############################################################################
+#
 #   Hessenberg form
 #
 ###############################################################################

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -3700,8 +3700,9 @@ such that $A^k = 0$. If `A` is not square an exception is raised.
 """
 function is_nilpotent(A::MatrixElem{T}) where {T <: RingElement}
   !is_square(A) && error("Dimensions don't match in is_nilpotent")
-  A = deepcopy(A)
+  is_zero(tr(A)) || return false
   n = nrows(A)
+  A = deepcopy(A)
   i = 1
   is_zero(A) && return true
   while i < n

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -294,6 +294,7 @@ export is_monic
 export is_monomial
 export is_monomial_recursive
 export is_negative
+export is_nilpotent
 export is_odd
 export is_one
 export is_perfect

--- a/test/Matrix-test.jl
+++ b/test/Matrix-test.jl
@@ -66,8 +66,9 @@ end
 
 @testset "Matrix.is_nilpotent" begin
   @test is_nilpotent(zero_matrix(QQ, 3, 3))
-  @test !is_nilpotent(identity_matrix(QQ, 3))
   @test is_nilpotent(upper_triangular_matrix(QQ.([0,1,1,0,1,0])))
+  @test !is_nilpotent(identity_matrix(QQ, 3))
+  @test !is_nilpotent(diagonal_matrix(QQ, [1,-1,0]))
 end
 
 @testset "Matrix.concat" begin

--- a/test/Matrix-test.jl
+++ b/test/Matrix-test.jl
@@ -64,6 +64,12 @@ end
     @test is_upper_triangular(matrix(ZZ, A))
 end
 
+@testset "Matrix.is_nilpotent" begin
+  @test is_nilpotent(zero_matrix(QQ, 3, 3))
+  @test !is_nilpotent(identity_matrix(QQ, 3))
+  @test is_nilpotent(upper_triangular_matrix(QQ.([0,1,1,0,1,0])))
+end
+
 @testset "Matrix.concat" begin
     for R in [ZZ, QQ, polynomial_ring(QQ, [:x, :y])[1]]
         S = matrix_space(R, 3, 3)


### PR DESCRIPTION
I need something for checking nilpotency of a matrix in OSCAR. If you have good ideas for speed improvements, please let me know. Otherwise, I would be happy to get this merged soonish, and performance things can be adapted later anyway.