### PR TITLE
Bump version to 0.43.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.43.3"
+version = "0.43.4"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
To be merged and released once 

- https://github.com/Nemocas/AbstractAlgebra.jl/pull/1827
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/1831
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/1811
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/1836

are merged.