### PR TITLE
Allow more inputs for `gens(::UniversalPolyRing, ...)`

### DIFF
--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -65,7 +65,9 @@ julia> number_of_generators(S)
 1
 
 julia> y, z = gens(S, [:y, :z])
-(y, z)
+2-element Vector{AbstractAlgebra.Generic.UnivPoly{BigInt}}:
+ y
+ z
 
 julia> number_of_generators(S)
 3

--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -84,7 +84,9 @@ julia> x = gen(S, :x)
 x
 
 julia> y, z = gens(S, [:y, :z])
-(y, z)
+2-element Vector{AbstractAlgebra.Generic.UnivPoly{BigInt}}:
+ y
+ z
 
 julia> x*y - z
 x*y - z

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -264,10 +264,15 @@ end
 
 gen(S::UniversalPolyRing, s::VarName) = gens(S, [s])[1]
 
-function gens(S::UniversalPolyRing{T}, v::Vector{<:VarName}) where {T <: RingElement}
-   idx = _ensure_variables(S, v)
-   return tuple((UnivPoly{T}(gen(mpoly_ring(S), i), S) for i in idx)...)
-end
+#function gens(S::UniversalPolyRing{T}, v::Vector{<:VarName}) where {T <: RingElement}
+#   idx = _ensure_variables(S, v)
+#   return tuple((UnivPoly{T}(gen(mpoly_ring(S), i), S) for i in idx)...)
+#end
+
+# @varnames_interface expects the 
+gens(S::UniversalPolyRing, varnames...) = _gens(S, varnames...)[2:end]
+_gens(S::UniversalPolyRing, v::Vector{Symbol}) = nothing, [gen(S, s) for s in v]
+@varnames_interface _gens(S::UniversalPolyRing, s)
 
 function gen(S::UniversalPolyRing{T}, i::Int) where {T}
    @boundscheck 1 <= i <= nvars(S) || throw(ArgumentError("generator index out of range"))

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -323,7 +323,7 @@ end
       @test length(2x2^2 + 3x2 + 1) == 3
 
       @test gen(S, :x) == x
-      @test gens(S, ['x', 'y']) == (x, y)
+      @test gens(S, ['x', 'y']) == [x, y]
       @test gen(S, 1) == x
       @test gen(S, 2) == y
       @test gen(S, 3) == z

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -337,6 +337,12 @@ end
       @test vars(2x2^2 + 3x2 + 1) == [x]
 
       @test characteristic(S) == 0
+
+      xs, ys = gens(S, :x => (1:4), :y =>(1:2, 1:3))
+      @test xs isa Vector{elem_type(S)}
+      @test length(xs) == 4
+      @test ys isa Matrix{elem_type(S)}
+      @test size(ys) == (2, 3)
    end
 end
 


### PR DESCRIPTION
using `@varnames_interface` with a small workaround.

Due to weirdness with this macro between modules and inclusion order, I distributed the macro calls to respective files.