### PR TITLE
Tweak printing of Julia parent types

### DIFF
--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -54,8 +54,12 @@ is_positive(n::T) where T<:Real = n > zero(T)
 #
 ###############################################################################
 
-function show(io::IO, R::Floats)
+function show(io::IO, R::Floats{BigFloat})
    print(io, "Floats")
+end
+
+function show(io::IO, R::Floats{T}) where T
+   print(io, "Floats{$T}()")
 end
 
 function expressify(a::AbstractFloat; context = nothing)

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -58,8 +58,12 @@ function expressify(a::Integer; context = nothing)
     return a
 end
 
-function show(io::IO, R::Integers)
+function show(io::IO, R::Integers{BigInt})
    print(io, "Integers")
+end
+
+function show(io::IO, R::Integers{T}) where T
+   print(io, "Integers{$T}()")
 end
 
 ###############################################################################

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -70,8 +70,12 @@ function expressify(a::Rational; context = nothing)
     end
 end
 
-function show(io::IO, R::Rationals)
+function show(io::IO, R::Rationals{BigInt})
    print(io, "Rationals")
+end
+
+function show(io::IO, R::Rationals{T}) where T
+   print(io, "Rationals{$T}()")
 end
 
 ###############################################################################


### PR DESCRIPTION
So that e.g. `Integers{BigInt}` and `Integers{Int}` don't print
identically.
