### PR TITLE
Fix a bug in gcd for polynomials

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1886,8 +1886,8 @@ function gcd(a::PolyRingElem{T}, b::PolyRingElem{T}, ignore_content::Bool = fals
          end
       end
       b = divexact(b, content(b))
+      b = c*b
    end
-   b = c*b
    return divexact(b, canonical_unit(leading_coefficient(b)))
 end
 


### PR DESCRIPTION
I don't know what this function is doing, so this is an educated guess. For polynomials over fields, another `gcd` is used. The function fixed here is only called if one specifies the `ignore_content = true`.

I found this by calling `is_squarefree` on a polynomial over a number field in Nemo.
