### PR TITLE
add `number_of_generators` for `UniversalPolyRing`

### DIFF
--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -73,8 +73,14 @@ Universal Polynomial Ring over Integers
 julia> x = gen(S, "x")
 x
 
+julia> number_of_generators(S)
+1
+
 julia> y, z = gens(S, ["y", "z"])
 (y, z)
+
+julia> number_of_generators(S)
+3
 ```
 
 ## Universal polynomial functionality

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -36,6 +36,8 @@ end
 
 number_of_variables(S::UniversalPolyRing) = length(S.S)
 
+number_of_generators(S::UniversalPolyRing) = length(S.S)
+
 symbols(S::UniversalPolyRing) = S.S
 
 function vars(p::UnivPoly{T}) where {T}


### PR DESCRIPTION
It seems like the poor universal polynomials were overlooked again ;-) I tried to make this somehow in line with the `MPoly` implementation. In the documentation examples for the `MPoly`s we are testing `number_of_generators` for equality instead of simply printing the result like in the new examples for `UniversalPolyRing`. Is there a particular reason for this?