### PR TITLE
Merge MatSpace and Generic.MatSpace

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -34,7 +34,7 @@ For the most part, one doesn't want to work directly with the `MatSpaceElem` typ
 but with an abstract type called `Generic.Mat` which includes `MatSpaceElem` and views
 thereof.
 
-Parents of generic matrices (matrix spaces) have type `Generic.MatSpace{T}`. Parents of
+Parents of generic matrices (matrix spaces) have type `MatSpace{T}`. Parents of
 matrices in a matrix algebra have type `Generic.MatRing{T}`.
 
 The dimensions and base ring $R$ of a generic matrix are stored in its parent object,
@@ -47,9 +47,10 @@ demand.
 ## Abstract types
 
 The generic matrix types (matrix spaces) belong to the abstract type
-`MatElem{T}` and the matrix space parent types belong to
-`MatSpace{T}`. Similarly the generic matrix algebra matrix types belong
-to the abstract type `MatRingElem{T}` and the parent types belong to
+`MatElem{T}` and the all matrix space parents are of the concrete type
+`MatSpace{T}`.
+On the other hand, the generic matrix algebra matrix types belong
+to the abstract type `MatRingElem{T}` and the parent types belong to the abstract
  `MatRing{T}` Note that both
 the concrete type of a matrix space parent object and the abstract class it belongs to
 have the name `MatElem`, therefore disambiguation is required to specify which is

--- a/docs/src/matrix_interface.md
+++ b/docs/src/matrix_interface.md
@@ -31,9 +31,9 @@ performance.
 
 ## Types and parents
 
-AbstractAlgebra provides two abstract types for matrix spaces and their elements:
+AbstractAlgebra provides two types for matrix spaces and their elements:
 
-  * `MatSpace{T}` is the abstract type for matrix space parent types
+  * `MatSpace{T}` is the concrete type for matrix space parent types
   * `MatElem{T}` is the abstract type for matrix types belonging to a matrix space
 
 It also provides two abstract types for matrix algebras and their elements:

--- a/docs/src/visualizing_types.md
+++ b/docs/src/visualizing_types.md
@@ -44,4 +44,4 @@ are defined over.
   - `Generic.LaurentSeriesFieldElem{T}` (`Generic.LaurentSeriesField{T}`)
   - `Generic.ResidueRingElem{T}` (`Generic.ResidueRing{T}`)
   - `Generic.FracFieldElem{T}` (`Generic.FracField{T}`)
-  - `Generic.Mat{T}` (`Generic.MatSpace{T}`)
+  - `Generic.Mat{T}` (`MatSpace{T}`)

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -178,6 +178,8 @@ const NCRingElement = Union{NCRingElem, Integer, Rational, AbstractFloat}
 
 const FieldElement = Union{FieldElem, Rational, AbstractFloat}
 
+include("ConcreteTypes.jl")
+
 ###############################################################################
 #
 #   Fundamental interface for AbstractAlgebra

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -93,8 +93,6 @@ abstract type ResidueField{T} <: Field end
 
 abstract type FracField{T} <: Field end
 
-abstract type MatSpace{T} <: Module{T} end
-
 abstract type MatRing{T} <: NCRing end
 
 abstract type FreeAssociativeAlgebra{T} <: NCRing end

--- a/src/ConcreteTypes.jl
+++ b/src/ConcreteTypes.jl
@@ -1,0 +1,18 @@
+###############################################################################
+#
+#   Mat space
+#
+###############################################################################
+
+struct MatSpace{T <: NCRingElement} <: Module{T}
+  base_ring::NCRing
+  nrows::Int
+  ncols::Int
+
+  function MatSpace{T}(R::NCRing, r::Int, c::Int, cached::Bool = true) where T <: NCRingElement
+     # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
+     @assert elem_type(R) === T
+     (r < 0 || c < 0) && error("Dimensions must be non-negative")
+     return new{T}(R, r, c)
+  end
+end

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -118,4 +118,7 @@ Base.@deprecate_binding ResidueRingElem EuclideanRingResidueRingElem
 @deprecate hom(M::DirectSumModule{T}, N::DirectSumModule{T}, mp::Vector{ModuleHomomorphism{T}}) where T hom_direct_sum(M, N, mp)
 @deprecate hom(A::DirectSumModule{T}, B::DirectSumModule{T}, M::Matrix{<:Map{<:AbstractAlgebra.FPModule{T}, <:AbstractAlgebra.FPModule{T}}}) where {T} hom_direct_sum(A, B, M)
 
+# Deprecated for 0.44
+#Base.@deprecate_binding MatSpace AbstractAlgebra.MatSpace false
+
 end # generic

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1051,28 +1051,12 @@ end
 
 ###############################################################################
 #
-#   MatSpace / Mat
+#   Mat
 #
 ###############################################################################
 
-const NCRingElement = Union{NCRingElem, RingElement}
-
 # All MatSpaceElem's and views thereof
 abstract type Mat{T} <: MatElem{T} end
-
-# not really a mathematical ring
-struct MatSpace{T <: NCRingElement} <: AbstractAlgebra.MatSpace{T}
-   base_ring::NCRing
-   nrows::Int
-   ncols::Int
-
-   function MatSpace{T}(R::NCRing, r::Int, c::Int, cached::Bool = true) where T <: NCRingElement
-      # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-      @assert elem_type(R) === T
-      (r < 0 || c < 0) && error("Dimensions must be non-negative")
-      return new{T}(R, r, c)
-   end
-end
 
 struct MatSpaceElem{T <: NCRingElement} <: Mat{T}
    base_ring::NCRing

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -88,6 +88,7 @@ import ..AbstractAlgebra: LowercaseOff
 import ..AbstractAlgebra: Map
 import ..AbstractAlgebra: NCRing
 import ..AbstractAlgebra: NCRingElem
+import ..AbstractAlgebra: NCRingElement
 import ..AbstractAlgebra: O
 import ..AbstractAlgebra: Perm
 import ..AbstractAlgebra: Ring

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -65,7 +65,7 @@ AbstractAlgebra.divexact(x::F2Elem, y::F2Elem) = y.x ? x : throw(DivideError())
 Random.rand(rng::AbstractRNG, sp::Random.SamplerTrivial{F2}) = F2Elem(rand(rng, Bool))
 Random.gentype(::Type{F2}) = F2Elem
 
-const F2MatSpace = AbstractAlgebra.Generic.MatSpace{F2Elem}
+const F2MatSpace = MatSpace{F2Elem}
 
 (S::F2MatSpace)() = zero_matrix(F2(), S.nrows, S.ncols)
 
@@ -120,16 +120,16 @@ end
    @test S === matrix_space(R, 3, 3)
 
    @test elem_type(S) == Generic.MatSpaceElem{elem_type(R)}
-   @test elem_type(Generic.MatSpace{elem_type(R)}) == Generic.MatSpaceElem{elem_type(R)}
-   @test parent_type(Generic.MatSpaceElem{elem_type(R)}) == Generic.MatSpace{elem_type(R)}
-   @test base_ring_type(Generic.MatSpace{elem_type(R)}) == typeof(R)
+   @test elem_type(MatSpace{elem_type(R)}) == Generic.MatSpaceElem{elem_type(R)}
+   @test parent_type(Generic.MatSpaceElem{elem_type(R)}) == MatSpace{elem_type(R)}
+   @test base_ring_type(MatSpace{elem_type(R)}) == typeof(R)
    @test base_ring_type(Generic.MatSpaceElem{elem_type(R)}) == typeof(R)
    @test base_ring_type(S) == typeof(R)
    @test base_ring(S) == R
    @test nrows(S) == 3
    @test ncols(S) == 3
 
-   @test typeof(S) <: Generic.MatSpace
+   @test typeof(S) <: MatSpace
 
    f = S(t^2 + 1)
 
@@ -353,8 +353,8 @@ end
    @test base_ring(S) == R
 
    @test elem_type(S) == Generic.MatSpaceElem{elem_type(R)}
-   @test elem_type(Generic.MatSpace{elem_type(R)}) == Generic.MatSpaceElem{elem_type(R)}
-   @test parent_type(Generic.MatSpaceElem{elem_type(R)}) == Generic.MatSpace{elem_type(R)}
+   @test elem_type(MatSpace{elem_type(R)}) == Generic.MatSpaceElem{elem_type(R)}
+   @test parent_type(Generic.MatSpaceElem{elem_type(R)}) == MatSpace{elem_type(R)}
 
    @test dense_matrix_type(R) == elem_type(S)
    @test dense_matrix_type(R(1)) == elem_type(S)


### PR DESCRIPTION
Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/1840.

This should technically be non-breaking as `Generic.MatSpace === MatSpace` after these changes, and thus all references to `Generic.MatSpace` still point to the actual type used for matrix spaces. In the next breaking release, we can uncomment the deprecation to fade out the use of `Generic.MatSpace`.

I haven't tested this with Nemo yet, let's hope for the best.