### PR TITLE
More generic test_elem methods

### DIFF
--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -13,6 +13,67 @@
 # - test_MatSpace_interface(R)
 # - test_MatAlgebra_interface(R)
 
+#
+# add methods for test_elem on ring elements here
+#
+
+function test_elem(R::AbstractAlgebra.Integers)
+   n = big(2)^rand((1,1,1,2,3,10,31,32,33,63,64,65,100))
+   return rand(R, -n:n)
+end
+
+function test_elem(R::AbstractAlgebra.Rationals)
+   B = base_ring(R)
+   n = test_elem(B)
+   d = test_elem(B)
+   return is_zero(d) ? R(n) : R(n, d)
+end
+
+function test_elem(R::AbstractAlgebra.FinField)
+   return rand(R)
+end
+
+function test_elem(R::AbstractAlgebra.Floats{T}) where T
+   return rand(T)*rand(-100:100)
+end
+
+function test_elem(Rx::AbstractAlgebra.PolyRing)
+   R = base_ring(Rx)
+   return Rx(elem_type(R)[test_elem(R) for i in 1:rand(0:6)])
+end
+
+function test_elem(S::Union{AbstractAlgebra.MatSpace,
+                            AbstractAlgebra.MatRing})
+   R = base_ring(S)
+   return S(elem_type(R)[test_elem(R) for i in 1:nrows(S), j in 1:ncols(S)])
+end
+
+function test_elem(R::AbstractAlgebra.EuclideanRingResidueRing)
+   return R(test_elem(base_ring(R)))
+end
+
+function test_elem(Rx::AbstractAlgebra.SeriesRing)
+   R = base_ring(Rx)
+   prec = rand(3:10)
+   len = rand(0:prec-1)
+   val = rand(0:prec-len)
+   # FIXME: constructors don't seem to catch use of negative val
+   @assert val >= 0
+   A = elem_type(R)[test_elem(R) for i in 1:len]
+   if len > 0 && is_zero(A[1])
+     A[1] = one(R)
+   end
+   if elem_type(Rx) <: RelPowerSeriesRingElem
+     @assert prec >= len + val
+     return Rx(A, len, prec, val)
+   else
+     @assert prec >= len
+     return Rx(A, len, prec)
+   end
+end
+
+
+# helper
 function equality(a::T, b::T) where T <: AbstractAlgebra.NCRingElement
    if is_exact_type(T)
       return a == b
@@ -484,11 +545,6 @@ function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 20)
 end
 
 
-function test_elem(Rx::AbstractAlgebra.PolyRing)
-   R = base_ring(Rx)
-   return Rx(elem_type(R)[test_elem(R) for i in 1:rand(0:6)])
-end
-
 function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
 
    T = elem_type(Rx)
@@ -568,12 +624,6 @@ function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
    end
 
    return nothing
-end
-
-function test_elem(S::Union{AbstractAlgebra.MatSpace,
-                            AbstractAlgebra.MatRing})
-   R = base_ring(S)
-   return S(elem_type(R)[test_elem(R) for i in 1:nrows(S), j in 1:ncols(S)])
 end
 
 

--- a/test/conformance-tests.jl
+++ b/test/conformance-tests.jl
@@ -1,19 +1,2 @@
+include("Groups-conformance-tests.jl")
 include("Rings-conformance-tests.jl")
-# TODO: add more
-
-# add methods for test_elem here
-
-function test_elem(R::AbstractAlgebra.Integers{BigInt})
-   n = big(2)^rand(1:100)
-   return rand(ZZ, -n:n)
-end
-
-function test_elem(R::AbstractAlgebra.Rationals{BigInt})
-   n = big(2)^rand(1:100)
-   m = big(2)^rand(1:100)
-   return rand(ZZ, -n:n)//rand(ZZ, 1:m)
-end
-
-function test_elem(R::AbstractAlgebra.GFField{Int64})
-   return rand(R)
-end

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -16,10 +16,6 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_elem(R::AbstractAlgebra.Generic.AbsPowerSeriesRing{BigInt})
-   rand(R, 0:12, -10:10)
-end
-
 @testset "Generic.AbsSeries.conformance" begin
    R, x = power_series_ring(ZZ, 30, "x", model=:capped_absolute)
    test_Ring_interface(R)

--- a/test/generic/PermGroupAPI-test.jl
+++ b/test/generic/PermGroupAPI-test.jl
@@ -1,6 +1,4 @@
 @testset "Groups API PermGroup" begin
-
-    include(joinpath(dirname(dirname(pathof(AbstractAlgebra))), "test", "Groups-conformance-tests.jl"))
     @testset "Sym($n)" for n in [1,2,5,10]
         G = SymmetricGroup(n)
         test_Group_interface(G)

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -16,10 +16,6 @@
 # Note: only useful to distinguish rings and fields for 1/2, 3/4, 5/6 if the
 # algos differ, and 7 can often stand in for 5/6 if the algorithm supports it.
 
-function test_elem(R::AbstractAlgebra.Generic.RelPowerSeriesRing{BigInt})
-   rand(R, 0:12, -10:10)
-end
-
 @testset "Generic.RelSeries.conformance" begin
    R, x = power_series_ring(ZZ, 10, "x")
    test_Ring_interface(R)

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,11 +1,3 @@
-function test_elem(R::AbstractAlgebra.EuclideanRingResidueRing{BigInt})
-   return rand(R, 0:characteristic(R))
-end
-
-function test_elem(R::AbstractAlgebra.EuclideanRingResidueRing{AbstractAlgebra.Generic.Poly{T}}) where T
-   return rand(R, 0:100, -100:100)
-end
-
 @testset "EuclideanRingResidueRingElem.conformance_tests" begin
    test_Ring_interface(residue_ring(ZZ, 1)[1])   # is_gen fails on polys
    test_Ring_interface_recursive(residue_ring(ZZ, -4)[1])

--- a/test/julia/Floats-test.jl
+++ b/test/julia/Floats-test.jl
@@ -1,11 +1,3 @@
-function test_elem(R::AbstractAlgebra.Floats{Float64})
-   return rand(Float64)*rand(-100:100)
-end
-
-function test_elem(R::AbstractAlgebra.Floats{BigFloat})
-   return rand(BigFloat)*rand(-100:100)
-end
-
 @testset "Julia.Floats.conformance_tests" begin
    test_Ring_interface(RDF)
    test_Ring_interface(RealField)

--- a/test/julia/GFElem-test.jl
+++ b/test/julia/GFElem-test.jl
@@ -1,7 +1,3 @@
-function test_elem(R::AbstractAlgebra.GFField)
-   return rand(R)
-end
-
 @testset "Julia.GFElem.conformance_tests" begin
    test_Field_interface_recursive(GF(3))
    test_Field_interface_recursive(GF(13))

--- a/test/julia/Rationals-test.jl
+++ b/test/julia/Rationals-test.jl
@@ -1,8 +1,3 @@
-function test_elem(R::AbstractAlgebra.Rationals{BigInt})
-   n = big(2)^rand(1:100)
-   return rand(QQ, -n:n)
-end
-
 @testset "Julia.Rationals.conformance_tests" begin
    test_Field_interface_recursive(QQ)
 end


### PR DESCRIPTION
Also make sure other packages which only load Rings-conformance-tests.jl
get them.

Finally cleanup how we include Groups-conformance-tests.jl


Unfortunately this causes test failures and eventually a bus error crash (!). This is due to the `test_elem(Rx::AbstractAlgebra.SeriesRing)` method. The crash can be triggered with
```
R, x = power_series_ring(ZZ, 10, :x)
include("test/Rings-conformance-tests.jl");
test_Ring_interface(R)
```
Note that there are failures before that because the tests for the unsafe ops `add!` etc. don't take into account that the series rings are inexact. I hope #1816 will fix that part.

But even taking that into account, we really shouldn't get a hard crash here