### PR TITLE
Bump version to 0.43.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.43.8"
+version = "0.43.9"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
once https://github.com/Nemocas/AbstractAlgebra.jl/pull/1867 is merged, to mitigate the chance of somehow breaking the compatibility with this change somewhere downstream