### PR TITLE
Change `==` to error by default (instead of returning `false`) when comparing elements for which no equality test has been implemented

### DIFF
--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -6,7 +6,7 @@
 
 function Base.:(==)(x::AbstractAlgebra.SetElem, y::AbstractAlgebra.SetElem)
   x === y && return true
-  error("== is not implemented for the given types")
+  throw(NotImplementedError(:==, x, y))
 end
 
 ###############################################################################

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -6,7 +6,7 @@
 
 function Base.:(==)(x::AbstractAlgebra.SetElem, y::AbstractAlgebra.SetElem)
   x === y && return true
-  throw(NotImplementedError(:==, x, y))
+  throw(NotImplementedError(:(==), x, y))
 end
 
 ###############################################################################

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -4,7 +4,8 @@
 #
 ###############################################################################
 
-function Base.:(==)(::AbstractAlgebra.SetElem, ::AbstractAlgebra.SetElem)
+function Base.:(==)(x::AbstractAlgebra.SetElem, y::AbstractAlgebra.SetElem)
+  x === y && return true
   error("== is not implemented for the given types")
 end
 

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -6,6 +6,10 @@
 
 # TODO: Move more generic functions to this file.
 
+function Base.:(==)(::AbstractAlgebra.SetElem, ::AbstractAlgebra.SetElem)
+  error("== is not implemented for the given types")
+end
+
 ###############################################################################
 #
 #   Parents, elements and data type methods

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -4,6 +4,15 @@
 #
 ###############################################################################
 
+function Base.:(==)(x::SetElem, y::SetElem)
+  x === y && return true
+  throw(NotImplementedError(:(==), x, y))
+end
+
+function Base.hash(a::SetElem, h::UInt)
+  throw(NotImplementedError(:hash, a, h))
+end
+
 ###############################################################################
 #
 #   Parents, elements and data type methods


### PR DESCRIPTION
Closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/1800, resolves https://github.com/oscar-system/Oscar.jl/issues/4107.

This includes only the snippet from https://github.com/Nemocas/AbstractAlgebra.jl/pull/1800#issuecomment-2401919352

cc @joschmitt 