### PR TITLE
Adapt to `hvcat` error type in julia

### DIFF
--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -216,7 +216,11 @@ end
          @test_throws MethodError T[1;;;]
       end
 
-      @test_throws ArgumentError T[1; 2 3]
+      if VERSION < v"1.12.0-DEV.1612"
+         @test_throws ArgumentError T[1; 2 3]
+      else
+         @test_throws DimensionMismatch T[1; 2 3]
+      end
    end
 
    arr = [1 2; 3 4]


### PR DESCRIPTION
Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/1901.

This is fixing the error @thofma pointed out in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1900#issuecomment-2469971904.