### PR TITLE
Add AbstractAlgebra.doctestsetup() helper and use it, then regenerate doctests so they benefit from `@show_name`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
             Pkg.instantiate()
             using Documenter
             using AbstractAlgebra
-            DocMeta.setdocmeta!(AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive = true)
+            DocMeta.setdocmeta!(AbstractAlgebra, :DocTestSetup, AbstractAlgebra.doctestsetup(); recursive = true)
             doctest(AbstractAlgebra)'
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ using Documenter, AbstractAlgebra
 # because we want to force that each jldoctest has its individual
 # `setup = :(using AbstractAlgebra)`.
 # The reason is that the AbstractAlgebra doctests are run also in Nemo,
-# where `using AbstractAlgebra` is deliberately avoided.
+# where `using AbstractAlgebra` must be avoided, as a few symbols change
+# their meaning, e.g. `QQ`.
 
 makedocs(
          format = Documenter.HTML(;

--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -1,10 +1,9 @@
-# Assertion and Verbosity Macros
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
+
+# Assertion and Verbosity Macros
 
 We describe here various macros provided by AbstractAlgebra.
 

--- a/docs/src/direct_sum.md
+++ b/docs/src/direct_sum.md
@@ -43,7 +43,7 @@ julia> m2 = F(BigInt[9, 7, -2, 2, -4])
 (9, 7, -2, 2, -4)
 
 julia> S1, f1 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S1 -> F)
 
 julia> m1 = F(BigInt[3, 1, 7, 7, -7])
 (3, 1, 7, 7, -7)
@@ -52,7 +52,7 @@ julia> m2 = F(BigInt[-8, 6, 10, -1, 1])
 (-8, 6, 10, -1, 1)
 
 julia> S2, f2 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S2 -> F)
 
 julia> m1 = F(BigInt[2, 4, 2, -3, -10])
 (2, 4, 2, -3, -10)
@@ -61,10 +61,10 @@ julia> m2 = F(BigInt[5, 7, -6, 9, -5])
 (5, 7, -6, 9, -5)
 
 julia> S3, f3 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S3 -> F)
 
 julia> D, f = direct_sum(S1, S2, S3)
-(DirectSumModule over integers, AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: submodule over integers with 2 generators and no relations -> DirectSumModule, Hom: submodule over integers with 2 generators and no relations -> DirectSumModule, Hom: submodule over integers with 2 generators and no relations -> DirectSumModule], AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: DirectSumModule -> submodule over integers with 2 generators and no relations, Hom: DirectSumModule -> submodule over integers with 2 generators and no relations, Hom: DirectSumModule -> submodule over integers with 2 generators and no relations])
+(DirectSumModule over integers, AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: S1 -> D, Hom: S2 -> D, Hom: S3 -> D], AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: D -> S1, Hom: D -> S2, Hom: D -> S3])
 ```
 
 ## Functionality for direct sums
@@ -91,7 +91,7 @@ julia> m2 = F(BigInt[9, 7, -2, 2, -4])
 (9, 7, -2, 2, -4)
 
 julia> S1, f1 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S1 -> F)
 
 julia> m1 = F(BigInt[3, 1, 7, 7, -7])
 (3, 1, 7, 7, -7)
@@ -100,7 +100,7 @@ julia> m2 = F(BigInt[-8, 6, 10, -1, 1])
 (-8, 6, 10, -1, 1)
 
 julia> S2, f2 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S2 -> F)
 
 julia> m1 = F(BigInt[2, 4, 2, -3, -10])
 (2, 4, 2, -3, -10)
@@ -109,10 +109,10 @@ julia> m2 = F(BigInt[5, 7, -6, 9, -5])
 (5, 7, -6, 9, -5)
 
 julia> S3, f3 = sub(F, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 5 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S3 -> F)
 
 julia> D, f = direct_sum(S1, S2, S3)
-(DirectSumModule over integers, AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: submodule over integers with 2 generators and no relations -> DirectSumModule, Hom: submodule over integers with 2 generators and no relations -> DirectSumModule, Hom: submodule over integers with 2 generators and no relations -> DirectSumModule], AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: DirectSumModule -> submodule over integers with 2 generators and no relations, Hom: DirectSumModule -> submodule over integers with 2 generators and no relations, Hom: DirectSumModule -> submodule over integers with 2 generators and no relations])
+(DirectSumModule over integers, AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: S1 -> D, Hom: S2 -> D, Hom: S3 -> D], AbstractAlgebra.Generic.ModuleHomomorphism{BigInt}[Hom: D -> S1, Hom: D -> S2, Hom: D -> S3])
 
 julia> summands(D)
 3-element Vector{AbstractAlgebra.Generic.Submodule{BigInt}}:

--- a/docs/src/direct_sum.md
+++ b/docs/src/direct_sum.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Direct Sums

--- a/docs/src/euclidean_interface.md
+++ b/docs/src/euclidean_interface.md
@@ -1,6 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = :(using AbstractAlgebra)
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Euclidean Ring Interface

--- a/docs/src/finfield.md
+++ b/docs/src/finfield.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Finite fields

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Generic fraction fields

--- a/docs/src/fraction_interface.md
+++ b/docs/src/fraction_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Fraction Field Interface

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -75,7 +75,7 @@ julia> R, (x, y, z) = free_associative_algebra(ZZ, [:x, :y, :z])
 (Free associative algebra on 3 indeterminates over integers, AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{BigInt}[x, y, z])
 
 julia> B = MPolyBuildCtx(R)
-Builder for an element of free associative algebra
+Builder for an element of R
 
 julia> push_term!(B, ZZ(1), [1,2,3,1]); push_term!(B, ZZ(2), [3,3,1]); finish(B)
 x*y*z*x + 2*z^2*x

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra.Generic
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Free algebras

--- a/docs/src/free_module.md
+++ b/docs/src/free_module.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Free Modules and Vector Spaces

--- a/docs/src/function_field.md
+++ b/docs/src/function_field.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Rational function fields

--- a/docs/src/function_field.md
+++ b/docs/src/function_field.md
@@ -234,7 +234,7 @@ julia> R1, x1 = rational_function_field(QQ, "x1") # characteristic 0
 (Rational function field over rationals, x1)
 
 julia> U1, z1 = R1["z1"]
-(Univariate polynomial ring in z1 over rational function field, z1)
+(Univariate polynomial ring in z1 over R1, z1)
 
 julia> f = (x1^2 + 1)//(x1 + 1)*z1^3 + 4*z1 + 1//(x1 + 1)
 (x1^2 + 1)//(x1 + 1)*z1^3 + 4*z1 + 1//(x1 + 1)
@@ -255,7 +255,7 @@ julia> R2, x2 = rational_function_field(GF(23), "x1") # characteristic p
 (Rational function field over finite field F_23, x1)
 
 julia> U2, z2 = R2["z2"]
-(Univariate polynomial ring in z2 over rational function field, z2)
+(Univariate polynomial ring in z2 over R2, z2)
 
 julia> g = z2^2 + 3z2 + 1
 z2^2 + 3*z2 + 1
@@ -283,7 +283,7 @@ julia> R, x = rational_function_field(GF(23), :x) # characteristic p
 (Rational function field over finite field F_23, x)
 
 julia> U, z = R[:z]
-(Univariate polynomial ring in z over rational function field, z)
+(Univariate polynomial ring in z over R, z)
 
 julia> g = z^2 + 3z + 1
 z^2 + 3*z + 1
@@ -359,7 +359,7 @@ julia> R, x = rational_function_field(QQ, :x)
 (Rational function field over rationals, x)
 
 julia> U, z = R[:z]
-(Univariate polynomial ring in z over rational function field, z)
+(Univariate polynomial ring in z over R, z)
 
 julia> g = z^2 + 3*(x + 1)//(x + 2)*z + 1
 z^2 + (3*x + 3)//(x + 2)*z + 1
@@ -422,7 +422,7 @@ julia> R, x = rational_function_field(QQ, :x)
 (Rational function field over rationals, x)
 
 julia> U, z = R[:z]
-(Univariate polynomial ring in z over rational function field, z)
+(Univariate polynomial ring in z over R, z)
 
 julia> g = z^2 + 3*(x + 1)//(x + 2)*z + 1
 z^2 + (3*x + 3)//(x + 2)*z + 1

--- a/docs/src/functional_map.md
+++ b/docs/src/functional_map.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Functional maps

--- a/docs/src/ideal.md
+++ b/docs/src/ideal.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Ideal functionality

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Integer ring

--- a/docs/src/laurent_mpolynomial.md
+++ b/docs/src/laurent_mpolynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Sparse distributed multivariate Laurent polynomials

--- a/docs/src/laurent_polynomial.md
+++ b/docs/src/laurent_polynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Generic Laurent polynomials

--- a/docs/src/map_cache.md
+++ b/docs/src/map_cache.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Cached maps

--- a/docs/src/map_interface.md
+++ b/docs/src/map_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Map Interface

--- a/docs/src/map_with_inverse.md
+++ b/docs/src/map_with_inverse.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Map with inverse

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -834,7 +834,7 @@ julia> K, = residue_field(R, x^3 + 3x + 1); a = K(x);
 
 julia> S = matrix_space(K, 3, 3)
 Matrix space of 3 rows and 3 columns
-  over residue field of univariate polynomial ring modulo x^3 + 3*x + 1
+  over residue field of R modulo x^3 + 3*x + 1
 
 julia> A = S([K(0) 2a + 3 a^2 + 1; a^2 - 2 a - 1 2a; a^2 - 2 a - 1 2a])
 [      0   2*x + 3   x^2 + 1]
@@ -871,7 +871,7 @@ julia> K, = residue_field(R, x^3 + 3x + 1); a = K(x);
 
 julia> S = matrix_space(K, 3, 3)
 Matrix space of 3 rows and 3 columns
-  over residue field of univariate polynomial ring modulo x^3 + 3*x + 1
+  over residue field of R modulo x^3 + 3*x + 1
 
 julia> M = S([K(0) 2a + 3 a^2 + 1; a^2 - 2 a - 1 2a; a^2 + 3a + 1 2a K(1)])
 [            0   2*x + 3   x^2 + 1]
@@ -994,7 +994,7 @@ julia> K, = residue_field(R, x^3 + 3x + 1); a = K(x);
 
 julia> S = matrix_space(K, 3, 3)
 Matrix space of 3 rows and 3 columns
-  over residue field of univariate polynomial ring modulo x^3 + 3*x + 1
+  over residue field of R modulo x^3 + 3*x + 1
 
 julia> A = S([K(0) 2a + 3 a^2 + 1; a^2 - 2 a - 1 2a; a^2 + 3a + 1 2a K(1)])
 [            0   2*x + 3   x^2 + 1]

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Matrix functionality

--- a/docs/src/matrix_algebras.md
+++ b/docs/src/matrix_algebras.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Generic matrix algebras

--- a/docs/src/matrix_interface.md
+++ b/docs/src/matrix_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Matrix Interface

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Miscellaneous

--- a/docs/src/module.md
+++ b/docs/src/module.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Finitely presented modules

--- a/docs/src/module.md
+++ b/docs/src/module.md
@@ -224,10 +224,10 @@ julia> m2 = rand(M, -10:10)
 (4, 4, -7)
 
 julia> S, f = sub(M, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 3 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S -> M)
 
 julia> I, g = image(f)
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 3 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: I -> M)
 
 julia> is_isomorphic(S, I)
 true
@@ -259,16 +259,14 @@ julia> m2 = rand(M, -10:10)
 (4, 4, -7)
 
 julia> S, f = sub(M, [m1, m2])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 3 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: S -> M)
 
 julia> Q, g = quo(M, S)
 (Quotient module over integers with 2 generators and relations:
-[16 -21], Hom: free module of rank 3 over integers -> quotient module over integers with 2 generators and relations:
-[16 -21])
+[16 -21], Hom: M -> Q)
 
 julia> I, f = snf(Q)
-(Invariant factor decomposed module over integers with invariant factors BigInt[0], Hom: invariant factor decomposed module over integers with invariant factors BigInt[0] -> quotient module over integers with 2 generators and relations:
-[16 -21])
+(Invariant factor decomposed module over integers with invariant factors BigInt[0], Hom: I -> Q)
 
 julia> invs = invariant_factors(Q)
 1-element Vector{BigInt}:

--- a/docs/src/module_homomorphism.md
+++ b/docs/src/module_homomorphism.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Module Homomorphisms

--- a/docs/src/module_homomorphism.md
+++ b/docs/src/module_homomorphism.md
@@ -75,13 +75,13 @@ julia> m = M([ZZ(1), ZZ(2), ZZ(3)])
 (1, 2, 3)
 
 julia> S, f = sub(M, [m])
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 3 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: S -> M)
 
 julia> Q, g = quo(M, S)
-(Quotient module over integers with 2 generators and no relations, Hom: free module of rank 3 over integers -> quotient module over integers with 2 generators and no relations)
+(Quotient module over integers with 2 generators and no relations, Hom: M -> Q)
 
 julia> kernel(g)
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 3 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> M)
 
 ```
 

--- a/docs/src/module_interface.md
+++ b/docs/src/module_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Module Interface

--- a/docs/src/mpoly_interface.md
+++ b/docs/src/mpoly_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Multivariate Polynomial Ring Interface

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Sparse distributed multivariate polynomials

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -151,7 +151,7 @@ julia> R, (x, y) = polynomial_ring(ZZ, [:x, :y])
 (Multivariate polynomial ring in 2 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y])
 
 julia> C = MPolyBuildCtx(R)
-Builder for an element of multivariate polynomial ring
+Builder for an element of R
 
 julia> push_term!(C, ZZ(3), [1, 2]);
 

--- a/docs/src/mseries.md
+++ b/docs/src/mseries.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Multivariate series

--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -70,7 +70,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> U, z = R[:z]
 (Univariate polynomial ring in z over matrix ring, z)
@@ -124,7 +124,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = x^3 + 3x + 21
 x^3 + [3 0; 0 3]*x + [21 0; 0 21]
@@ -157,7 +157,7 @@ julia> v = var(T)
 :y
 
 julia> U = parent(y + 1)
-Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring
+Univariate polynomial ring in y over S
 
 julia> g == deepcopy(g)
 true
@@ -211,7 +211,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> a = zero(T)
 0
@@ -269,7 +269,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -303,7 +303,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -337,7 +337,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]
@@ -371,7 +371,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 
 julia> f = x*y^2 + (x + 1)*y + 3
@@ -405,7 +405,7 @@ julia> S, x = polynomial_ring(R, :x)
 (Univariate polynomial ring in x over matrix ring, x)
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over univariate polynomial ring in x over matrix ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + [3 0; 0 3]

--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Univariate polynomials over a noncommutative ring

--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Permutations and Symmetric groups

--- a/docs/src/poly_interface.md
+++ b/docs/src/poly_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Univariate Polynomial Ring Interface

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -124,7 +124,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = x^3 + 3x + 21
 x^3 + 3*x + 21
@@ -236,7 +236,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> U = base_ring(S)
 Univariate polynomial ring in x over integers
@@ -245,7 +245,7 @@ julia> V = base_ring(y + 1)
 Univariate polynomial ring in x over integers
 
 julia> T = parent(y + 1)
-Univariate polynomial ring in y over univariate polynomial ring
+Univariate polynomial ring in y over R
 ```
 
 ## Euclidean polynomial rings
@@ -286,7 +286,7 @@ julia> R, x = polynomial_ring(QQ, :x)
 julia> S, = residue_ring(R, x^3 + 3x + 1);
 
 julia> T, y = polynomial_ring(S, :y)
-(Univariate polynomial ring in y over residue ring, y)
+(Univariate polynomial ring in y over S, y)
 
 julia> f = (3*x^2 + x + 2)*y + x^2 + 1
 (3*x^2 + x + 2)*y + x^2 + 1
@@ -443,7 +443,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> T, z = polynomial_ring(QQ, :z)
 (Univariate polynomial ring in z over rationals, z)
@@ -451,7 +451,7 @@ julia> T, z = polynomial_ring(QQ, :z)
 julia> U, = residue_ring(ZZ, 17);
 
 julia> V, w = polynomial_ring(U, :w)
-(Univariate polynomial ring in w over residue ring, w)
+(Univariate polynomial ring in w over U, w)
 
 julia> var(R)
 :x
@@ -577,7 +577,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + 3
@@ -607,7 +607,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + 3
@@ -637,7 +637,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + 3
@@ -723,7 +723,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + 3
@@ -785,7 +785,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 
 julia> f = x*y^2 + (x + 1)*y + 3
@@ -837,7 +837,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> T, z = polynomial_ring(QQ, :z)
 (Univariate polynomial ring in z over rationals, z)
@@ -845,7 +845,7 @@ julia> T, z = polynomial_ring(QQ, :z)
 julia> U, = residue_ring(T, z^3 + 3z + 1);
 
 julia> V, w = polynomial_ring(U, :w)
-(Univariate polynomial ring in w over residue ring, w)
+(Univariate polynomial ring in w over U, w)
 
 julia> f = x*y^2 + (x + 1)*y + 3
 x*y^2 + (x + 1)*y + 3
@@ -886,7 +886,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = 3x*y^2 + (x + 1)*y + 3
 3*x*y^2 + (x + 1)*y + 3
@@ -924,7 +924,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = 3x*y^2 + (x + 1)*y + 3
 3*x*y^2 + (x + 1)*y + 3
@@ -963,7 +963,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> xs = [R(1), R(2), R(3), R(4)]
 4-element Vector{AbstractAlgebra.Generic.Poly{BigInt}}:
@@ -1035,7 +1035,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> f = chebyshev_t(20, y)
 524288*y^20 - 2621440*y^18 + 5570560*y^16 - 6553600*y^14 + 4659200*y^12 - 2050048*y^10 + 549120*y^8 - 84480*y^6 + 6600*y^4 - 200*y^2 + 1

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Univariate polynomial functionality

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Generic Puiseux series

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -246,7 +246,7 @@ julia> R, t = puiseux_series_ring(QQ, 10, :t)
 (Puiseux series field in t over rationals, t + O(t^11))
 
 julia> S, x = puiseux_series_ring(R, 30, :x)
-(Puiseux series field in x over puiseux series field, x + O(x^31))
+(Puiseux series field in x over R, x + O(x^31))
 
 julia> a = O(x^4)
 O(x^4)
@@ -340,7 +340,7 @@ julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S, x = puiseux_series_ring(R, 30, :x)
-(Puiseux series ring in x over univariate polynomial ring, x + O(x^31))
+(Puiseux series ring in x over R, x + O(x^31))
 
 julia> T, z = puiseux_series_ring(QQ, 30, :z)
 (Puiseux series field in z over rationals, z + O(z^31))

--- a/docs/src/quotient_module.md
+++ b/docs/src/quotient_module.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Quotient modules

--- a/docs/src/quotient_module.md
+++ b/docs/src/quotient_module.md
@@ -46,10 +46,10 @@ julia> m = M([ZZ(1), ZZ(2)])
 (1, 2)
 
 julia> N, f = sub(M, [m])
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: N -> M)
 
 julia> Q, g = quo(M, N)
-(Quotient module over integers with 1 generator and no relations, Hom: free module of rank 2 over integers -> quotient module over integers with 1 generator and no relations)
+(Quotient module over integers with 1 generator and no relations, Hom: M -> Q)
 
 julia> p = M([ZZ(3), ZZ(1)])
 (3, 1)
@@ -64,10 +64,10 @@ julia> m = V([QQ(1), QQ(2)])
 (1//1, 2//1)
 
 julia> N, f = sub(V, [m])
-(Subspace over rationals with 1 generator and no relations, Hom: subspace over rationals with 1 generator and no relations -> vector space of dimension 2 over rationals)
+(Subspace over rationals with 1 generator and no relations, Hom: N -> V)
 
 julia> Q, g = quo(V, N)
-(Quotient space over rationals with 1 generator and no relations, Hom: vector space of dimension 2 over rationals -> quotient space over rationals with 1 generator and no relations)
+(Quotient space over rationals with 1 generator and no relations, Hom: V -> Q)
 
 ```
 
@@ -94,12 +94,11 @@ julia> m = M([ZZ(2), ZZ(3)])
 (2, 3)
 
 julia> N, g = sub(M, [m])
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: N -> M)
 
 julia> Q, h = quo(M, N)
 (Quotient module over integers with 2 generators and relations:
-[2 3], Hom: free module of rank 2 over integers -> quotient module over integers with 2 generators and relations:
-[2 3])
+[2 3], Hom: M -> Q)
 
 julia> supermodule(Q) == M
 true
@@ -111,10 +110,10 @@ julia> m = V([QQ(1), QQ(2)])
 (1//1, 2//1)
 
 julia> N, f = sub(V, [m])
-(Subspace over rationals with 1 generator and no relations, Hom: subspace over rationals with 1 generator and no relations -> vector space of dimension 2 over rationals)
+(Subspace over rationals with 1 generator and no relations, Hom: N -> V)
 
 julia> Q, g = quo(V, N)
-(Quotient space over rationals with 1 generator and no relations, Hom: vector space of dimension 2 over rationals -> quotient space over rationals with 1 generator and no relations)
+(Quotient space over rationals with 1 generator and no relations, Hom: V -> Q)
 
 julia> dim(V)
 2

--- a/docs/src/rand.md
+++ b/docs/src/rand.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Random interface

--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Rational field

--- a/docs/src/real.md
+++ b/docs/src/real.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Real field

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -85,7 +85,7 @@ julia> k = S(x + 1)
 x + 1
 
 julia> U, f = quo(R, x^3 + 3x + 1)
-(Residue ring of univariate polynomial ring modulo x^3 + 3*x + 1, Map: univariate polynomial ring -> residue ring)
+(Residue ring of R modulo x^3 + 3*x + 1, Map: R -> S)
 
 julia> U === S
 true
@@ -205,7 +205,7 @@ julia> V = base_ring(f)
 Univariate polynomial ring in x over rationals
 
 julia> T = parent(f)
-Residue ring of univariate polynomial ring modulo x^3 + 3*x + 1
+Residue ring of R modulo x^3 + 3*x + 1
 
 julia> f == deepcopy(f)
 true

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Generic residue rings

--- a/docs/src/residue_interface.md
+++ b/docs/src/residue_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Residue Ring Interface

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -476,7 +476,7 @@ julia> R, t = power_series_ring(QQ, 10, :t)
 (Univariate power series ring over rationals, t + O(t^11))
 
 julia> S, x = power_series_ring(R, 30, :x)
-(Univariate power series ring over univariate power series ring, x + O(x^31))
+(Univariate power series ring over R, x + O(x^31))
 
 julia> a = O(x^4)
 O(x^4)
@@ -559,7 +559,7 @@ julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S, x = power_series_ring(R, 30, :x)
-(Univariate power series ring over univariate polynomial ring, x + O(x^31))
+(Univariate power series ring over R, x + O(x^31))
 
 julia> a = 2x + x^3
 2*x + x^3 + O(x^31)
@@ -600,7 +600,7 @@ julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S, x = power_series_ring(R, 30, :x)
-(Univariate power series ring over univariate polynomial ring, x + O(x^31))
+(Univariate power series ring over R, x + O(x^31))
 
 julia> a = 2x + x^3
 2*x + x^3 + O(x^31)
@@ -641,7 +641,7 @@ julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S, x = power_series_ring(R, 30, :x)
-(Univariate power series ring over univariate polynomial ring, x + O(x^31))
+(Univariate power series ring over R, x + O(x^31))
 
 julia> a = 1 + x + 2x^2 + O(x^5)
 1 + x + 2*x^2 + O(x^5)
@@ -698,7 +698,7 @@ julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
 julia> S, x = power_series_ring(R, 30, :x)
-(Univariate power series ring over univariate polynomial ring, x + O(x^31))
+(Univariate power series ring over R, x + O(x^31))
 
 julia> T, z = power_series_ring(QQ, 30, :z)
 (Univariate power series ring over rationals, z + O(z^31))

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Power series

--- a/docs/src/series_interface.md
+++ b/docs/src/series_interface.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Series Ring Interface

--- a/docs/src/submodule.md
+++ b/docs/src/submodule.md
@@ -52,7 +52,7 @@ julia> n = M([ZZ(2), ZZ(-1)])
 (2, -1)
 
 julia> N, f = sub(M, [m, n])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: N -> M)
 
 julia> v = N([ZZ(3), ZZ(4)])
 (3, 4)
@@ -70,7 +70,7 @@ julia> n = V([QQ(2), QQ(-1)])
 (2//1, -1//1)
 
 julia> N, f = sub(V, [m, n])
-(Subspace over rationals with 2 generators and no relations, Hom: subspace over rationals with 2 generators and no relations -> vector space of dimension 2 over rationals)
+(Subspace over rationals with 2 generators and no relations, Hom: N -> V)
 
 ```
 
@@ -110,10 +110,10 @@ julia> n = M([ZZ(1), ZZ(4)])
 (1, 4)
 
 julia> N1, = sub(M, [m, n])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: N1 -> M)
 
 julia> N2, = sub(M, [m])
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: N2 -> M)
 
 julia> supermodule(N1) == M
 true
@@ -124,7 +124,6 @@ julia> is_compatible(N1, N2)
 julia> is_submodule(N1, M)
 false
 
-
 julia> V = vector_space(QQ, 2)
 Vector space of dimension 2 over rationals
 
@@ -132,14 +131,13 @@ julia> m = V([QQ(2), QQ(3)])
 (2//1, 3//1)
 
 julia> N, = sub(V, [m])
-(Subspace over rationals with 1 generator and no relations, Hom: subspace over rationals with 1 generator and no relations -> vector space of dimension 2 over rationals)
+(Subspace over rationals with 1 generator and no relations, Hom: N -> V)
 
 julia> dim(V)
 2
 
 julia> dim(N)
 1
-
 ```
 
 ### Intersection
@@ -162,10 +160,10 @@ julia> n = M([ZZ(1), ZZ(4)])
 (1, 4)
 
 julia> N1 = sub(M, [m, n])
-(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 2 generators and no relations, Hom: submodule over integers with 2 generators and no relations -> M)
 
 julia> N2 = sub(M, [m])
-(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> free module of rank 2 over integers)
+(Submodule over integers with 1 generator and no relations, Hom: submodule over integers with 1 generator and no relations -> M)
 
 julia> I = intersect(N1, N2)
 Any[]

--- a/docs/src/submodule.md
+++ b/docs/src/submodule.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Submodules

--- a/docs/src/total_fraction.md
+++ b/docs/src/total_fraction.md
@@ -77,7 +77,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S = total_ring_of_fractions(R)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> f = S()
 0
@@ -117,7 +117,7 @@ julia> R, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
 julia> S = total_ring_of_fractions(R)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> f = S(x + 1)
 x + 1
@@ -166,7 +166,7 @@ julia> R, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
 julia> S = total_ring_of_fractions(R)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> f = S(x + 1)
 x + 1
@@ -178,7 +178,7 @@ julia> V = base_ring(f)
 Univariate polynomial ring in x over rationals
 
 julia> T = parent(f)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> m = characteristic(S)
 0
@@ -220,7 +220,7 @@ julia> R, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
 julia> S = total_ring_of_fractions(R)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> f = S(x + 1)
 x + 1
@@ -266,7 +266,7 @@ rand(R::TotFracRing, v...)
 julia> R, = residue_ring(ZZ, 12);
 
 julia> K = total_ring_of_fractions(R)
-Total ring of fractions of residue ring
+Total ring of fractions of R
 
 julia> f = rand(K, 0:11)
 7//5
@@ -275,7 +275,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S = total_ring_of_fractions(R)
-Total ring of fractions of univariate polynomial ring
+Total ring of fractions of R
 
 julia> g = rand(S, -1:3, -10:10)
 (4*x + 4)//(-4*x^2 - x + 4)

--- a/docs/src/total_fraction.md
+++ b/docs/src/total_fraction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Total ring of fractions

--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # Universal polynomial

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
-DocTestSetup = quote
-    using AbstractAlgebra
-end
+DocTestSetup = AbstractAlgebra.doctestsetup()
 DocTestFilters = r"[0-9\.]+ seconds \(.*\)"
 ```
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -453,6 +453,10 @@ function test_module(x, y)
    run(`$julia_exe -e $cmd`)
 end
 
+function doctestsetup()
+  return :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
+end
+
 ###############################################################################
 #
 #   Utils

--- a/src/AliasMacro.jl
+++ b/src/AliasMacro.jl
@@ -15,7 +15,7 @@ as the two names really refer to the same object.
 The alias also gets a special docstring that points out that it is an alias
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> foo(x::Int) = x
 foo (generic function with 1 method)
 

--- a/src/AliasMacro.jl
+++ b/src/AliasMacro.jl
@@ -15,7 +15,7 @@ as the two names really refer to the same object.
 The alias also gets a special docstring that points out that it is an alias
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> foo(x::Int) = x
 foo (generic function with 1 method)
 

--- a/src/Assertions.jl
+++ b/src/Assertions.jl
@@ -29,7 +29,7 @@ Add the symbol `s` to the list of (global) verbosity scopes.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 ```
@@ -92,7 +92,7 @@ function [`get_verbosity_level`](@ref).
 We will set up different verbosity scopes with different verbosity levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_verbosity_scope(:Test1);
 
 julia> AbstractAlgebra.add_verbosity_scope(:Test2);
@@ -198,7 +198,7 @@ function [`get_verbosity_level`](@ref).
 We will set up different verbosity scopes with different verbosity levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_verbosity_scope(:Test1);
 
 julia> AbstractAlgebra.add_verbosity_scope(:Test2);
@@ -315,7 +315,7 @@ verbosity scopes by calling the function [`add_verbosity_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 julia> AbstractAlgebra.set_verbosity_level(:MyScope, 4)
@@ -345,7 +345,7 @@ verbosity scopes by calling the function [`add_verbosity_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 julia> AbstractAlgebra.get_verbosity_level(:MyScope)
@@ -386,7 +386,7 @@ Add the symbol `s` to the list of (global) assertion scopes.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 ```
@@ -411,7 +411,7 @@ assertion scopes by calling the function [`add_assertion_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.set_assertion_level(:MyScope, 4)
@@ -444,7 +444,7 @@ assertion scopes by calling the function [`add_assertion_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.get_assertion_level(:MyScope)
@@ -499,7 +499,7 @@ function [`get_assertion_level`](@ref).
 We will set up different assertion scopes with different assertion levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.get_assertion_level(:MyScope)
@@ -574,7 +574,7 @@ If the number of arguments is not 2, an `AssertionError` is raised.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> function req_test(x::Int)
        @req iseven(x) "x must be even"
        return div(x,2)

--- a/src/Assertions.jl
+++ b/src/Assertions.jl
@@ -29,7 +29,7 @@ Add the symbol `s` to the list of (global) verbosity scopes.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 ```
@@ -92,7 +92,7 @@ function [`get_verbosity_level`](@ref).
 We will set up different verbosity scopes with different verbosity levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_verbosity_scope(:Test1);
 
 julia> AbstractAlgebra.add_verbosity_scope(:Test2);
@@ -198,7 +198,7 @@ function [`get_verbosity_level`](@ref).
 We will set up different verbosity scopes with different verbosity levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_verbosity_scope(:Test1);
 
 julia> AbstractAlgebra.add_verbosity_scope(:Test2);
@@ -315,7 +315,7 @@ verbosity scopes by calling the function [`add_verbosity_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 julia> AbstractAlgebra.set_verbosity_level(:MyScope, 4)
@@ -345,7 +345,7 @@ verbosity scopes by calling the function [`add_verbosity_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_verbosity_scope(:MyScope)
 
 julia> AbstractAlgebra.get_verbosity_level(:MyScope)
@@ -386,7 +386,7 @@ Add the symbol `s` to the list of (global) assertion scopes.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 ```
@@ -411,7 +411,7 @@ assertion scopes by calling the function [`add_assertion_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.set_assertion_level(:MyScope, 4)
@@ -444,7 +444,7 @@ assertion scopes by calling the function [`add_assertion_scope`](@ref).
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.get_assertion_level(:MyScope)
@@ -499,7 +499,7 @@ function [`get_assertion_level`](@ref).
 We will set up different assertion scopes with different assertion levels in a
 custom function to show how to use this macro.
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.add_assertion_scope(:MyScope)
 
 julia> AbstractAlgebra.get_assertion_level(:MyScope)
@@ -574,7 +574,7 @@ If the number of arguments is not 2, an `AssertionError` is raised.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> function req_test(x::Int)
        @req iseven(x) "x must be even"
        return div(x,2)

--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -36,7 +36,7 @@ enabled. Thus it is not necessary to apply this macro to such a type.
 
 Applying the macro to a struct definition results in internal storage
 of the attributes:
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> @attributes mutable struct MyGroup
            order::Int
            MyGroup(order::Int) = new(order)
@@ -53,7 +53,7 @@ true
 
 Applying the macro to a typename results in external storage of the
 attributes:
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> mutable struct MyOtherGroup
            order::Int
            MyOtherGroup(order::Int) = new(order)
@@ -301,7 +301,7 @@ end
 ```
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> @attributes mutable struct Foo
            x::Int
            Foo(x::Int) = new(x)

--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -36,7 +36,7 @@ enabled. Thus it is not necessary to apply this macro to such a type.
 
 Applying the macro to a struct definition results in internal storage
 of the attributes:
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> @attributes mutable struct MyGroup
            order::Int
            MyGroup(order::Int) = new(order)
@@ -53,7 +53,7 @@ true
 
 Applying the macro to a typename results in external storage of the
 attributes:
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> mutable struct MyOtherGroup
            order::Int
            MyOtherGroup(order::Int) = new(order)
@@ -301,7 +301,7 @@ end
 ```
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> @attributes mutable struct Foo
            x::Int
            Foo(x::Int) = new(x)

--- a/src/CommonTypes.jl
+++ b/src/CommonTypes.jl
@@ -40,7 +40,7 @@ There are two inner constructors of `Perm`:
   constitutes a valid permutation. To skip the check call `Perm(v, false)`.
    
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Perm([1,2,3])
 ()
    

--- a/src/CommonTypes.jl
+++ b/src/CommonTypes.jl
@@ -40,7 +40,7 @@ There are two inner constructors of `Perm`:
   constitutes a valid permutation. To skip the check call `Perm(v, false)`.
    
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Perm([1,2,3])
 ()
    

--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -169,7 +169,7 @@ The syntax `a(vals...)` is also supported.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, (x, y) = free_associative_algebra(ZZ, ["x", "y"]);
 
 julia> f = x*y - y*x

--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -169,7 +169,7 @@ The syntax `a(vals...)` is also supported.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, (x, y) = free_associative_algebra(ZZ, ["x", "y"]);
 
 julia> f = x*y - y*x

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -26,7 +26,7 @@ Falls back to `Generic.MPoly{T}`.
 See also [`mpoly_ring_type`](@ref), [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> mpoly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.MPoly{BigInt}
 
@@ -57,7 +57,7 @@ respectively `elem_type(S)`. Implemented via [`mpoly_type`](@ref).
 See also [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> mpoly_ring_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.MPolyRing{BigInt}
 
@@ -1413,7 +1413,7 @@ See also: [`polynomial_ring(::Ring, ::Vararg)`](@ref), [`@polynomial_ring`](@ref
 
 # Example
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, generators = polynomial_ring(ZZ, [:x, :y, :z])
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y, z])
 ```
@@ -1439,7 +1439,7 @@ Return a tuple `S, generators...` with `generators[i]` corresponding to `varname
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, (a, b, c) = polynomial_ring(ZZ, [:a, :b, :c])
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[a, b, c])
 
@@ -1470,7 +1470,7 @@ Same as [`polynomial_ring(::Ring, ["s$i" for i in 1:n])`](@ref polynomial_ring(:
 
 # Example
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, x = polynomial_ring(ZZ, 3)
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[x1, x2, x3])
 ```
@@ -1485,7 +1485,7 @@ introduce the generators into the current scope.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S = @polynomial_ring(ZZ, "x#" => (1:2, 1:2), "y#" => 1:3)
 Multivariate polynomial ring in 7 variables x11, x21, x12, x22, ..., y3
   over integers

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -26,7 +26,7 @@ Falls back to `Generic.MPoly{T}`.
 See also [`mpoly_ring_type`](@ref), [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> mpoly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.MPoly{BigInt}
 
@@ -57,7 +57,7 @@ respectively `elem_type(S)`. Implemented via [`mpoly_type`](@ref).
 See also [`dense_poly_type`](@ref) and [`dense_poly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> mpoly_ring_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.MPolyRing{BigInt}
 
@@ -1413,7 +1413,7 @@ See also: [`polynomial_ring(::Ring, ::Vararg)`](@ref), [`@polynomial_ring`](@ref
 
 # Example
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, generators = polynomial_ring(ZZ, [:x, :y, :z])
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[x, y, z])
 ```
@@ -1439,7 +1439,7 @@ Return a tuple `S, generators...` with `generators[i]` corresponding to `varname
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, (a, b, c) = polynomial_ring(ZZ, [:a, :b, :c])
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[a, b, c])
 
@@ -1470,7 +1470,7 @@ Same as [`polynomial_ring(::Ring, ["s$i" for i in 1:n])`](@ref polynomial_ring(:
 
 # Example
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, x = polynomial_ring(ZZ, 3)
 (Multivariate polynomial ring in 3 variables over integers, AbstractAlgebra.Generic.MPoly{BigInt}[x1, x2, x3])
 ```
@@ -1485,7 +1485,7 @@ introduce the generators into the current scope.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S = @polynomial_ring(ZZ, "x#" => (1:2, 1:2), "y#" => 1:3)
 Multivariate polynomial ring in 7 variables x11, x21, x12, x22, ..., y3
   over integers

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -69,7 +69,7 @@ Base.:\(f::Map, x) = preimage(f, x)
 Compose the two maps $f$ and $g$, i.e. return the map $h$ such that $h(x) = g(f(x))$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> f = map_from_func(x -> x + 1, ZZ, ZZ);
 
 julia> g = map_from_func(x -> QQ(x), ZZ, QQ);
@@ -102,7 +102,7 @@ end
 Return an identity map on the domain $R$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = ZZ[:t]
 (Univariate polynomial ring in t over integers, t)
 
@@ -129,7 +129,7 @@ Construct the generic functional map with domain and codomain given by the paren
 $R$ and $S$ corresponding to the Julia function $f$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> f = map_from_func(x -> x + 1, ZZ, ZZ)
 Map defined by a Julia function
   from integers

--- a/src/Map.jl
+++ b/src/Map.jl
@@ -69,7 +69,7 @@ Base.:\(f::Map, x) = preimage(f, x)
 Compose the two maps $f$ and $g$, i.e. return the map $h$ such that $h(x) = g(f(x))$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> f = map_from_func(x -> x + 1, ZZ, ZZ);
 
 julia> g = map_from_func(x -> QQ(x), ZZ, QQ);
@@ -102,7 +102,7 @@ end
 Return an identity map on the domain $R$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = ZZ[:t]
 (Univariate polynomial ring in t over integers, t)
 
@@ -129,7 +129,7 @@ Construct the generic functional map with domain and codomain given by the paren
 $R$ and $S$ corresponding to the Julia function $f$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> f = map_from_func(x -> x + 1, ZZ, ZZ)
 Map defined by a Julia function
   from integers

--- a/src/Matrix-Strassen.jl
+++ b/src/Matrix-Strassen.jl
@@ -12,7 +12,7 @@ The speedup depends on the ring and the entry sizes.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> m = matrix(ZZ, rand(-10:10, 1000, 1000));
 
 julia> n1 = similar(m); n2 = similar(m); n3 = similar(m);

--- a/src/Matrix-Strassen.jl
+++ b/src/Matrix-Strassen.jl
@@ -12,7 +12,7 @@ The speedup depends on the ring and the entry sizes.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> m = matrix(ZZ, rand(-10:10, 1000, 1000));
 
 julia> n1 = similar(m); n2 = similar(m); n3 = similar(m);

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1466,7 +1466,7 @@ Alias for `LinearAlgebra.issymmetric`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> M = matrix(ZZ, [1 2 3; 2 4 5; 3 5 6])
 [1   2   3]
 [2   4   5]
@@ -1501,7 +1501,7 @@ Return the transpose of the given matrix.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1563,7 +1563,7 @@ $i$-th and $j$-th rows, respectively.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1610,7 +1610,7 @@ require the matrix to be square.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1651,7 +1651,7 @@ its entries, assuming it exists.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1695,7 +1695,7 @@ Apply the pemutation $P$ to the rows of the matrix $x$ and return the result.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1740,7 +1740,7 @@ Apply the pemutation $P$ to the columns of the matrix $x$ and return the result.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -2442,7 +2442,7 @@ Return the determinant of the matrix $M$. We assume $M$ is square.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -2562,7 +2562,7 @@ Return an array consisting of the `k`-minors of `A`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -2584,7 +2584,7 @@ Return an iterator that computes the `k`-minors of `A`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -2613,7 +2613,7 @@ Return the `k`-th exterior power of `A`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = matrix(ZZ, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 julia> exterior_power(A, 2)
@@ -2647,7 +2647,7 @@ Return `true` if the given matrix is skew symmetric with respect to its main
 diagonal, i.e., `transpose(M) == -M`, otherwise return `false`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> M = matrix(ZZ, [0 -1 -2; 1 0 -3; 2 3 0])
 [0   -1   -2]
 [1    0   -3]
@@ -2826,7 +2826,7 @@ Return the rank of the matrix $M$.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = QQ[1 2; 3 4];
 
 julia> d = rank(A)
@@ -3409,7 +3409,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.istriu`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> is_upper_triangular(QQ[1 2 ; 0 4])
 true
 
@@ -3525,7 +3525,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.istril`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> is_lower_triangular(QQ[1 2 ; 0 4])
 false
 
@@ -3560,7 +3560,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.isdiag`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> is_diagonal(QQ[1 0 ; 0 4])
 true
 
@@ -3685,7 +3685,7 @@ function to compute an integral kernel.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -4162,7 +4162,7 @@ the resulting polynomial is an element of it.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, = residue_ring(ZZ, 7);
 
 julia> S = matrix_space(R, 4, 4)
@@ -4367,7 +4367,7 @@ the resulting polynomial is an element of it.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R = GF(13)
 Finite field F_13
 
@@ -5965,7 +5965,7 @@ preserves the minimal and characteristic polynomials of a matrix.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, = residue_ring(ZZ, 7);
 
 julia> S = matrix_space(R, 4, 4)
@@ -6021,7 +6021,7 @@ Return a matrix $b$ with the entries of $a$, where the $i$th and $j$th
 row are swapped.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> M = identity_matrix(ZZ, 3)
 [1   0   0]
 [0   1   0]
@@ -6052,7 +6052,7 @@ Swap the $i$th and $j$th row of $a$ in place. The function returns the mutated
 matrix (since matrices are assumed to be mutable in AbstractAlgebra.jl).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> M = identity_matrix(ZZ, 3)
 [1   0   0]
 [0   1   0]
@@ -6635,7 +6635,7 @@ Constructs the matrix over $R$ with entries as in `arr`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> matrix(GF(3), [1 2 ; 3 4])
 [1   2]
 [0   1]
@@ -6821,7 +6821,7 @@ Return the $m \times n$ matrix over $R$ with `x` along the main diagonal and
 zeroes elsewhere. If `n` is not specified, it defaults to `m`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> diagonal_matrix(ZZ(2), 2, 3)
 [2   0   0]
 [0   2   0]
@@ -6853,7 +6853,7 @@ matrix. Otherwise the parent is inferred from the vector $x$.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> diagonal_matrix(ZZ(1), ZZ(2))
 [1   0]
 [0   2]
@@ -6924,7 +6924,7 @@ $n(n+1)/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> lower_triangular_matrix([1, 2, 3])
 [1   0]
 [2   3]
@@ -6963,7 +6963,7 @@ $n(n+1)/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> upper_triangular_matrix([1, 2, 3])
 [1   2]
 [0   3]
@@ -7002,7 +7002,7 @@ $(n-1)n/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> strictly_lower_triangular_matrix([1, 2, 3])
 [0   0   0]
 [1   0   0]
@@ -7042,7 +7042,7 @@ $(n-1)n/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> strictly_upper_triangular_matrix([1, 2, 3])
 [0   1   2]
 [0   0   3]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1466,7 +1466,7 @@ Alias for `LinearAlgebra.issymmetric`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> M = matrix(ZZ, [1 2 3; 2 4 5; 3 5 6])
 [1   2   3]
 [2   4   5]
@@ -1501,7 +1501,7 @@ Return the transpose of the given matrix.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1563,7 +1563,7 @@ $i$-th and $j$-th rows, respectively.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1610,7 +1610,7 @@ require the matrix to be square.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1651,7 +1651,7 @@ its entries, assuming it exists.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1695,7 +1695,7 @@ Apply the pemutation $P$ to the rows of the matrix $x$ and return the result.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -1740,7 +1740,7 @@ Apply the pemutation $P$ to the columns of the matrix $x$ and return the result.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, t = polynomial_ring(QQ, :t)
 (Univariate polynomial ring in t over rationals, t)
 
@@ -2442,7 +2442,7 @@ Return the determinant of the matrix $M$. We assume $M$ is square.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -2562,7 +2562,7 @@ Return an array consisting of the `k`-minors of `A`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -2584,7 +2584,7 @@ Return an iterator that computes the `k`-minors of `A`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -2613,7 +2613,7 @@ Return the `k`-th exterior power of `A`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = matrix(ZZ, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 julia> exterior_power(A, 2)
@@ -2647,7 +2647,7 @@ Return `true` if the given matrix is skew symmetric with respect to its main
 diagonal, i.e., `transpose(M) == -M`, otherwise return `false`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> M = matrix(ZZ, [0 -1 -2; 1 0 -3; 2 3 0])
 [0   -1   -2]
 [1    0   -3]
@@ -2826,7 +2826,7 @@ Return the rank of the matrix $M$.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = QQ[1 2; 3 4];
 
 julia> d = rank(A)
@@ -3409,7 +3409,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.istriu`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> is_upper_triangular(QQ[1 2 ; 0 4])
 true
 
@@ -3525,7 +3525,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.istril`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> is_lower_triangular(QQ[1 2 ; 0 4])
 false
 
@@ -3560,7 +3560,7 @@ definition also applies to non-square matrices.
 Alias for `LinearAlgebra.isdiag`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> is_diagonal(QQ[1 0 ; 0 4])
 true
 
@@ -3685,7 +3685,7 @@ function to compute an integral kernel.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -4162,7 +4162,7 @@ the resulting polynomial is an element of it.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, = residue_ring(ZZ, 7);
 
 julia> S = matrix_space(R, 4, 4)
@@ -4184,7 +4184,6 @@ y^4 + 2*y^2 + 6*y + 2
 
 julia> A = charpoly(M)
 x^4 + 2*x^2 + 6*x + 2
-
 ```
 """
 function charpoly(S::PolyRing{T}, Y::MatrixElem{T}) where {T <: RingElement}
@@ -4368,7 +4367,7 @@ the resulting polynomial is an element of it.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R = GF(13)
 Finite field F_13
 
@@ -5966,7 +5965,7 @@ preserves the minimal and characteristic polynomials of a matrix.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, = residue_ring(ZZ, 7);
 
 julia> S = matrix_space(R, 4, 4)
@@ -6022,7 +6021,7 @@ Return a matrix $b$ with the entries of $a$, where the $i$th and $j$th
 row are swapped.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> M = identity_matrix(ZZ, 3)
 [1   0   0]
 [0   1   0]
@@ -6053,7 +6052,7 @@ Swap the $i$th and $j$th row of $a$ in place. The function returns the mutated
 matrix (since matrices are assumed to be mutable in AbstractAlgebra.jl).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> M = identity_matrix(ZZ, 3)
 [1   0   0]
 [0   1   0]
@@ -6636,7 +6635,7 @@ Constructs the matrix over $R$ with entries as in `arr`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> matrix(GF(3), [1 2 ; 3 4])
 [1   2]
 [0   1]
@@ -6822,7 +6821,7 @@ Return the $m \times n$ matrix over $R$ with `x` along the main diagonal and
 zeroes elsewhere. If `n` is not specified, it defaults to `m`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> diagonal_matrix(ZZ(2), 2, 3)
 [2   0   0]
 [0   2   0]
@@ -6854,7 +6853,7 @@ matrix. Otherwise the parent is inferred from the vector $x$.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> diagonal_matrix(ZZ(1), ZZ(2))
 [1   0]
 [0   2]
@@ -6925,7 +6924,7 @@ $n(n+1)/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> lower_triangular_matrix([1, 2, 3])
 [1   0]
 [2   3]
@@ -6964,7 +6963,7 @@ $n(n+1)/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> upper_triangular_matrix([1, 2, 3])
 [1   2]
 [0   3]
@@ -7003,7 +7002,7 @@ $(n-1)n/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> strictly_lower_triangular_matrix([1, 2, 3])
 [0   0   0]
 [1   0   0]
@@ -7043,7 +7042,7 @@ $(n-1)n/2$.
 An exception is thrown if there is no integer $n$ with this property.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> strictly_upper_triangular_matrix([1, 2, 3])
 [0   1   2]
 [0   0   3]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -4170,7 +4170,7 @@ Matrix space of 4 rows and 4 columns
   over residue ring of integers modulo 7
 
 julia> T, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over residue ring, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> M = S([R(1) R(2) R(4) R(3); R(2) R(5) R(1) R(0);
               R(6) R(1) R(3) R(2); R(1) R(1) R(3) R(5)])
@@ -4373,7 +4373,7 @@ julia> R = GF(13)
 Finite field F_13
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over finite field F_13, y)
+(Univariate polynomial ring in y over R, y)
 
 julia> M = R[7 6 1;
              7 7 5;

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -30,7 +30,7 @@ Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 See also [`dense_poly_ring_type`](@ref), [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> dense_poly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.Poly{BigInt}
 
@@ -61,7 +61,7 @@ The type of univariate polynomial rings with coefficients of type `T` respective
 See also [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> dense_poly_ring_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.PolyRing{BigInt}
 
@@ -745,7 +745,7 @@ Setting the optional argument `cached` to `false` will prevent the parent object
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -30,7 +30,7 @@ Falls back to `Generic.NCPoly{T}` respectively `Generic.Poly{T}`.
 See also [`dense_poly_ring_type`](@ref), [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> dense_poly_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.Poly{BigInt}
 
@@ -61,7 +61,7 @@ The type of univariate polynomial rings with coefficients of type `T` respective
 See also [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> dense_poly_ring_type(AbstractAlgebra.ZZ(1))
 AbstractAlgebra.Generic.PolyRing{BigInt}
 
@@ -745,7 +745,7 @@ Setting the optional argument `cached` to `false` will prevent the parent object
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -750,7 +750,7 @@ julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
 julia> S, y = polynomial_ring(R, :y)
-(Univariate polynomial ring in y over univariate polynomial ring, y)
+(Univariate polynomial ring in y over R, y)
 ```
 """
 function polynomial_ring(R::NCRing, s::VarName =:x; kw...)

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -142,7 +142,7 @@ Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 Return true if $a$ is invertible, else return false.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -217,7 +217,7 @@ end
 Return an array $M$ of "powers" of `a` where $M[i + 1] = a^i$ for $i = 0..d$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
 [1   2   3]
 [2   3   4]

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -142,7 +142,7 @@ Base.literal_pow(::typeof(^), x::NCRingElem, ::Val{p}) where {p} = x^p
 Return true if $a$ is invertible, else return false.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -217,7 +217,7 @@ end
 Return an array $M$ of "powers" of `a` where $M[i + 1] = a^i$ for $i = 0..d$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
 [1   2   3]
 [2   3   4]

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -2110,7 +2110,7 @@ for details.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.is_terse(stdout)
 false
 
@@ -2133,7 +2133,7 @@ for details.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.is_terse(stdout)
 false
 

--- a/src/PrettyPrinting.jl
+++ b/src/PrettyPrinting.jl
@@ -2110,7 +2110,7 @@ for details.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.is_terse(stdout)
 false
 
@@ -2133,7 +2133,7 @@ for details.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.is_terse(stdout)
 false
 

--- a/src/PrintHelper.jl
+++ b/src/PrintHelper.jl
@@ -8,7 +8,7 @@ obtain the correct pluralization. But it works well enough in the
 vast majority of cases.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> pluralize("generator")
 "generators"
 
@@ -70,7 +70,7 @@ have. Ideally, though, please instead improve `pluralize` to handle your needs
 correctly.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> ItemQuantity(0, "generator")
 0 generators
 
@@ -82,7 +82,7 @@ julia> ItemQuantity(2, "generator")
 ```
 
 Here is an example with a custom plural form.
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> ItemQuantity(0, "ox", "oxen")
 0 oxen
 

--- a/src/PrintHelper.jl
+++ b/src/PrintHelper.jl
@@ -8,7 +8,7 @@ obtain the correct pluralization. But it works well enough in the
 vast majority of cases.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> pluralize("generator")
 "generators"
 
@@ -70,7 +70,7 @@ have. Ideally, though, please instead improve `pluralize` to handle your needs
 correctly.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> ItemQuantity(0, "generator")
 0 generators
 
@@ -82,7 +82,7 @@ julia> ItemQuantity(2, "generator")
 ```
 
 Here is an example with a custom plural form.
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> ItemQuantity(0, "ox", "oxen")
 0 oxen
 

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -177,7 +177,7 @@ $Ax = b$ or $xA = b$ for different $b$.
 
 # Example
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = QQ[1 2 3; 0 3 0; 5 0 0];
 
 julia> C = solve_init(A)

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -177,7 +177,7 @@ $Ax = b$ or $xA = b$ for different $b$.
 
 # Example
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = QQ[1 2 3; 0 3 0; 5 0 0];
 
 julia> C = solve_init(A)

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -16,7 +16,7 @@
 Return parent object of given element $a$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> G = SymmetricGroup(5); g = Perm([3,4,5,2,1])
 (1,3,5)(2,4)
 
@@ -39,7 +39,7 @@ function parent end
 Given a parent object (or its type), return the type of its elements.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, x = power_series_ring(QQ, 2, :x)
 (Univariate power series ring over rationals, x + O(x^3))
 
@@ -57,7 +57,7 @@ elem_type(T::DataType) = throw(MethodError(elem_type, (T,)))
 Given an element (or its type), return the type of its parent object.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -80,7 +80,7 @@ parent_type(T::DataType) = throw(MethodError(parent_type, (T,)))
 Return base ring $R$ of given element or parent $a$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -104,7 +104,7 @@ base_ring(x::NCRingElement) = base_ring(parent(x))
 Return the type of the base ring of the given element, element type, parent or parent type $a$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -143,7 +143,7 @@ Return the multiplicative identity in the algebraic structure of $a$, which can
 be either an element or parent.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S = matrix_space(ZZ, 2, 2)
 Matrix space of 2 rows and 2 columns
   over integers
@@ -174,7 +174,7 @@ Return the additive identity in the algebraic structure of $a$, which can be
 either an element or parent.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S = matrix_ring(QQ, 2)
 Matrix ring of degree 2
   over rationals
@@ -204,7 +204,7 @@ function zero end
 Return true if $a$ is the multiplicative identity, else return false.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S = matrix_space(ZZ, 2, 2); T = matrix_space(ZZ, 2, 3); U = matrix_space(ZZ, 3, 2);
 
 julia> isone(S([1 0; 0 1]))
@@ -231,7 +231,7 @@ function isone end
 Return true if $a$ is the additative identity, else return false.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> T, x = puiseux_series_field(QQ, 10, :x)
 (Puiseux series field in x over rationals, x + O(x^11))
 
@@ -256,7 +256,7 @@ function iszero end
 # Return element generating parent $a$.
 
 # # Examples
-# ```jldoctest; setup = AbstractAlgebra.doctestsetup()
+# ```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 # julia> S, x = laurent_polynomial_ring(QQ, :x)
 # (Univariate Laurent Polynomial Ring in x over Rationals, x)
 
@@ -272,7 +272,7 @@ function gen end
 # Return elements generating parent $a$ in an array.
 
 # # Examples
-# ```jldoctest; setup = AbstractAlgebra.doctestsetup()
+# ```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 # ```
 # """
 function gens end

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -16,7 +16,7 @@
 Return parent object of given element $a$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> G = SymmetricGroup(5); g = Perm([3,4,5,2,1])
 (1,3,5)(2,4)
 
@@ -39,7 +39,7 @@ function parent end
 Given a parent object (or its type), return the type of its elements.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, x = power_series_ring(QQ, 2, :x)
 (Univariate power series ring over rationals, x + O(x^3))
 
@@ -57,7 +57,7 @@ elem_type(T::DataType) = throw(MethodError(elem_type, (T,)))
 Given an element (or its type), return the type of its parent object.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -80,7 +80,7 @@ parent_type(T::DataType) = throw(MethodError(parent_type, (T,)))
 Return base ring $R$ of given element or parent $a$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S, x = polynomial_ring(QQ, :x)
 (Univariate polynomial ring in x over rationals, x)
 
@@ -104,7 +104,7 @@ base_ring(x::NCRingElement) = base_ring(parent(x))
 Return the type of the base ring of the given element, element type, parent or parent type $a$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = polynomial_ring(ZZ, :x)
 (Univariate polynomial ring in x over integers, x)
 
@@ -143,7 +143,7 @@ Return the multiplicative identity in the algebraic structure of $a$, which can
 be either an element or parent.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S = matrix_space(ZZ, 2, 2)
 Matrix space of 2 rows and 2 columns
   over integers
@@ -174,7 +174,7 @@ Return the additive identity in the algebraic structure of $a$, which can be
 either an element or parent.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S = matrix_ring(QQ, 2)
 Matrix ring of degree 2
   over rationals
@@ -204,7 +204,7 @@ function zero end
 Return true if $a$ is the multiplicative identity, else return false.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S = matrix_space(ZZ, 2, 2); T = matrix_space(ZZ, 2, 3); U = matrix_space(ZZ, 3, 2);
 
 julia> isone(S([1 0; 0 1]))
@@ -231,7 +231,7 @@ function isone end
 Return true if $a$ is the additative identity, else return false.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> T, x = puiseux_series_field(QQ, 10, :x)
 (Puiseux series field in x over rationals, x + O(x^11))
 
@@ -256,7 +256,7 @@ function iszero end
 # Return element generating parent $a$.
 
 # # Examples
-# ```jldoctest; setup = :(using AbstractAlgebra)
+# ```jldoctest; setup = AbstractAlgebra.doctestsetup()
 # julia> S, x = laurent_polynomial_ring(QQ, :x)
 # (Univariate Laurent Polynomial Ring in x over Rationals, x)
 
@@ -272,7 +272,7 @@ function gen end
 # Return elements generating parent $a$ in an array.
 
 # # Examples
-# ```jldoctest; setup = :(using AbstractAlgebra)
+# ```jldoctest; setup = AbstractAlgebra.doctestsetup()
 # ```
 # """
 function gens end

--- a/src/generic/AhoCorasick.jl
+++ b/src/generic/AhoCorasick.jl
@@ -29,7 +29,7 @@ An Aho-Corasick automaton, which can be used to efficiently search for a fixed l
 arbitrary lists of integers
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> keywords = [[1, 2, 3, 4], [1, 5, 4], [4, 1, 2], [1, 2]];
 
 julia> aut = Generic.aho_corasick_automaton(keywords);
@@ -56,7 +56,7 @@ The return value of searching in a given word with an AhoCorasickAutomaton. Cont
 the word that matches a keyword in the automaton, an index of the keyword that was matched and the keyword itself.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> keywords = [[1, 2, 3, 4], [1, 5, 4], [4, 1, 2], [1, 2]];
 
 julia> aut = Generic.aho_corasick_automaton(keywords);

--- a/src/generic/AhoCorasick.jl
+++ b/src/generic/AhoCorasick.jl
@@ -29,7 +29,7 @@ An Aho-Corasick automaton, which can be used to efficiently search for a fixed l
 arbitrary lists of integers
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> keywords = [[1, 2, 3, 4], [1, 5, 4], [4, 1, 2], [1, 2]];
 
 julia> aut = Generic.aho_corasick_automaton(keywords);
@@ -56,7 +56,7 @@ The return value of searching in a given word with an AhoCorasickAutomaton. Cont
 the word that matches a keyword in the automaton, an index of the keyword that was matched and the keyword itself.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> keywords = [[1, 2, 3, 4], [1, 5, 4], [4, 1, 2], [1, 2]];
 
 julia> aut = Generic.aho_corasick_automaton(keywords);

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -372,7 +372,7 @@ coefficient Ring implements isless.
 The order of letters is the reverse of the order given when initialising the algebra.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, (x, y) = free_associative_algebra(QQ, ["x", "y"]);
 
 julia> x < y^2

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -372,7 +372,7 @@ coefficient Ring implements isless.
 The order of letters is the reverse of the order given when initialising the algebra.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, (x, y) = free_associative_algebra(QQ, ["x", "y"]);
 
 julia> x < y^2

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -17,7 +17,7 @@ The full symmetric group singleton type.
 `SymmetricGroup(n)` constructs the full symmetric group $S_n$ on $n$-symbols. The type of elements of the group is inferred from the type of `n`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> G = SymmetricGroup(5)
 Full symmetric group over 5 elements
 
@@ -78,7 +78,7 @@ Fieldnames:
  * `part::Vector{Int}` - a non-increasing sequence of summands of `n`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Partition([4,2,1,1,1])
 4₁2₁1₃
 
@@ -121,7 +121,7 @@ See also `Combinatorics.partitions(1:n)`.
 Note: All returned partitions share memory, so advancing to the next one will change the previous. For persistent storage one should `copy` the result
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> ap = AllParts(5);
 
 julia> for p in ap; println(p) end
@@ -164,7 +164,7 @@ represented by partitions `lambda` and `mu`.
 (below dots symbolise the removed entries)
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> l = Partition([4,3,2])
 4₁3₁2₁
 
@@ -214,7 +214,7 @@ Fields:
 * `fill` - the row-major fill vector: the entries of the diagram.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Partition([4,3,1]); y = YoungTableau(p)
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -1325,7 +1325,7 @@ So this is a typical matrix to represent an projection from
 a direct sum into a summand or an injection into the sum.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Generic.inj_proj_mat(ZZ, 2, 5, 3)
 [0   0   1   0   0]
 [0   0   0   1   0]

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -17,7 +17,7 @@ The full symmetric group singleton type.
 `SymmetricGroup(n)` constructs the full symmetric group $S_n$ on $n$-symbols. The type of elements of the group is inferred from the type of `n`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> G = SymmetricGroup(5)
 Full symmetric group over 5 elements
 
@@ -78,7 +78,7 @@ Fieldnames:
  * `part::Vector{Int}` - a non-increasing sequence of summands of `n`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Partition([4,2,1,1,1])
 4₁2₁1₃
 
@@ -121,7 +121,7 @@ See also `Combinatorics.partitions(1:n)`.
 Note: All returned partitions share memory, so advancing to the next one will change the previous. For persistent storage one should `copy` the result
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> ap = AllParts(5);
 
 julia> for p in ap; println(p) end
@@ -164,7 +164,7 @@ represented by partitions `lambda` and `mu`.
 (below dots symbolise the removed entries)
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> l = Partition([4,3,2])
 4₁3₁2₁
 
@@ -214,7 +214,7 @@ Fields:
 * `fill` - the row-major fill vector: the entries of the diagram.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Partition([4,3,1]); y = YoungTableau(p)
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -1325,7 +1325,7 @@ So this is a typical matrix to represent an projection from
 a direct sum into a summand or an injection into the sum.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Generic.inj_proj_mat(ZZ, 2, 5, 3)
 [0   0   1   0   0]
 [0   0   0   1   0]

--- a/src/generic/Misc/Rings.jl
+++ b/src/generic/Misc/Rings.jl
@@ -36,7 +36,7 @@ If $n < 0$ we throw a `DomainError()`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = ZZ[:x];
 
 julia> rising_factorial(x, 1)
@@ -68,7 +68,7 @@ If $n < 0$ we throw a `DomainError()`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = ZZ[:x];
 
 julia> rising_factorial2(x, 1)

--- a/src/generic/Misc/Rings.jl
+++ b/src/generic/Misc/Rings.jl
@@ -36,7 +36,7 @@ If $n < 0$ we throw a `DomainError()`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = ZZ[:x];
 
 julia> rising_factorial(x, 1)
@@ -68,7 +68,7 @@ If $n < 0$ we throw a `DomainError()`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = ZZ[:x];
 
 julia> rising_factorial2(x, 1)

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -72,7 +72,7 @@ it on demand. Since cycle structure is cached in `g` you may call
 `cycles(g)` before calling `parity`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
@@ -117,7 +117,7 @@ the homomorphism from the permutation group to the unit group of $\mathbb{Z}$
 whose kernel is the alternating group.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
@@ -185,7 +185,7 @@ The cycle decomposition is cached in `g` and used in future computation of
 `permtype`, `parity`, `sign`, `order` and `^` (powering).
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
@@ -247,7 +247,7 @@ The lengths are sorted in decreasing order by default. `permtype(g)` fully
 determines the conjugacy class of `g`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
@@ -302,7 +302,7 @@ as strings). This can be either
 The difference is purely esthetical.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> setpermstyle(:array)
 :array
 
@@ -432,7 +432,7 @@ If `g` and `h` are parametrized by different types, the result is promoted
 accordingly.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Perm([2,3,1,4])*Perm([1,3,4,2]) # (1,2,3)*(2,3,4)
 (1,3)(2,4)
 ```
@@ -452,7 +452,7 @@ the cycle structure, repeated powering of `g` will be faster with the default
 method.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> g = Perm([2,3,4,5,1])
 (1,2,3,4,5)
 
@@ -595,7 +595,7 @@ Note: you need to explicitly copy permutations intended to be stored or
 modified.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> elts = Generic.elements!(SymmetricGroup(5));
 
 
@@ -685,7 +685,7 @@ Return the permutation matrix as a sparse matrix representing `a` via natural
 embedding of the permutation group into the general linear group over $\mathbb{Z}$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Perm([2,3,1])
 (1,2,3)
 
@@ -713,7 +713,7 @@ This corresponds to the natural embedding of $S_k$ into $S_n$ as the
 subgroup permuting points indexed by `V`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Perm([2,1,4,3])
 (1,2)(3,4)
 
@@ -733,7 +733,7 @@ Return the natural embedding of a permutation group into `G` as the
 subgroup permuting points indexed by `V`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Perm([2,3,1])
 (1,2,3)
 
@@ -870,7 +870,7 @@ of the minimal support is constructed, i.e. the maximal $n$ in the
 decomposition determines the parent group $S_n$.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = perm"(1,3)(2,4)"
 (1,3)(2,4)
 
@@ -936,7 +936,7 @@ For more details see e.g. Chapter 2.8 of *Group Theory and Physics* by
 S.Sternberg.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> G = SymmetricGroup(4)
 Full symmetric group over 4 elements
 

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -72,7 +72,7 @@ it on demand. Since cycle structure is cached in `g` you may call
 `cycles(g)` before calling `parity`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
@@ -117,7 +117,7 @@ the homomorphism from the permutation group to the unit group of $\mathbb{Z}$
 whose kernel is the alternating group.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> g = Perm([3,4,1,2,5])
 (1,3)(2,4)
 
@@ -185,7 +185,7 @@ The cycle decomposition is cached in `g` and used in future computation of
 `permtype`, `parity`, `sign`, `order` and `^` (powering).
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
@@ -247,7 +247,7 @@ The lengths are sorted in decreasing order by default. `permtype(g)` fully
 determines the conjugacy class of `g`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> g = Perm([3,4,5,2,1,6])
 (1,3,5)(2,4)
 
@@ -302,7 +302,7 @@ as strings). This can be either
 The difference is purely esthetical.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> setpermstyle(:array)
 :array
 
@@ -432,7 +432,7 @@ If `g` and `h` are parametrized by different types, the result is promoted
 accordingly.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Perm([2,3,1,4])*Perm([1,3,4,2]) # (1,2,3)*(2,3,4)
 (1,3)(2,4)
 ```
@@ -452,7 +452,7 @@ the cycle structure, repeated powering of `g` will be faster with the default
 method.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> g = Perm([2,3,4,5,1])
 (1,2,3,4,5)
 
@@ -595,7 +595,7 @@ Note: you need to explicitly copy permutations intended to be stored or
 modified.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> elts = Generic.elements!(SymmetricGroup(5));
 
 
@@ -685,7 +685,7 @@ Return the permutation matrix as a sparse matrix representing `a` via natural
 embedding of the permutation group into the general linear group over $\mathbb{Z}$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Perm([2,3,1])
 (1,2,3)
 
@@ -713,7 +713,7 @@ This corresponds to the natural embedding of $S_k$ into $S_n$ as the
 subgroup permuting points indexed by `V`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Perm([2,1,4,3])
 (1,2)(3,4)
 
@@ -733,7 +733,7 @@ Return the natural embedding of a permutation group into `G` as the
 subgroup permuting points indexed by `V`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Perm([2,3,1])
 (1,2,3)
 
@@ -870,7 +870,7 @@ of the minimal support is constructed, i.e. the maximal $n$ in the
 decomposition determines the parent group $S_n$.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = perm"(1,3)(2,4)"
 (1,3)(2,4)
 
@@ -936,7 +936,7 @@ For more details see e.g. Chapter 2.8 of *Group Theory and Physics* by
 S.Sternberg.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> G = SymmetricGroup(4)
 Full symmetric group over 4 elements
 

--- a/src/generic/PolyRingHom.jl
+++ b/src/generic/PolyRingHom.jl
@@ -188,7 +188,7 @@ If no coefficient map is entered, invoke a canonical homomorphism of `C`
 to `S`, if such a homomorphism exists, and throw an error, otherwise.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Zx, x = ZZ[:x];
 
 julia> F = hom(Zx, Zx, x + 1);

--- a/src/generic/PolyRingHom.jl
+++ b/src/generic/PolyRingHom.jl
@@ -188,7 +188,7 @@ If no coefficient map is entered, invoke a canonical homomorphism of `C`
 to `S`, if such a homomorphism exists, and throw an error, otherwise.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Zx, x = ZZ[:x];
 
 julia> F = hom(Zx, Zx, x + 1);

--- a/src/generic/PriorityQueue.jl
+++ b/src/generic/PriorityQueue.jl
@@ -31,7 +31,7 @@ Parameters
 `ord::Base.Order.Ordering` Priority queue ordering
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1
@@ -134,7 +134,7 @@ Verify if priority queue `pq` has `key` in its keys.
 
 # Example
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> pq = Generic.PriorityQueue("a" => 1, "b" => 2, "c" => 3)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "a" => 1
@@ -248,7 +248,7 @@ Insert the a key `k` into a priority queue `pq` with priority `v`.
 
 # Examples 
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> a = Generic.PriorityQueue("a" => 1, "b" => 2, "c" => 3, "e" => 5)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 4 entries:
   "a" => 1
@@ -286,7 +286,7 @@ Remove and return the lowest priority key and value from a priority queue `pq` a
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> a = Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1
@@ -331,7 +331,7 @@ Delete the mapping for the given `key` in a priority queue `pq` and return the p
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> q = Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1

--- a/src/generic/PriorityQueue.jl
+++ b/src/generic/PriorityQueue.jl
@@ -31,7 +31,7 @@ Parameters
 `ord::Base.Order.Ordering` Priority queue ordering
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1
@@ -134,7 +134,7 @@ Verify if priority queue `pq` has `key` in its keys.
 
 # Example
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> pq = Generic.PriorityQueue("a" => 1, "b" => 2, "c" => 3)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "a" => 1
@@ -248,7 +248,7 @@ Insert the a key `k` into a priority queue `pq` with priority `v`.
 
 # Examples 
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> a = Generic.PriorityQueue("a" => 1, "b" => 2, "c" => 3, "e" => 5)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 4 entries:
   "a" => 1
@@ -286,7 +286,7 @@ Remove and return the lowest priority key and value from a priority queue `pq` a
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> a = Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1
@@ -331,7 +331,7 @@ Delete the mapping for the given `key` in a priority queue `pq` and return the p
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> q = Generic.PriorityQueue(Base.Order.Forward, "a" => 2, "b" => 3, "c" => 1)
 AbstractAlgebra.Generic.PriorityQueue{String, Int64, Base.Order.ForwardOrdering} with 3 entries:
   "c" => 1

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1189,7 +1189,7 @@ the universal polynomial ring $S = R[\ldots]$ with no variables in it initially.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> S = universal_polynomial_ring(ZZ)
 Universal Polynomial Ring over Integers
 

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1189,7 +1189,7 @@ the universal polynomial ring $S = R[\ldots]$ with no variables in it initially.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> S = universal_polynomial_ring(ZZ)
 Universal Polynomial Ring over Integers
 

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -10,7 +10,7 @@
 Return the size of the vector which represents the partition.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Partition([4,3,1]); size(p)
 (3,)
 ```
@@ -137,7 +137,7 @@ Return the vector of all permutations of `n`. For an unsafe generator version
 see `partitions!`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Generic.partitions(5)
 7-element Vector{AbstractAlgebra.Generic.Partition{Int64}}:
  1₅
@@ -159,7 +159,7 @@ Return the conjugated partition of `part`, i.e. the partition corresponding
 to the Young diagram of `part` reflected through the main diagonal.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> p = Partition([4,2,1,1,1])
 4₁2₁1₃
 
@@ -314,7 +314,7 @@ Return `size` of the smallest array containing `Y`, i.e. the tuple of the
 number of rows and the number of columns of `Y`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1]); size(y)
 (3, 4)
 ```
@@ -337,7 +337,7 @@ Return the column-major linear index into the `size(Y)`-array. If a box is
 outside of the array return `0`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -482,7 +482,7 @@ as string). This can be either
 The difference is purely esthetical.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> Generic.setyoungtabstyle(:array)
 :array
 
@@ -530,7 +530,7 @@ end
 Construct sparse integer matrix representing the tableau.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1]);
 
 
@@ -558,7 +558,7 @@ Replace the fill vector `Y.fill` by `V`. No check if the resulting tableau is
 standard (i.e. increasing along rows and columns) is performed.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -591,7 +591,7 @@ Return the conjugated tableau, i.e. the tableau reflected through the main
 diagonal.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -622,7 +622,7 @@ Return the row length of `Y` at box `(i,j)`, i.e. the number of boxes in the
 `i`-th row of the diagram of `Y` located to the right of the `(i,j)`-th box.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -651,7 +651,7 @@ Return the column length of `Y` at box `(i,j)`, i.e. the number of boxes in
 the `j`-th column of the diagram of `Y` located below of the `(i,j)`-th box.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -683,7 +683,7 @@ number of cells in the `j`-th column below the `(i,j)`-th box, plus `1`.
 Return `0` for `(i,j)` not in the tableau `Y`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -721,7 +721,7 @@ Since the computation overflows easily `BigInt` is returned. You may perform
 the computation of the dimension in different type by calling `dim(Int, Y)`.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> dim(YoungTableau([4,3,1]))
 70
 

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -10,7 +10,7 @@
 Return the size of the vector which represents the partition.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Partition([4,3,1]); size(p)
 (3,)
 ```
@@ -137,7 +137,7 @@ Return the vector of all permutations of `n`. For an unsafe generator version
 see `partitions!`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Generic.partitions(5)
 7-element Vector{AbstractAlgebra.Generic.Partition{Int64}}:
  1₅
@@ -159,7 +159,7 @@ Return the conjugated partition of `part`, i.e. the partition corresponding
 to the Young diagram of `part` reflected through the main diagonal.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> p = Partition([4,2,1,1,1])
 4₁2₁1₃
 
@@ -314,7 +314,7 @@ Return `size` of the smallest array containing `Y`, i.e. the tuple of the
 number of rows and the number of columns of `Y`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1]); size(y)
 (3, 4)
 ```
@@ -337,7 +337,7 @@ Return the column-major linear index into the `size(Y)`-array. If a box is
 outside of the array return `0`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -482,7 +482,7 @@ as string). This can be either
 The difference is purely esthetical.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> Generic.setyoungtabstyle(:array)
 :array
 
@@ -530,7 +530,7 @@ end
 Construct sparse integer matrix representing the tableau.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1]);
 
 
@@ -558,7 +558,7 @@ Replace the fill vector `Y.fill` by `V`. No check if the resulting tableau is
 standard (i.e. increasing along rows and columns) is performed.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -591,7 +591,7 @@ Return the conjugated tableau, i.e. the tableau reflected through the main
 diagonal.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -622,7 +622,7 @@ Return the row length of `Y` at box `(i,j)`, i.e. the number of boxes in the
 `i`-th row of the diagram of `Y` located to the right of the `(i,j)`-th box.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -651,7 +651,7 @@ Return the column length of `Y` at box `(i,j)`, i.e. the number of boxes in
 the `j`-th column of the diagram of `Y` located below of the `(i,j)`-th box.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -683,7 +683,7 @@ number of cells in the `j`-th column below the `(i,j)`-th box, plus `1`.
 Return `0` for `(i,j)` not in the tableau `Y`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> y = YoungTableau([4,3,1])
 ┌───┬───┬───┬───┐
 │ 1 │ 2 │ 3 │ 4 │
@@ -721,7 +721,7 @@ Since the computation overflows easily `BigInt` is returned. You may perform
 the computation of the dimension in different type by calling `dim(Int, Y)`.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> dim(YoungTableau([4,3,1]))
 70
 

--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -23,7 +23,7 @@ Convert `A` to a Julia `Matrix{U}` of the same dimensions with the same elements
 If `U` is omitted then `eltype(M)` is used in its place.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -49,7 +49,7 @@ Matrix{U}(M::MatrixElem{T}) where {U<:NCRingElement, T<:NCRingElement} = U[M[i, 
 Convert `A` to a Julia `Matrix` of the same dimensions with the same elements.
 
 # Examples
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> R, x = ZZ[:x]; A = R[x^0 x^1; x^2 x^3]
 [  1     x]
 [x^2   x^3]

--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -23,7 +23,7 @@ Convert `A` to a Julia `Matrix{U}` of the same dimensions with the same elements
 If `U` is omitted then `eltype(M)` is used in its place.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> A = ZZ[1 2 3; 4 5 6]
 [1   2   3]
 [4   5   6]
@@ -49,7 +49,7 @@ Matrix{U}(M::MatrixElem{T}) where {U<:NCRingElement, T<:NCRingElement} = U[M[i, 
 Convert `A` to a Julia `Matrix` of the same dimensions with the same elements.
 
 # Examples
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> R, x = ZZ[:x]; A = R[x^0 x^1; x^2 x^3]
 [  1     x]
 [x^2   x^3]

--- a/src/misc/Evaluate.jl
+++ b/src/misc/Evaluate.jl
@@ -9,7 +9,7 @@ the variables from the polynomial ring `R`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> evaluate(:((x^2 + 1)//(y + 1//2)), Dict(:x => 1, :y => QQ(2)))
 4//5
 

--- a/src/misc/Evaluate.jl
+++ b/src/misc/Evaluate.jl
@@ -9,7 +9,7 @@ the variables from the polynomial ring `R`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> evaluate(:((x^2 + 1)//(y + 1//2)), Dict(:x => 1, :y => QQ(2)))
 4//5
 

--- a/src/misc/VarNames.jl
+++ b/src/misc/VarNames.jl
@@ -27,7 +27,7 @@ is shorthand for `["s$i$j" for i in iter1, j in iter2]`.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.variable_names([:x, :y])
 2-element Vector{Symbol}:
  :x
@@ -121,7 +121,7 @@ Turn `vec` into the shape of `varnames`. Reverse flattening from [`variable_name
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> s = ([:a, :b], "x#" => (1:1, 1:2), "y#" => 1:2, [:z]);
 
 julia> AbstractAlgebra.reshape_to_varnames(AbstractAlgebra.variable_names(s...), s...)
@@ -176,7 +176,7 @@ Mimic usual keyword arguments for usage in macros.
 Return a copy of `default` with the key value pairs from `kvs` applied.
 
 # Example
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> AbstractAlgebra.keyword_arguments((:(a=1), :(b=:yes)),
        Dict(:a=>0, :b=>:no, :c=>0),
        Dict(:b => [:(:yes), :(:no)]))
@@ -206,7 +206,7 @@ Turn argument list like `(1, a=2; b=3).args` into `(1; a=2, b=3).args`.
 
 Intended to let a macro call `@m(1, a=2; b=3)` mimic a usual function call.
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> args = AbstractAlgebra.normalise_keyword_arguments(:(1, a=2; b=3).args); :($(args...),)
 :((1; a = 2, b = 3))
 
@@ -419,7 +419,7 @@ Setting `macros=:no` disables macro creation.
 
 # Examples
 
-```jldoctest; setup = AbstractAlgebra.doctestsetup()
+```jldoctest; setup = :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__))
 julia> f(a, s::Vector{Symbol}) = a, String.(s)
 f (generic function with 1 method)
 

--- a/src/misc/VarNames.jl
+++ b/src/misc/VarNames.jl
@@ -27,7 +27,7 @@ is shorthand for `["s$i$j" for i in iter1, j in iter2]`.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.variable_names([:x, :y])
 2-element Vector{Symbol}:
  :x
@@ -121,7 +121,7 @@ Turn `vec` into the shape of `varnames`. Reverse flattening from [`variable_name
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> s = ([:a, :b], "x#" => (1:1, 1:2), "y#" => 1:2, [:z]);
 
 julia> AbstractAlgebra.reshape_to_varnames(AbstractAlgebra.variable_names(s...), s...)
@@ -176,7 +176,7 @@ Mimic usual keyword arguments for usage in macros.
 Return a copy of `default` with the key value pairs from `kvs` applied.
 
 # Example
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> AbstractAlgebra.keyword_arguments((:(a=1), :(b=:yes)),
        Dict(:a=>0, :b=>:no, :c=>0),
        Dict(:b => [:(:yes), :(:no)]))
@@ -206,7 +206,7 @@ Turn argument list like `(1, a=2; b=3).args` into `(1; a=2, b=3).args`.
 
 Intended to let a macro call `@m(1, a=2; b=3)` mimic a usual function call.
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> args = AbstractAlgebra.normalise_keyword_arguments(:(1, a=2; b=3).args); :($(args...),)
 :((1; a = 2, b = 3))
 
@@ -419,7 +419,7 @@ Setting `macros=:no` disables macro creation.
 
 # Examples
 
-```jldoctest; setup = :(using AbstractAlgebra)
+```jldoctest; setup = AbstractAlgebra.doctestsetup()
 julia> f(a, s::Vector{Symbol}) = a, String.(s)
 f (generic function with 1 method)
 


### PR DESCRIPTION
... similar to what we do in Oscar. Arguably the test outputs in docstrings are better this way for the user, as they look more like what they would be seeing.

If successful we should probably do the same in Nemo (and Hecke?)