### PR TITLE
Restrict unsafe ops for ResElem to EuclideanRingResidueRingElem

### DIFF
--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -406,27 +406,6 @@ _div_for_howell_form(a::T, b::T) where {T <: RingElement} = div(a, b)
 
 ###############################################################################
 #
-#   Unsafe functions
-#
-###############################################################################
-
-function zero!(a::ResElem{T}) where {T <: RingElement}
-   a.data = zero!(a.data)
-   return a
-end
-
-function mul!(c::ResElem{T}, a::ResElem{T}, b::ResElem{T}) where {T <: RingElement}
-   c.data = mod(data(a)*data(b), modulus(a))
-   return c
-end
-
-function add!(c::ResElem{T}, a::ResElem{T}, b::ResElem{T}) where {T <: RingElement}
-   c.data = mod(data(a) + data(b), modulus(a))
-   return c
-end
-
-###############################################################################
-#
 #   Random functions
 #
 ###############################################################################

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -125,3 +125,24 @@ function rand(R::Union{EuclideanRingResidueRing{T}, EuclideanRingResidueField{T}
    end
    return r
 end
+
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
+
+function zero!(a::T) where {T <: EuclideanRingResidueRingElem}
+   a.data = zero!(a.data)
+   return a
+end
+
+function mul!(c::T, a::T, b::T) where {T <: EuclideanRingResidueRingElem}
+   c.data = mod(data(a)*data(b), modulus(a))
+   return c
+end
+
+function add!(c::T, a::T, b::T) where {T <: EuclideanRingResidueRingElem}
+   c.data = mod(data(a) + data(b), modulus(a))
+   return c
+end


### PR DESCRIPTION
They rely on implementation details and thus are not truly generic.
In practice they cause problems for ResElem subtypes in Nemo.
