### PR TITLE
Add a docstring for universal_polynomial_ring

### DIFF
--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -41,18 +41,8 @@ construct the universal polynomial ring itself. This is unique given a base ring
 The universal polynomial ring over a given base ring `R` is constructed with
 one of the following constructor functions.
 
-```julia
-universal_polynomial_ring(R::Ring; cached::Bool = true, internal_ordering::Symbol=:lex)
-```
-
-Given a base ring `R` and an array `S` of strings, return an object representing
-the universal polynomial ring $S = R[\ldots]$ with no variables in it initially.
-
-**Examples**
-
-```jldoctest
-julia> S = universal_polynomial_ring(ZZ)
-Universal Polynomial Ring over Integers
+```@docs
+universal_polynomial_ring
 ```
 
 ## Adding variables

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1121,7 +1121,7 @@ the universal polynomial ring $S = R[\ldots]$ with no variables in it initially.
 
 # Examples
 
-```jldoctest
+```jldoctest; setup = :(using AbstractAlgebra)
 julia> S = universal_polynomial_ring(ZZ)
 Universal Polynomial Ring over Integers
 

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1134,7 +1134,6 @@ julia> y, z = gens(S, [:y, :z])
 julia> x*y - z
 x*y - z
 ```
-
 """
 function universal_polynomial_ring(R::Ring; cached::Bool=true, internal_ordering::Symbol=:lex)
    T = elem_type(R)

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1113,7 +1113,30 @@ end
 #
 ###############################################################################
 
-function universal_polynomial_ring(R::Ring; internal_ordering=:lex, cached::Bool=true)
+@doc raw"""
+    universal_polynomial_ring(R::Ring; cached::Bool=true, internal_ordering::Symbol=:lex)
+
+Given a base ring `R`, return an object representing
+the universal polynomial ring $S = R[\ldots]$ with no variables in it initially.
+
+# Examples
+
+```jldoctest
+julia> S = universal_polynomial_ring(ZZ)
+Universal Polynomial Ring over Integers
+
+julia> x = gen(S, :x)
+x
+
+julia> y, z = gens(S, [:y, :z])
+(y, z)
+
+julia> x*y - z
+x*y - z
+```
+
+"""
+function universal_polynomial_ring(R::Ring; cached::Bool=true, internal_ordering::Symbol=:lex)
    T = elem_type(R)
    U = mpoly_type(R)
 


### PR DESCRIPTION
Also replacedocumentation for `universal_polynomial_ring` in
the manual by that docstring -- this also fixes a mistake in
it, as the manual mentioned a non-existing argument `S`.
