### PR TITLE
Add `is_nothing` alias

### DIFF
--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -6,6 +6,7 @@
 @alias is_inf isinf
 @alias is_integer isinteger
 @alias is_less isless
+@alias is_nothing isnothing
 @alias is_odd isodd
 @alias is_one isone
 @alias is_real isreal


### PR DESCRIPTION
I now expected this to exist multiple times, we have similarly used aliases for `iszero` and `isone` already, so I see no reason to not add this.