### PR TITLE
Change eltype defs to `Type{...}` and some iterator cleanup

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -506,7 +506,6 @@ function Base.iterate(a::MatrixElem{T}, ij=(0, 1)) where T <: NCRingElement
 end
 
 Base.IteratorSize(::Type{<:MatrixElem}) = Base.HasShape{2}()
-Base.IteratorEltype(::Type{<:MatrixElem}) = Base.HasEltype() # default
 
 Base.pairs(M::MatElem) = Base.pairs(IndexCartesian(), M)
 Base.pairs(::IndexCartesian, M::MatElem) = Base.Iterators.Pairs(M, CartesianIndices(axes(M)))

--- a/src/Module.jl
+++ b/src/Module.jl
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-Base.eltype(M::FPModule{T}) where T <: FinFieldElem = elem_type(M)
+Base.eltype(T::Type{<:FPModule{<:FinFieldElem}}) = elem_type(T)
 
 function zero(M::FPModule{T}) where T <: RingElement
    R = base_ring(M)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -400,20 +400,10 @@ function Base.iterate(PCR::Iterators.Reverse{<:PolyCoeffs{<:PolyRingElem}},
    end
 end
  
-Base.IteratorEltype(M::PolyRingElem) = Base.HasEltype()
+Base.eltype(::Type{<:PolyRingElem{T}}) where {T} = T
 
-Base.eltype(M::PolyRingElem{T}) where {T} = T
-
-Base.eltype(M::PolyCoeffs) = Base.eltype(M.f)
+Base.eltype(::Type{PolyCoeffs{T}}) where {T} = Base.eltype(T)
  
-Base.eltype(M::Iterators.Reverse{<:PolyCoeffs}) = Base.eltype(M.itr.f)
-
-Base.eltype(M::Iterators.Take{<:PolyCoeffs}) = Base.eltype(M.xs.f)
-
-Base.eltype(M::Iterators.Take{<:Iterators.Reverse{<:PolyCoeffs}}) = Base.eltype(M.xs.itr.f)
-
-Base.IteratorSize(M::PolyCoeffs{<:PolyRingElem}) = Base.HasLength()
-
 Base.length(M::PolyCoeffs{<:PolyRingElem}) = length(M.f)
  
 function Base.lastindex(a::PolyCoeffs{<:PolyRingElem})

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -234,7 +234,7 @@ function Base.length(
 end
 
 function Base.eltype(
-    x::FreeAssAlgExponentWords{T},
+    ::Type{FreeAssAlgExponentWords{T}},
 ) where {S <: RingElement, T <: FreeAssociativeAlgebraElem{S}}
     return Vector{Int}
 end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -931,19 +931,19 @@ function Base.length(x::Union{MPolyCoeffs, MPolyExponentVectors, MPolyTerms, MPo
    return length(x.poly)
 end
 
-function Base.eltype(x::MPolyCoeffs{T}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{MPolyCoeffs{T}}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
    return S
 end
 
-function Base.eltype(x::MPolyExponentVectors{T}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{MPolyExponentVectors{T}}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
    return Vector{Int}
 end
 
-function Base.eltype(x::MPolyMonomials{T}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{MPolyMonomials{T}}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
    return T
 end
 
-function Base.eltype(x::MPolyTerms{T}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{MPolyTerms{T}}) where T <: AbstractAlgebra.MPolyRingElem{S} where S <: RingElement
    return T
 end
 

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -628,8 +628,6 @@ julia> unique(A)
 """
 elements!(G::SymmetricGroup)= (p for p in AllPerms(G.n))
 
-Base.IteratorSize(::Type{<:SymmetricGroup}) = Base.HasLength()
-
 @inline function Base.iterate(G::SymmetricGroup)
    A = AllPerms(G.n)
    a, b = iterate(A)

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -466,19 +466,19 @@ function Base.length(x::Union{UnivPolyCoeffs, UnivPolyExponentVectors, UnivPolyT
    return length(x.poly)
 end
 
-function Base.eltype(x::UnivPolyCoeffs{T}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{UnivPolyCoeffs{T}}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
    return S
 end
 
-function Base.eltype(x::UnivPolyExponentVectors{T}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{UnivPolyExponentVectors{T}}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
    return Vector{Int}
 end
 
-function Base.eltype(x::UnivPolyMonomials{T}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{UnivPolyMonomials{T}}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
    return T
 end
 
-function Base.eltype(x::UnivPolyTerms{T}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
+function Base.eltype(::Type{UnivPolyTerms{T}}) where T <: AbstractAlgebra.UniversalPolyRingElem{S} where S <: RingElement
    return T
 end
 


### PR DESCRIPTION
> However the form that accepts a type argument should be defined for
  new types. (docstring of `eltype`)

this makes it possible to clean up some of the `eltype` methods.
furthermore remove some useless iterator getters that just reproduce julia defaults