### PR TITLE
Get rid of InteractiveUtils dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 version = "0.43.9"
 
 [deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
@@ -13,7 +12,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-InteractiveUtils = "1.6"
 LinearAlgebra = "1.6"
 MacroTools = "0.5"
 Preferences = "1"

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,8 +1,6 @@
 using Random: Random, AbstractRNG, GLOBAL_RNG, SamplerTrivial
 using RandomExtensions: RandomExtensions, make, Make, Make2, Make3, Make4
 
-using InteractiveUtils: InteractiveUtils, subtypes
-
 using Test: @test # for "interface-conformance" functions
 
 import LinearAlgebra

--- a/src/polysubst.jl
+++ b/src/polysubst.jl
@@ -1,4 +1,6 @@
-for T in subtypes(PolyRingElem)
+for T in [
+  Generic.Poly,
+  ]
   (f::T)(a) = subst(f, a)
 
   function (f::T)(a::T)
@@ -18,7 +20,9 @@ for T in subtypes(PolyRingElem)
   end
 end
 
-for T in subtypes(NCPolyRingElem)
+for T in [
+  Generic.NCPoly,
+  ]
   (f::T)(a::Integer) = evaluate(f, a)
 
   function (f::T)(a::NCRingElem)


### PR DESCRIPTION
The calls to subtypes don't do anything here. They seem to be an artifact from the time before the split of Nemo and AA.

I am working on some further tweaking of the file, but I think this change here can easily be merged without waiting for further refactoring.