### PR TITLE
Change `similar`, `zero_matrix`, `ones_matrix` to use `UndefInitializer` constructors

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -93,12 +93,7 @@ function (s::MatSpace{T})(a::MatrixElem{T}) where {T <: NCRingElement}
   _check_dim(nrows(s), ncols(s), a)
   base_ring(s) == base_ring(a) || throw(DomainError((s, a), "Base rings do not match."))
   a isa eltype(s) && return a
-
-  M = s()  # zero matrix
-  for i = 1:nrows(s), j = 1:ncols(s)
-    M[i, j] = a[i, j]
-  end
-  return M
+  return matrix(base_ring(a), b)
 end
 
 # create a matrix with b on the diagonal
@@ -6634,7 +6629,10 @@ function matrix(R::NCRing, arr::MatElem)
 end
 
 function matrix(R::NCRing, arr::MatRingElem)
-   return matrix_space(R, nrows(arr), ncols(arr))(arr)
+   M = zero_matrix(R, nrows(arr), ncols(arr))
+   for i in 1:nrows(s), j in 1:ncols(s)
+      M[i, j] = a[i, j]
+   end
 end
 
 function matrix(mat::MatrixElem{T}) where {T<:NCRingElement}

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6688,7 +6688,10 @@ end
 
 Return the $r \times c$ zero matrix over $R$.
 """
-zero_matrix(R::NCRing, r::Int, c::Int) = zero!(dense_matrix_type(R)(R, undef, r, c))
+function zero_matrix(R::NCRing, r::Int, c::Int)
+  (r < 0 || c < 0) && error("Dimensions must be non-negative")
+  return zero!(dense_matrix_type(R)(R, undef, r, c))
+end
 
 zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int) = zero_matrix(R, n, m)
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -395,7 +395,7 @@ end
 Create an uninitialized matrix over the given ring and dimensions,
 with defaults based upon the given source matrix `x`.
 """
-similar(x::MatElem, R::NCRing, r::Int, c::Int) = zero_matrix(R, r, c)
+similar(x::MatElem, R::NCRing, r::Int, c::Int) = dense_matrix_type(R)(R, undef, r, c)
   
 similar(x::MatElem, R::NCRing) = similar(x, R, nrows(x), ncols(x))
 
@@ -879,7 +879,7 @@ function zero!(x::MatrixElem{T}) where T <: NCRingElement
    for i = 1:nrows(x), j = 1:ncols(x)
       x[i, j] = zero(R)
    end
-   x
+   return x
 end
 
 function add!(c::MatrixElem{T}, a::MatrixElem{T}, b::MatrixElem{T}) where T <: NCRingElement
@@ -6725,16 +6725,7 @@ end
 
 Return the $r \times c$ zero matrix over $R$.
 """
-function zero_matrix(R::NCRing, r::Int, c::Int)
-   arr = Matrix{elem_type(R)}(undef, r, c)
-   for i in 1:r
-      for j in 1:c
-         arr[i, j] = zero(R)
-      end
-   end
-   z = Generic.MatSpaceElem{elem_type(R)}(R, arr)
-   return z
-end
+zero_matrix(R::NCRing, r::Int, c::Int) = zero!(dense_matrix_type(R)(R, undef, r, c))
 
 zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int) = zero_matrix(R, n, m)
 
@@ -6750,11 +6741,9 @@ zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int) = zero_matrix(R, n, m)
 Return the $r \times c$ ones matrix over $R$.
 """
 function ones_matrix(R::NCRing, r::Int, c::Int)
-   z = zero_matrix(R, r, c)
-   for i in 1:r
-      for j in 1:c
-         z[i, j] = one(R)
-      end
+   z = dense_matrix_type(R)(R, undef, r, c)
+   for i in 1:r, j in 1:c
+      z[i, j] = one(R)
    end
    return z
 end

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -93,7 +93,7 @@ function (s::MatSpace{T})(a::MatrixElem{T}) where {T <: NCRingElement}
   _check_dim(nrows(s), ncols(s), a)
   base_ring(s) == base_ring(a) || throw(DomainError((s, a), "Base rings do not match."))
   a isa eltype(s) && return a
-  return matrix(base_ring(a), b)
+  return matrix(base_ring(s), a)
 end
 
 # create a matrix with b on the diagonal
@@ -6630,8 +6630,8 @@ end
 
 function matrix(R::NCRing, arr::MatRingElem)
    M = zero_matrix(R, nrows(arr), ncols(arr))
-   for i in 1:nrows(s), j in 1:ncols(s)
-      M[i, j] = a[i, j]
+   for i in 1:nrows(arr), j in 1:ncols(arr)
+      M[i, j] = arr[i, j]
    end
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -107,16 +107,9 @@ function (s::MatSpace)(b::NCRingElement)
   return diagonal_matrix(R(b), nrows(s), ncols(s))
 end
 
-# convert a Julia matrix
-function (a::MatSpace{T})(b::AbstractMatrix{S}) where {T <: NCRingElement, S}
-  _check_dim(nrows(a), ncols(a), b)
-  return matrix(base_ring(a), b)
-end
-
-# convert a Julia vector
-function (a::MatSpace{T})(b::AbstractVector) where T <: NCRingElement
-  _check_dim(nrows(a), ncols(a), b)
-  return a(transpose(reshape(b, a.ncols, a.nrows)))
+# convert a Julia matrix or vector
+function (a::MatSpace{T})(b::AbstractVecOrMat) where T <: NCRingElement
+  return matrix(base_ring(a), nrows(a), ncols(a), b)
 end
 
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6633,6 +6633,7 @@ function matrix(R::NCRing, arr::MatRingElem)
    for i in 1:nrows(arr), j in 1:ncols(arr)
       M[i, j] = arr[i, j]
    end
+   return M
 end
 
 function matrix(mat::MatrixElem{T}) where {T<:NCRingElement}

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -25,6 +25,10 @@ parent(a::MatElem) = matrix_space(base_ring(a), nrows(a), ncols(a))
 
 Return the type of matrices with coefficients of type `T` respectively
 `elem_type(S)`.
+
+Implementations of the ring interface only need to provide a method
+for the argument a subtype of `NCRingElement`; the other variants are
+implemented by calling that method.
 """
 dense_matrix_type(::T) where T <: NCRing = dense_matrix_type(elem_type(T))
 dense_matrix_type(::T) where T <: NCRingElement = dense_matrix_type(T)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -73,11 +73,13 @@ struct F2Matrix <: AbstractAlgebra.MatElem{F2Elem}
    m::Generic.MatSpaceElem{F2Elem}
 end
 
+F2Matrix(::F2, ::UndefInitializer, r::Int, c::Int) = F2Matrix(Generic.MatSpaceElem{F2Elem}(F2(), undef, r, c))
+
 AbstractAlgebra.elem_type(::Type{F2MatSpace}) = F2Matrix
 AbstractAlgebra.parent_type(::Type{F2Matrix}) = F2MatSpace
 
 AbstractAlgebra.base_ring(::F2MatSpace) = F2()
-AbstractAlgebra.dense_matrix_type(::Type{F2}) = F2Matrix
+AbstractAlgebra.dense_matrix_type(::Type{F2Elem}) = F2Matrix
 AbstractAlgebra.matrix_space(::F2, r::Int, c::Int) = F2MatSpace(F2(), r, c)
 
 AbstractAlgebra.number_of_rows(a::F2Matrix) = nrows(a.m)


### PR DESCRIPTION
This is incompatible with older Nemo versions which did not provide `UndefInitializer` constructors for their matrices. Thus I've added the "breaking" label.

<s>Note quite done yet, I'd like to convert more places to use the `undef` constructors.</s> Should be OK to review now.