### PR TITLE
Add `eachrow` and `eachcol`

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -616,6 +616,20 @@ axes(t::MatrixElem{T}, d::Integer) where T <: NCRingElement = Base.OneTo(size(t,
 
 ###############################################################################
 #
+#   eachrow / eachcol
+#
+###############################################################################
+
+@static if VERSION < v"1.9"
+  Base.eachrow(a::MatrixElem) = (view(a, i, :) for i in 1:nrows(a))
+  Base.eachcol(a::MatrixElem) = (view(a, :, i) for i in 1:ncols(a))
+else
+  Base.eachrow(a::MatrixElem) = Slices(a, (1, :), (axes(a, 1),))
+  Base.eachcol(a::MatrixElem) = Slices(a, (:, 1), (axes(a, 2),))
+end
+
+###############################################################################
+#
 #   Matrix spaces iteration
 #
 ###############################################################################

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -4058,6 +4058,20 @@ end
    end
 end
 
+@testset "Generic.Mat.slices" begin
+  A = ZZ[1 2 3; 4 5 6]
+  @test length(eachrow(A)) == nrows(A)
+  @test length(eachcol(A)) == ncols(A)
+
+  @test first(eachrow(A)) == [ZZ(1), ZZ(2), ZZ(3)]
+  @test first(eachcol(A)) == [ZZ(1), ZZ(4)]
+
+  A = zero_matrix(ZZ, 2, 0)
+  @test length(eachrow(A)) == nrows(A)
+  @test length(eachcol(A)) == ncols(A)
+  @test first(eachrow(A)) == elem_type(ZZ)[]
+end
+
 @testset "Generic.Mat.change_base_ring" begin
    for (P, Q, T) in ((matrix_space(ZZ, 2, 3), matrix_space(ZZ, 3, 2), MatElem),
                      (matrix_ring(ZZ, 3), matrix_ring(ZZ, 3), MatRingElem))


### PR DESCRIPTION
Closes https://github.com/oscar-system/Oscar.jl/issues/4175 .

This needs some extra work because `Slices` only exists since Julia 1.9. Is it fine like this?
