### PR TITLE
Add implication: integral domains are not trivial

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -194,8 +194,7 @@ Test whether the ring $R$ is trivial. A ring is trivial if it consists
 of a single element, or equivalently if its characteristic is 1. Such
 rings are also called zero rings.
 """
-is_trivial(F::NCRing) = iszero(one(F))
-is_trivial(F::Field) = false
+is_trivial(R::NCRing) = !is_domain_type(elem_type(R)) && iszero(one(R))
 
 @doc raw"""
     is_perfect(F::Field)


### PR DESCRIPTION
This way e.g. 'is_trivial(ZZ)' is compiled into 'reutrn false'.

If we also add a few more dedicated `is_trivial` methods for e.g. some quotient ring implementations, we may even be able to get by without caching this value anywhere?