### PR TITLE
Delete redundant isequal method

### DIFF
--- a/src/generic/TotalFraction.jl
+++ b/src/generic/TotalFraction.jl
@@ -315,10 +315,6 @@ function ==(x::TotFrac{T}, y::TotFrac{T}) where {T <: RingElem}
            denominator(x, false)*numerator(y, false))
 end
 
-function isequal(x::TotFrac{T}, y::TotFrac{T}) where {T <: RingElem}
-   return x == y
-end
-
 ###############################################################################
 #
 #   Ad hoc comparisons


### PR DESCRIPTION
The default method already delegates to ==
