### PR TITLE
Make addmul! fully generic, add docstrings

### DIFF
--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -130,14 +130,6 @@ Base.:\(y::Union{Integer, Rational, AbstractFloat}, x::NCRingElem) = divexact_le
 
 Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 
-function addmul!(z::T, x::T, y::T, c::T) where T <: NCRingElem
-   c = mul!(c, x, y)
-   z = add!(z, c)
-   return z
-end
-
-addmul!(z::T, x::T, y::T) where T <: NCRingElem = addmul!(z, x, y, parent(z)())
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -377,6 +377,28 @@ This is a shorthand for `mul!(a, a, b)`.
 mul!(a, b) = mul!(a, a, b)
 
 @doc raw"""
+    addmul!(a, b, c, t)
+
+Return `a + b * c`, possibly modifying the objects `a` and `t` in the process.
+"""
+function addmul!(a, b, c, t)
+   t = mul!(t, b, c)
+   return add!(a, t)
+end
+
+@doc raw"""
+    addmul!(a, b, c)
+
+Return `a + b * c`, possibly modifying the object `a` in the process.
+
+This is usually a shorthand for `addmul!(a, b, c, parent(a)())`, but
+in some cases may be more efficient. For multiple operations in a row
+that use temporary storage, it is still best to use the four argument
+version.
+"""
+addmul!(a, b, c) = addmul!(a, b, c, parent(a)())
+
+@doc raw"""
     div!(a, b, c)
 
 Return `div(b, c)`, possibly modifying the object `a` in the process.

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3894,6 +3894,14 @@ function add!(a::MPoly{T}, b::MPoly{T}, c::MPoly{T}) where {T <: RingElement}
    return a
 end
 
+function sub!(a::MPoly{T}, b::MPoly{T}, c::MPoly{T}) where {T <: RingElement}
+   t = b - c
+   a.coeffs = t.coeffs
+   a.exps = t.exps
+   a.length = t.length
+   return a
+end
+
 function mul!(a::MPoly{T}, b::MPoly{T}, c::MPoly{T}) where {T <: RingElement}
    t = b*c
    a.coeffs = t.coeffs
@@ -3902,20 +3910,9 @@ function mul!(a::MPoly{T}, b::MPoly{T}, c::MPoly{T}) where {T <: RingElement}
    return a
 end
 
-function add!(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
-   t = a + b
-   a.coeffs = t.coeffs
-   a.exps = t.exps
-   a.length = t.length
-   return a
-end
-
 function addmul!(a::MPoly{T}, b::MPoly{T}, c::MPoly{T}) where {T <: RingElement}
-   t = a + (b * c)
-   a.coeffs = t.coeffs
-   a.exps = t.exps
-   a.length = t.length
-   return a
+   t = b * c
+   return add!(a, t)
 end
 
 function resize_exps!(a::Matrix{UInt}, n::Int)

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -721,15 +721,6 @@ function fit!(a::SparsePoly{T}, n::Int) where {T <: RingElement}
    return nothing
 end
 
-function addmul!(a::SparsePoly{T}, b::SparsePoly{T}, c::SparsePoly{T}, d::SparsePoly{T}) where {T <: RingElement}
-   t = b*c
-   t += a
-   a.coeffs = t.coeffs
-   a.exps = t.exps
-   a.length = t.length
-   return a
-end
-
 function mul!(a::SparsePoly{T}, b::SparsePoly{T}, c::SparsePoly{T}) where {T <: RingElement}
    t = b*c
    a.coeffs = t.coeffs
@@ -740,6 +731,14 @@ end
 
 function add!(a::SparsePoly{T}, b::SparsePoly{T}, c::SparsePoly{T}) where {T <: RingElement}
    t = b + c
+   a.coeffs = t.coeffs
+   a.exps = t.exps
+   a.length = t.length
+   return a
+end
+
+function sub!(a::SparsePoly{T}, b::SparsePoly{T}, c::SparsePoly{T}) where {T <: RingElement}
+   t = b - c
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1011,13 +1011,13 @@ function add!(a::UnivPoly{T}, b::UnivPoly{T}, c::UnivPoly{T}) where {T <: RingEl
    return a
 end
 
-function mul!(a::UnivPoly{T}, b::UnivPoly{T}, c::UnivPoly{T}) where {T <: RingElement}
-   a.p = mul!(a.p, b.p, c.p)
+function sub!(a::UnivPoly{T}, b::UnivPoly{T}, c::UnivPoly{T}) where {T <: RingElement}
+   a.p = sub!(a.p, b.p, c.p)
    return a
 end
 
-function addmul!(a::UnivPoly{T}, b::UnivPoly{T}, c::UnivPoly{T}) where {T <: RingElement}
-   a.p = (a + b*c).p
+function mul!(a::UnivPoly{T}, b::UnivPoly{T}, c::UnivPoly{T}) where {T <: RingElement}
+   a.p = mul!(a.p, b.p, c.p)
    return a
 end
 

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -161,11 +161,6 @@ end
 # No actual mutation is permitted for Julia types
 # See #1077
 
-
-function addmul!(a::T, b::T, c::T, d::T) where T <: AbstractFloat
-   return a + b*c
-end
-
 function addmul!(a::T, b::T, c::T) where T <: AbstractFloat # special case, no temporary required
    return a + b*c
 end

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -539,11 +539,6 @@ end
 # No actual mutation is permitted for Julia types
 # See #1077
 
-
-function addmul!(a::T, b::T, c::T, d::T) where T <: Integer
-   return a + b*c
-end
-
 function addmul!(a::T, b::T, c::T) where T <: Integer # special case, no temporary required
    return a + b*c
 end

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -279,12 +279,6 @@ function add!(a::Rational{T}, b::Rational{T}) where T <: Integer
    end
 end
 
-function addmul!(a::Rational{T}, b::Rational{T}, c::Rational{T}, d::Rational{T}) where T <: Integer
-   d = mul!(d, b, c)
-   a = add!(a, d)
-   return a
-end
-
 ###############################################################################
 #
 #   Random generation


### PR DESCRIPTION
Now we can e.g. use addmul! on 3 or 4 ZZMatrix instances and get an efficient result.

Use this to get rid of some now redundant `addmul!` methods.

Also remove some redundant `add!` methods and add some `sub!` methods.