### PR TITLE
Add `Base.keys(::MatElem)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.43.10"
+version = "0.43.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -567,6 +567,7 @@ end
 
 Base.IteratorSize(::Type{<:MatrixElem}) = Base.HasShape{2}()
 
+Base.keys(M::MatElem) = CartesianIndices(axes(M))
 Base.pairs(M::MatElem) = Base.pairs(IndexCartesian(), M)
 Base.pairs(::IndexCartesian, M::MatElem) = Base.Iterators.Pairs(M, CartesianIndices(axes(M)))
 

--- a/test/Matrix-test.jl
+++ b/test/Matrix-test.jl
@@ -132,6 +132,21 @@ end
   @test Matrix(Sa) == a
 end
 
+@testset "Matrix.keys and pairs" begin
+  a = matrix(ZZ, 2, 3, [6, 3, 0, 10, 12, 14])
+  @test keys(a) == CartesianIndices((2, 3))
+  @test issetequal(
+    keys(a),
+    [CartesianIndex(1, 1), CartesianIndex(1, 2), CartesianIndex(1, 3),
+     CartesianIndex(2, 1), CartesianIndex(2, 2), CartesianIndex(2, 3)],
+  )
+  @test issetequal(
+    pairs(a),
+    [CartesianIndex(1, 1) => 6, CartesianIndex(1, 2) => 3, CartesianIndex(1, 3) => 0,
+     CartesianIndex(2, 1) => 10, CartesianIndex(2, 2) => 12, CartesianIndex(2, 3) => 14],
+  )
+end
+
 @testset "Strassen" begin
    S = matrix(QQ, rand(-10:10, 100, 100))
    T = S*S


### PR DESCRIPTION
This is needed to e.g. do a `findall(f, ::MatElem)` in julia 1.10, and thus is needed for the 1.10 tests on https://github.com/oscar-system/Oscar.jl/pull/4322.