### PR TITLE
Correct mutating op fallbacks

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -16,7 +16,7 @@ is_zero_divisor(a::T) where T <: FieldElem = is_zero(a)
 
 Base.divrem(a::T, b::T) where {T <: FieldElem} = divexact(a, b), zero(parent(a))
 
-div(a::T, b::T) where {T <: FieldElem} = divexact(a, b)
+Base.div(a::T, b::T) where {T <: FieldElem} = divexact(a, b)
 
 function gcd(x::T, y::T) where {T <: FieldElem}
    check_parent(x, y)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1479,11 +1479,6 @@ function Base.divrem(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: RingElem
    return q, f
 end
 
-function Base.div(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: RingElement
-   q, r = divrem(f, g)
-   return q
-end
-
 ##############################################################################
 #
 #  Ad hoc Euclidean division

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -328,11 +328,16 @@ neg!(a) = neg!(a, a)
     inv!(z, a)
     inv!(a)
 
-Return `inv(a)`, possibly modifying the object `z` in the process.
+Return `AbstractAlgebra.inv(a)`, possibly modifying the object `z` in the process.
 Aliasing is permitted.
 The unary version is a shorthand for `inv!(a, a)`.
+
+!!! note
+    `AbstractAlgebra.inv` and `Base.inv` differ only in their behavior on julia
+    types like `Integer` and `Rational{Int}`. The former makes it adhere to the
+    Ring interface.
 """
-inv!(z, a) = inv(a)
+inv!(z, a) = AbstractAlgebra.inv(a)
 inv!(a) = inv!(a, a)
 
 for (name, op) in ((:add!, :+), (:sub!, :-), (:mul!, :*))
@@ -378,7 +383,7 @@ submul!(z, a, b) = submul!(z, a, b, parent(z)())
 
 function divexact end
 
-for name in (:divexact, :div, :rem, :mod, :gcd, :lcm)
+for name in (:divexact, :rem, :mod, :gcd, :lcm)
   name_bang = Symbol(name, "!")
   @eval begin
     @doc """
@@ -393,6 +398,22 @@ for name in (:divexact, :div, :rem, :mod, :gcd, :lcm)
     $name_bang(a, b) = $name_bang(a, a, b)
   end
 end
+
+@doc """
+    div!(z, a, b)
+    div!(a, b)
+
+Return `div(a, b)`, possibly modifying the object `z` in the process.
+Aliasing is permitted.
+The two argument version is a shorthand for `div(a, a, b)`.
+
+!!! note
+    `AbstractAlgebra.div` and `Base.div` differ only in their behavior on julia
+    types like `Integer` and `Rational{Int}`. The former makes it adhere to the
+    Ring interface.
+"""
+div!(z, a, b) = AbstractAlgebra.div(a, b)
+div!(a, b) = div!(a, a, b)
 
 @doc raw"""
     canonical_injection(D, i)

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -106,7 +106,7 @@ function is_gen(a::LaurentMPolyWrap)
     return !iszero(_var_index(a))
 end
 
-function inv(a::LaurentMPolyWrap)
+function Base.inv(a::LaurentMPolyWrap)
     (ap, ad) = _normalize(a)
     return LaurentMPolyWrap(parent(a), inv(ap), neg!(ad, ad))
 end
@@ -204,7 +204,7 @@ function gcd(a::LaurentMPolyWrap, b::LaurentMPolyWrap)
     return LaurentMPolyWrap(parent(a), gcd(ap, bp), zero!(ad))
 end
 
-function divrem(a::LaurentMPolyWrap, b::LaurentMPolyWrap)
+function Base.divrem(a::LaurentMPolyWrap, b::LaurentMPolyWrap)
     check_parent(a, b)
     error("divrem not implemented for LaurentMPoly")
 end

--- a/src/generic/Misc/Localization.jl
+++ b/src/generic/Misc/Localization.jl
@@ -263,10 +263,6 @@ function Base.divrem(a::LocalizedEuclideanRingElem{T}, b::LocalizedEuclideanRing
   end
 end
 
-function Base.div(a::LocalizedEuclideanRingElem{T}, b::LocalizedEuclideanRingElem{T}) where {T}
-  return divrem(a, b)[1]
-end
-
 function rem(a::LocalizedEuclideanRingElem{T}, b::LocalizedEuclideanRingElem{T}) where {T}
   return divrem(a, b)[2]
 end


### PR DESCRIPTION
`Base.inv` and `AbstractAlgebra.inv` differ in handling Integers. The base version returns floats, while the AA version errors if it doesn't get a unit.

Similarly, `Base.div` and `AbstractAlgebra.div` differ. For this function, we need to either change the fallback of `div!` from `AbstractAlgebra.div` to `Base.div`, or change the docstring in a similar way as for `inv!`. Which of the two do we want here?

(In the any case, https://github.com/Nemocas/AbstractAlgebra.jl/pull/1816 needs to be adjusted to be consistent.)