### PR TITLE
Add `free_associative_algebra_type`

### DIFF
--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -254,3 +254,24 @@ end
 function rand(S::FreeAssociativeAlgebra, term_range, exp_bound, v...)
    rand(GLOBAL_RNG, S, term_range, exp_bound, v...)
 end
+
+###############################################################################
+#
+#   free_associative_algebra constructor
+#
+###############################################################################
+
+function free_associative_algebra(
+  R::AbstractAlgebra.Ring,
+  s::Vector{Symbol};
+  cached::Bool = true,
+)
+  parent_obj = Generic.FreeAssociativeAlgebra{elem_type(R)}(R, s, cached)
+  return (parent_obj, gens(parent_obj))
+end
+
+free_associative_algebra_type(::Type{T}) where T<:RingElement = Generic.FreeAssociativeAlgebra{T}
+
+free_associative_algebra_type(::Type{S}) where S<:Ring = free_associative_algebra_type(elem_type(S))
+free_associative_algebra_type(x) = free_associative_algebra_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
+free_associative_algebra_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `RingElement`."))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -220,6 +220,7 @@ export finish
 export fit!
 export fraction_field
 export free_associative_algebra
+export free_associative_algebra_type
 export free_module
 export function_field
 export gcd

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -696,19 +696,3 @@ function _map(g::S, a::FreeAssociativeAlgebraElem{T}, Rx) where {S, T <: RingEle
 
     return finish(M)
 end
-
-
-###############################################################################
-#
-#   free_associative_algebra constructor
-#
-###############################################################################
-
-function free_associative_algebra(
-    R::AbstractAlgebra.Ring,
-    s::Vector{Symbol};
-    cached::Bool = true,
-)
-    parent_obj = FreeAssociativeAlgebra{elem_type(R)}(R, s, cached)
-    return (parent_obj, gens(parent_obj))
-end

--- a/src/misc/VarNames.jl
+++ b/src/misc/VarNames.jl
@@ -475,7 +475,7 @@ macro varnames_interface(e::Expr, options::Expr...)
     end
 end
 
-@varnames_interface Generic.free_associative_algebra(R::Ring, s)
+@varnames_interface free_associative_algebra(R::Ring, s)
 @varnames_interface Generic.laurent_polynomial_ring(R::Ring, s)
 @varnames_interface Generic.rational_function_field(K::Field, s)
 

--- a/test/generic/FreeAssociativeAlgebra-test.jl
+++ b/test/generic/FreeAssociativeAlgebra-test.jl
@@ -1,10 +1,14 @@
 @testset "Generic.FreeAssociativeAlgebra.constructors" begin
    R, x = ZZ["y"]
+   @test free_associative_algebra_type(R) == free_associative_algebra_type(typeof(R))
+   @test free_associative_algebra_type(R) == free_associative_algebra_type(elem_type(R))
+   @test isconcretetype(free_associative_algebra_type(R))
 
    for num_vars = 1:5
       var_names = ["x$j" for j in 1:num_vars]
 
       S, varlist = free_associative_algebra(R, var_names)
+      @test S isa free_associative_algebra_type(R)
 
       @test free_associative_algebra(R, var_names, cached = true)[1] === free_associative_algebra(R, var_names, cached = true)[1]
       @test free_associative_algebra(R, var_names, cached = false)[1] !== free_associative_algebra(R, var_names, cached = true)[1]


### PR DESCRIPTION
This is analogous to `dense_poly_ring_type` and friends, and can be used to assert concrete types in downstream code that currently uses the abstract type `FreeAssociativeAlgebra` (even though we currently only have one subtype, namely `Generic.FreeAssociativeAlgebra`).