### PR TITLE
Adapt `test_mutating_op_like_(add)mul` to work with scalar mul as well

### DIFF
--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -147,50 +147,104 @@ function test_mutating_op_like_neg(f::Function, f!::Function, A)
 end
 
 function test_mutating_op_like_add(f::Function, f!::Function, A, B)
-   # initialize storage var with different values to check that its value is not used
-   for z in [zero(A), deepcopy(A), deepcopy(B)]
-      a = deepcopy(A)
-      b = deepcopy(B)
-      z = f!(z, a, b)
-      @test equality(z, f(A, B))
-      @test a == A
-      @test b == B
-   end
+  # initialize storage var with different values to check that its value is not used
+  for z in [zero(A), deepcopy(A), deepcopy(B)]
+     a = deepcopy(A)
+     b = deepcopy(B)
+     z = f!(z, a, b)
+     @test equality(z, f(A, B))
+     @test a == A
+     @test b == B
+  end
 
-   a = deepcopy(A)
-   b = deepcopy(B)
-   a = f!(a, a, b)
-   @test equality(a, f(A, B))
-   @test b == B
+  a = deepcopy(A)
+  b = deepcopy(B)
+  a = f!(a, a, b)
+  @test equality(a, f(A, B))
+  @test b == B
 
-   a = deepcopy(A)
-   b = deepcopy(B)
-   b = f!(b, a, b)
-   @test equality(b, f(A, B))
-   @test a == A
+  a = deepcopy(A)
+  b = deepcopy(B)
+  b = f!(b, a, b)
+  @test equality(b, f(A, B))
+  @test a == A
 
-   a = deepcopy(A)
-   b = deepcopy(B)
-   a = f!(a, b, b)
-   @test equality(a, f(B, B))
-   @test b == B
+  a = deepcopy(A)
+  b = deepcopy(B)
+  a = f!(a, b, b)
+  @test equality(a, f(B, B))
+  @test b == B
 
-   b = deepcopy(B)
-   b = f!(b, b, b)
-   @test equality(b, f(B, B))
+  b = deepcopy(B)
+  b = f!(b, b, b)
+  @test equality(b, f(B, B))
 
-   a = deepcopy(A)
-   b = deepcopy(B)
-   a = f!(a, b)
-   @test equality(a, f(A, B))
-   @test b == B
+  a = deepcopy(A)
+  b = deepcopy(B)
+  a = f!(a, b)
+  @test equality(a, f(A, B))
+  @test b == B
 
-   b = deepcopy(B)
-   b = f!(b, b)
-   @test equality(b, f(B, B))
+  b = deepcopy(B)
+  b = f!(b, b)
+  @test equality(b, f(B, B))
 end
 
-function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B)
+function test_mutating_op_like_mul(f::Function, f!::Function, A, B; left_factor_is_scalar::Bool = false, right_factor_is_scalar::Bool = false)
+  # initialize storage var with different values to check that its value is not used
+  for z in [zero(A), deepcopy(A), deepcopy(B)]
+     a = deepcopy(A)
+     b = deepcopy(B)
+     z = f!(z, a, b)
+     @test equality(z, f(A, B))
+     @test a == A
+     @test b == B
+  end
+
+  if !left_factor_is_scalar
+    a = deepcopy(A)
+    b = deepcopy(B)
+    a = f!(a, a, b)
+    @test equality(a, f(A, B))
+    @test b == B
+  end
+
+  if !right_factor_is_scalar
+    a = deepcopy(A)
+    b = deepcopy(B)
+    b = f!(b, a, b)
+    @test equality(b, f(A, B))
+    @test a == A
+  end
+
+  if !left_factor_is_scalar && !right_factor_is_scalar
+    a = deepcopy(A)
+    b = deepcopy(B)
+    a = f!(a, b, b)
+    @test equality(a, f(B, B))
+    @test b == B
+
+    b = deepcopy(B)
+    b = f!(b, b, b)
+    @test equality(b, f(B, B))
+  end
+
+  if !left_factor_is_scalar
+    a = deepcopy(A)
+    b = deepcopy(B)
+    a = f!(a, b)
+    @test equality(a, f(A, B))
+    @test b == B
+  end
+
+  if !left_factor_is_scalar && !right_factor_is_scalar
+    b = deepcopy(B)
+    b = f!(b, b)
+    @test equality(b, f(B, B))
+  end
+end
+
+function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B; left_factor_is_scalar::Bool = false, right_factor_is_scalar::Bool = false)
    f!(z, a, b, ::Nothing) = f!_(z, a, b)
    f!(z, a, b, t) = f!_(z, a, b, t)
 
@@ -205,27 +259,33 @@ function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B)
       @test a == A
       @test b == B
 
-      a = deepcopy(A)
-      b = deepcopy(B)
-      a = f!(a, a, b, t)
-      @test equality(a, f(A, A, B))
-      @test b == B
+      if !left_factor_is_scalar
+        a = deepcopy(A)
+        b = deepcopy(B)
+        a = f!(a, a, b, t)
+        @test equality(a, f(A, A, B))
+        @test b == B
+      end
 
-      a = deepcopy(A)
-      b = deepcopy(B)
-      b = f!(b, a, b, t)
-      @test equality(b, f(B, A, B))
-      @test a == A
+      if !right_factor_is_scalar
+        a = deepcopy(A)
+        b = deepcopy(B)
+        b = f!(b, a, b, t)
+        @test equality(b, f(B, A, B))
+        @test a == A
+      end
 
-      a = deepcopy(A)
-      b = deepcopy(B)
-      a = f!(a, b, b, t)
-      @test equality(a, f(A, B, B))
-      @test b == B
+      if !left_factor_is_scalar && !right_factor_is_scalar
+        a = deepcopy(A)
+        b = deepcopy(B)
+        a = f!(a, b, b, t)
+        @test equality(a, f(A, B, B))
+        @test b == B
 
-      b = deepcopy(B)
-      b = f!(b, b, b, t)
-      @test equality(b, f(B, B, B))
+        b = deepcopy(B)
+        b = f!(b, b, b, t)
+        @test equality(b, f(B, B, B))
+      end
    end
 end
 
@@ -418,7 +478,7 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
 
             test_mutating_op_like_add(+, add!, a, b)
             test_mutating_op_like_add(-, sub!, a, b)
-            test_mutating_op_like_add(*, mul!, a, b)
+            test_mutating_op_like_mul(*, mul!, a, b)
 
             test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, a, b, c)
             test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, a, b, c)

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -146,111 +146,87 @@ function test_mutating_op_like_neg(f::Function, f!::Function, A)
    @test equality(a, f(A))
 end
 
-function test_mutating_op_like_add(f::Function, f!::Function, A, B)
-  # initialize storage var with different values to check that its value is not used
-  for z in [zero(A), deepcopy(A), deepcopy(B)]
-     a = deepcopy(A)
-     b = deepcopy(B)
-     z = f!(z, a, b)
-     @test equality(z, f(A, B))
-     @test a == A
-     @test b == B
-  end
+function test_mutating_op_like_add(f::Function, f!::Function, A, B, T = Any)
+   @req A isa T || B isa T "Invalid argument types"
 
-  a = deepcopy(A)
-  b = deepcopy(B)
-  a = f!(a, a, b)
-  @test equality(a, f(A, B))
-  @test b == B
+   # initialize storage var with different values to check that its value is not used
+   storage_values = T[]
+   if A isa T
+      push!(storage_values, zero(A))
+      push!(storage_values, deepcopy(A))
+   end
+   if B isa T
+      push!(storage_values, zero(B))
+      push!(storage_values, deepcopy(B))
+   end
+   for z in storage_values
+      a = deepcopy(A)
+      b = deepcopy(B)
+      z = f!(z, a, b)
+      @test equality(z, f(A, B))
+      @test a == A
+      @test b == B
+   end
 
-  a = deepcopy(A)
-  b = deepcopy(B)
-  b = f!(b, a, b)
-  @test equality(b, f(A, B))
-  @test a == A
+   if A isa T
+      a = deepcopy(A)
+      b = deepcopy(B)
+      a = f!(a, a, b)
+      @test equality(a, f(A, B))
+      @test b == B
 
-  a = deepcopy(A)
-  b = deepcopy(B)
-  a = f!(a, b, b)
-  @test equality(a, f(B, B))
-  @test b == B
+      a = deepcopy(A)
+      b = deepcopy(B)
+      a = f!(a, b)
+      @test equality(a, f(A, B))
+      @test b == B
+   end
 
-  b = deepcopy(B)
-  b = f!(b, b, b)
-  @test equality(b, f(B, B))
+   if B isa T
+      a = deepcopy(A)
+      b = deepcopy(B)
+      b = f!(b, a, b)
+      @test equality(b, f(A, B))
+      @test a == A
+   end
 
-  a = deepcopy(A)
-  b = deepcopy(B)
-  a = f!(a, b)
-  @test equality(a, f(A, B))
-  @test b == B
+   if A isa T && B isa T
+      # `f(B, B)` may fail if `!(A isa T)`, since we call it with different arguments than the intended `f(A, B)` (same for f!)
+      a = deepcopy(A)
+      b = deepcopy(B)
+      a = f!(a, b, b)
+      @test equality(a, f(B, B))
+      @test b == B
+   
+      b = deepcopy(B)
+      b = f!(b, b, b)
+      @test equality(b, f(B, B))
 
-  b = deepcopy(B)
-  b = f!(b, b)
-  @test equality(b, f(B, B))
+      b = deepcopy(B)
+      b = f!(b, b)
+      @test equality(b, f(B, B))
+   end
 end
 
-function test_mutating_op_like_mul(f::Function, f!::Function, A, B; left_factor_is_scalar::Bool = false, right_factor_is_scalar::Bool = false)
-  # initialize storage var with different values to check that its value is not used
-  for z in [zero(A), deepcopy(A), deepcopy(B)]
-     a = deepcopy(A)
-     b = deepcopy(B)
-     z = f!(z, a, b)
-     @test equality(z, f(A, B))
-     @test a == A
-     @test b == B
-  end
+function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B, T = Any)
+   @req Z isa T "Invalid argument types"
+   @req A isa T || B isa T "Invalid argument types"
 
-  if !left_factor_is_scalar
-    a = deepcopy(A)
-    b = deepcopy(B)
-    a = f!(a, a, b)
-    @test equality(a, f(A, B))
-    @test b == B
-  end
-
-  if !right_factor_is_scalar
-    a = deepcopy(A)
-    b = deepcopy(B)
-    b = f!(b, a, b)
-    @test equality(b, f(A, B))
-    @test a == A
-  end
-
-  if !left_factor_is_scalar && !right_factor_is_scalar
-    a = deepcopy(A)
-    b = deepcopy(B)
-    a = f!(a, b, b)
-    @test equality(a, f(B, B))
-    @test b == B
-
-    b = deepcopy(B)
-    b = f!(b, b, b)
-    @test equality(b, f(B, B))
-  end
-
-  if !left_factor_is_scalar
-    a = deepcopy(A)
-    b = deepcopy(B)
-    a = f!(a, b)
-    @test equality(a, f(A, B))
-    @test b == B
-  end
-
-  if !left_factor_is_scalar && !right_factor_is_scalar
-    b = deepcopy(B)
-    b = f!(b, b)
-    @test equality(b, f(B, B))
-  end
-end
-
-function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B; left_factor_is_scalar::Bool = false, right_factor_is_scalar::Bool = false)
    f!(z, a, b, ::Nothing) = f!_(z, a, b)
    f!(z, a, b, t) = f!_(z, a, b, t)
 
    # initialize storage var with different values to check that its value is not used
    # and `nothing` for the three-arg dispatch
-   for t in [nothing, zero(A), deepcopy(A)]
+   storage_values = Union{T,Nothing}[nothing]
+   if A isa T
+      push!(storage_values, zero(A))
+      push!(storage_values, deepcopy(A))
+   end
+   if B isa T
+      push!(storage_values, zero(B))
+      push!(storage_values, deepcopy(B))
+   end
+   for t in storage_values
       z = deepcopy(Z)
       a = deepcopy(A)
       b = deepcopy(B)
@@ -259,32 +235,33 @@ function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B; left_
       @test a == A
       @test b == B
 
-      if !left_factor_is_scalar
-        a = deepcopy(A)
-        b = deepcopy(B)
-        a = f!(a, a, b, t)
-        @test equality(a, f(A, A, B))
-        @test b == B
+      if A isa T
+         a = deepcopy(A)
+         b = deepcopy(B)
+         a = f!(a, a, b, t)
+         @test equality(a, f(A, A, B))
+         @test b == B
       end
 
-      if !right_factor_is_scalar
-        a = deepcopy(A)
-        b = deepcopy(B)
-        b = f!(b, a, b, t)
-        @test equality(b, f(B, A, B))
-        @test a == A
+      if B isa T
+         a = deepcopy(A)
+         b = deepcopy(B)
+         b = f!(b, a, b, t)
+         @test equality(b, f(B, A, B))
+         @test a == A
       end
 
-      if !left_factor_is_scalar && !right_factor_is_scalar
-        a = deepcopy(A)
-        b = deepcopy(B)
-        a = f!(a, b, b, t)
-        @test equality(a, f(A, B, B))
-        @test b == B
+      if A isa T && B isa T
+         # `f(B, B)` may fail if `!(A isa T)`, since we call it with different arguments than the intended `f(A, B)` (same for f!)
+         a = deepcopy(A)
+         b = deepcopy(B)
+         a = f!(a, b, b, t)
+         @test equality(a, f(A, B, B))
+         @test b == B
 
-        b = deepcopy(B)
-        b = f!(b, b, b, t)
-        @test equality(b, f(B, B, B))
+         b = deepcopy(B)
+         b = f!(b, b, b, t)
+         @test equality(b, f(B, B, B))
       end
    end
 end
@@ -478,7 +455,7 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
 
             test_mutating_op_like_add(+, add!, a, b)
             test_mutating_op_like_add(-, sub!, a, b)
-            test_mutating_op_like_mul(*, mul!, a, b)
+            test_mutating_op_like_add(*, mul!, a, b)
 
             test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, a, b, c)
             test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, a, b, c)


### PR DESCRIPTION
I now came across two places (namely https://github.com/thofma/Hecke.jl/pull/1659 for `SRow`s and https://github.com/oscar-system/Oscar.jl/pull/4271 for `RootSpaceElem`s) where we don't have a multiplication between objects, but only scalar multiplication (and corresponding `mul!` methods).

To make use of the `test_mutating_op_*` functions, we must have a way to disable multiplications between objects. I achieved this in this PR by adding two kwargs, that state if the left respective right factor of some multiplication is a scalar. If this is the case, we only run the tests where the output is aliased with a non-scalar input. This skips all tests where we would multiply two objects (which errors in the above cases) and the ones where we use a scalar type to save the output in (as these don't really make sense anyway and will fallback to the default impl).