### PR TITLE
Add `is_abelian` for groups

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -276,6 +276,7 @@ export inverse_image_fn
 export inverse_mat
 export invmod
 export iroot
+export is_abelian
 export is_associated
 export is_compatible
 export is_constant

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -678,6 +678,8 @@ order(::Type{T}, G::SymmetricGroup) where {T} = convert(T, factorial(T(G.n)))
 order(::Type{T}, g::Perm) where {T} =
    convert(T, foldl(lcm, length(c) for c in cycles(g)))
 
+is_abelian(G::SymmetricGroup) = G.n <= 2
+
 @doc raw"""
     matrix_repr(a::Perm)
 

--- a/src/generic/exports.jl
+++ b/src/generic/exports.jl
@@ -46,6 +46,7 @@ export inverse_fn
 export inverse_image_fn
 export inverse_mat
 export invmod
+export is_abelian
 export is_compatible
 export is_divisible_by
 export is_free

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -305,6 +305,13 @@ end
    @test collect(cycles(p^5)) == [T[1,9], T[2], T[3], T[4], T[5], T[6,10,8], T[7]]
    @test Generic.permtype(p^5) == [3, 2, 1, 1, 1, 1, 1]
    @test order(p^5) == 6
+
+   @test is_abelian(SymmetricGroup(T(1)))
+   @test is_abelian(SymmetricGroup(T(2)))
+   @test !is_abelian(SymmetricGroup(T(3)))
+   @test !is_abelian(SymmetricGroup(T(4)))
+   @test !is_abelian(SymmetricGroup(T(5)))
+   @test !is_abelian(SymmetricGroup(T(10)))
 end
 
 @testset "Perm.characters" begin


### PR DESCRIPTION
This is not required to be implemented, but this serves as a parent function for all uses downstream.