### PR TITLE
Throw an error in case of division by zero instead of crashing hard

### DIFF
--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -177,6 +177,7 @@ function divexact(a::Integer, b::Integer; check::Bool=true)
 end
 
 function divexact(a::BigInt, b::BigInt; check::Bool=true)
+   iszero(b) && throw(DivideError())
    q = BigInt()
    if check
       r = BigInt()
@@ -191,6 +192,7 @@ function divexact(a::BigInt, b::BigInt; check::Bool=true)
 end
 
 function divexact(a::BigInt, b::Int; check::Bool=true)
+   iszero(b) && throw(DivideError())
    q = BigInt()
    sgn = b < 0
    if check
@@ -206,6 +208,7 @@ function divexact(a::BigInt, b::Int; check::Bool=true)
 end
 
 function divexact(a::BigInt, b::UInt; check::Bool=true)
+   iszero(b) && throw(DivideError())
    q = BigInt()
    if check
       r = BigInt()

--- a/test/julia/Integers-test.jl
+++ b/test/julia/Integers-test.jl
@@ -66,6 +66,13 @@ end
    @test_throws ArgumentError divexact(big(10), big(4))
    @test_throws ArgumentError divexact(big(10), 4)
 
+   @test_throws DivideError divexact(big(10), big(0))
+   @test_throws DivideError divexact(big(10), big(0), check = false)
+   @test_throws DivideError divexact(big(10), 0)
+   @test_throws DivideError divexact(big(10), 0, check = false)
+   @test_throws DivideError divexact(big(10), UInt(0))
+   @test_throws DivideError divexact(big(10), UInt(0), check = false)
+
    for iter = 1:1000
       a1 = rand(R, -100:100)
       a2 = rand(R, -100:100)


### PR DESCRIPTION
Apparently, `__gmpz_divexact` crashes in case of a division by 0. I would say that we should throw an error even if `check = false`.
