### PR TITLE
feat: more generic `is_trivial`

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -194,7 +194,7 @@ Test whether the ring $R$ is trivial. A ring is trivial if it consists
 of a single element, or equivalently if its characteristic is 1. Such
 rings are also called zero rings.
 """
-is_trivial(F::NCRing) = one(F) == zero(F)
+is_trivial(F::NCRing) = iszero(one(F))
 is_trivial(F::Field) = false
 
 @doc raw"""

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -194,7 +194,7 @@ Test whether the ring $R$ is trivial. A ring is trivial if it consists
 of a single element, or equivalently if its characteristic is 1. Such
 rings are also called zero rings.
 """
-is_trivial(F::NCRing) = characteristic(F) == 1
+is_trivial(F::NCRing) = one(F) == zero(F)
 is_trivial(F::Field) = false
 
 @doc raw"""


### PR DESCRIPTION
As suggested by @YueRen. All rings implement `one` and `is_zero`, but many don't or cannot implement `characteristic`.

Will make #1857 less breaking.