### PR TITLE
Some MatrixRing fixes

### DIFF
--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -66,6 +66,7 @@ end
 
 
 function characteristic(a::MatRing)
+   iszero(a.n) && return 1
    return characteristic(base_ring(a))
 end
 

--- a/src/generic/MatRing.jl
+++ b/src/generic/MatRing.jl
@@ -211,6 +211,7 @@ end
 function matrix_ring(R::AbstractAlgebra.NCRing, n::Int; cached::Bool = true)
    # TODO: the 'cached' argument is ignored and mainly here for backwards compatibility
    # (and perhaps future compatibility, in case we need it again)
+   @req n >= 0 "n must be a non-negative integer"
    T = elem_type(R)
    return MatRing{T}(R, n)
 end

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -1,5 +1,7 @@
 @testset "Generic.MatAlg.constructors" begin
    R, t = polynomial_ring(QQ, "t")
+   @test_throws ArgumentError matrix_ring(R, -1)
+
    S = matrix_ring(R, 3)
 
    @test S === matrix_ring(R, 3)

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -179,6 +179,8 @@ end
    @test is_zero_column(M, 1)
 
    @test degree(M) == 2
+
+   @test characteristic(matrix_ring(R, 0)) == 1
 end
 
 @testset "Generic.MatAlg.size/axes" begin


### PR DESCRIPTION
- Check `n` in the constructor to be non-negative. Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/1851.
- Fix `characteristic(matrix_ring(R, 0))` to be `1`.