### PR TITLE
Widen signature of MatSpaceElem constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.43.6"
+version = "0.43.7"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1072,7 +1072,8 @@ function MatSpaceElem{T}(R::NCRing, A::AbstractMatrix{T}) where T <: NCRingEleme
    return MatSpaceElem{T}(R, Matrix(A))
 end
 
-function MatSpaceElem{T}(R::NCRing, r::Int, c::Int, A::Vector{T}) where T <: NCRingElement
+function MatSpaceElem{T}(R::NCRing, r::Int, c::Int, A::AbstractVector{T}) where T <: NCRingElement
+   Base.require_one_based_indexing(A)
    t = Matrix{T}(undef, r, c)
    for i = 1:r, j = 1:c
       t[i, j] = A[(i - 1) * c + j]


### PR DESCRIPTION
This is needed to e.g. feed the output of `eachrow(::MatSpaceElem)` again into its constructor, as is used in https://github.com/oscar-system/Oscar.jl/pull/4208