### PR TITLE
Use Random.default_rng() instead of Random.GLOBAL_RNG

### DIFF
--- a/docs/src/rand.md
+++ b/docs/src/rand.md
@@ -29,7 +29,7 @@ julia> using RandomExtensions
 julia> S, x = polynomial_ring(ZZ, :x)
 (Univariate Polynomial Ring in x over Integers, x)
 
-julia> rand(Random.GLOBAL_RNG, make(S, 1:3, -10:10))
+julia> rand(Random.default_rng(), make(S, 1:3, -10:10))
 -5*x + 4
 ```
 
@@ -119,7 +119,7 @@ having to create make instances.
 rand(rng::AbstractRNG, S::PolyRing, deg_range::AbstractUnitRange{Int}, v...) =
    rand(rng, make(S, deg_range, v...))
 
-rand(S::PolyRing, degs, v...) = rand(Random.GLOBAL_RNG, S, degs, v...)
+rand(S::PolyRing, degs, v...) = rand(Random.default_rng(), S, degs, v...)
 ```
 
 To test whether a random generator is working properly, the `test_rand` function

--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -958,7 +958,7 @@ rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{ConstPoly,ConstPolyRing}}) =
 
 rand(rng::AbstractRNG, R::ConstPolyRing, n::AbstractUnitRange{Int}) = R(rand(rng, n))
 
-rand(R::ConstPolyRing, n::AbstractUnitRange{Int}) = rand(Random.GLOBAL_RNG, R, n)
+rand(R::ConstPolyRing, n::AbstractUnitRange{Int}) = rand(Random.default_rng(), R, n)
 
 # Promotion rules
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1339,7 +1339,7 @@ end
 #
 ###############################################################################
 
-function rand_ordering(rng::AbstractRNG=Random.GLOBAL_RNG)
+function rand_ordering(rng::AbstractRNG=Random.default_rng())
    i = rand(rng, 1:3)
    if i == 1
       return :lex

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -339,13 +339,13 @@ end
 
 rand(rng::AbstractRNG, S::MatRing, v...) = rand(rng, make(S, v...))
 
-rand(S::MatRing, v...) = rand(Random.GLOBAL_RNG, S, v...)
+rand(S::MatRing, v...) = rand(Random.default_rng(), S, v...)
 
 # resolve ambiguities
 rand(rng::AbstractRNG, S::MatRing, dims::Integer...) =
    rand(rng, make(S), dims...)
 
-rand(S::MatRing, dims::Integer...) = rand(Random.GLOBAL_RNG, S, dims...)
+rand(S::MatRing, dims::Integer...) = rand(Random.default_rng(), S, dims...)
 
 function randmat_triu(rng::AbstractRNG, S::MatRing, v...)
    M = S()
@@ -365,7 +365,7 @@ function randmat_triu(rng::AbstractRNG, S::MatRing, v...)
    return M
 end
 
-randmat_triu(S::MatRing, v...) = randmat_triu(Random.GLOBAL_RNG, S, v...)
+randmat_triu(S::MatRing, v...) = randmat_triu(Random.default_rng(), S, v...)
 
 function randmat_with_rank(rng::AbstractRNG, S::MatRing{T}, rank::Int, v...) where {T <: RingElement}
    M = S()
@@ -403,7 +403,7 @@ function randmat_with_rank(rng::AbstractRNG, S::MatRing{T}, rank::Int, v...) whe
 end
 
 randmat_with_rank(S::MatRing{T}, rank::Int, v...) where {T <: RingElement} =
-   randmat_with_rank(Random.GLOBAL_RNG, S, rank, v...)
+   randmat_with_rank(Random.default_rng(), S, rank, v...)
 
 ###############################################################################
 #

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6561,13 +6561,13 @@ end
 
 rand(rng::AbstractRNG, S::MatSpace, v...) = rand(rng, make(S, v...))
 
-rand(S::MatSpace, v...) = rand(Random.GLOBAL_RNG, S, v...)
+rand(S::MatSpace, v...) = rand(Random.default_rng(), S, v...)
 
 # resolve ambiguities
 rand(rng::AbstractRNG, S::MatSpace, dims::Integer...) =
    rand(rng, make(S), dims...)
 
-rand(S::MatSpace, dims::Integer...) = rand(Random.GLOBAL_RNG, S, dims...)
+rand(S::MatSpace, dims::Integer...) = rand(Random.default_rng(), S, dims...)
 
 function randmat_triu(rng::AbstractRNG, S::MatSpace, v...)
    M = S()
@@ -6586,7 +6586,7 @@ function randmat_triu(rng::AbstractRNG, S::MatSpace, v...)
    return M
 end
 
-randmat_triu(S::MatSpace, v...) = randmat_triu(Random.GLOBAL_RNG, S, v...)
+randmat_triu(S::MatSpace, v...) = randmat_triu(Random.default_rng(), S, v...)
 
 function randmat_with_rank(rng::AbstractRNG, S::MatSpace{T}, rank::Int, v...) where {T <: RingElement}
    if !is_domain_type(T) && !(T <: ResElem)
@@ -6627,7 +6627,7 @@ function randmat_with_rank(rng::AbstractRNG, S::MatSpace{T}, rank::Int, v...) wh
 end
 
 randmat_with_rank(S::MatSpace{T}, rank::Int, v...) where {T <: RingElement} =
-   randmat_with_rank(Random.GLOBAL_RNG, S, rank, v...)
+   randmat_with_rank(Random.default_rng(), S, rank, v...)
 
 ################################################################################
 #

--- a/src/Module.jl
+++ b/src/Module.jl
@@ -312,7 +312,7 @@ function rand(rng::AbstractRNG, M::FPModule{T}, vals...) where T <: RingElement
    rand(rng, make(M, vals...))
 end
 
-rand(M::FPModule, vals...) = rand(Random.GLOBAL_RNG, M, vals...)
+rand(M::FPModule, vals...) = rand(Random.default_rng(), M, vals...)
 
 ###############################################################################
 #

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -724,7 +724,7 @@ end
 rand(rng::AbstractRNG, S::NCPolyRing, deg_range::AbstractUnitRange{Int}, v...) =
    rand(rng, make(S, deg_range, v...))
 
-rand(S::NCPolyRing, deg_range, v...) = rand(Random.GLOBAL_RNG, S, deg_range, v...)
+rand(S::NCPolyRing, deg_range, v...) = rand(Random.default_rng(), S, deg_range, v...)
 
 
 ###############################################################################

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3351,7 +3351,7 @@ rand(rng::AbstractRNG, S::PolyRing, deg_range::AbstractUnitRange{Int}, v...) =
 rand(rng::AbstractRNG, S::PolyRing, deg::Int, v...) =
    rand(rng, make(S, deg, v...))
 
-rand(S::PolyRing, degs, v...) = rand(Random.GLOBAL_RNG, S, degs, v...)
+rand(S::PolyRing, degs, v...) = rand(Random.default_rng(), S, degs, v...)
 
 ###############################################################################
 #

--- a/src/RelSeries.jl
+++ b/src/RelSeries.jl
@@ -1451,7 +1451,7 @@ end
 rand(rng::AbstractRNG, S::SeriesRing, val_range::AbstractUnitRange{Int}, v...) =
    rand(rng, make(S, val_range, v...))
 
-rand(S::SeriesRing, val_range, v...) = rand(Random.GLOBAL_RNG, S, val_range, v...)
+rand(S::SeriesRing, val_range, v...) = rand(Random.default_rng(), S, val_range, v...)
 
 ###############################################################################
 #

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -432,7 +432,7 @@ end
 
 rand(rng::AbstractRNG, S::ResidueRing, v...) = rand(rng, make(S, v...))
 
-rand(S::ResidueRing, v...) = rand(Random.GLOBAL_RNG, S, v...)
+rand(S::ResidueRing, v...) = rand(Random.default_rng(), S, v...)
 
 ###############################################################################
 #

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -473,7 +473,7 @@ end
 
 rand(rng::AbstractRNG, S::ResidueField, v...) = rand(rng, make(S, v...))
 
-rand(S::ResidueField, v...) = rand(Random.GLOBAL_RNG, S, v...)
+rand(S::ResidueField, v...) = rand(Random.default_rng(), S, v...)
 
 ###############################################################################
 #

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -1223,7 +1223,7 @@ end
 
 rand(rng::AbstractRNG, K::FunctionField, v...) = rand(rng, make(K, v...))
 
-rand(K::FunctionField, v...) = rand(Random.GLOBAL_RNG, K, v...)
+rand(K::FunctionField, v...) = rand(Random.default_rng(), K, v...)
 
 ###############################################################################
 #

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -727,7 +727,7 @@ rand(rng::AbstractRNG, S::PuiseuxSeriesRingOrField, val_range::AbstractUnitRange
         rand(rng, make(S, val_range, scale_range, v...))
 
 rand(S::PuiseuxSeriesRingOrField, val_range, scale_range, v...) =
-   rand(Random.GLOBAL_RNG, S, val_range, scale_range, v...)
+   rand(Random.default_rng(), S, val_range, scale_range, v...)
 
 
 ###############################################################################

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -188,7 +188,7 @@ end
 
 rand(rng::AbstractRNG, R::Floats, n::AbstractUnitRange) = rand(rng, make(R, n))
 
-rand(R::Floats, n) = rand(Random.GLOBAL_RNG, R, n)
+rand(R::Floats, n) = rand(Random.default_rng(), R, n)
 
 ###############################################################################
 #

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -571,7 +571,7 @@ rand(rng::AbstractRNG,
 
 rand(rng::AbstractRNG, R::Integers, n) = R(rand(rng, n))
 
-rand(R::Integers, n) = rand(Random.GLOBAL_RNG, R, n)
+rand(R::Integers, n) = rand(Random.default_rng(), R, n)
 
 ###############################################################################
 #

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -220,7 +220,7 @@ end
 
 rand(rng::AbstractRNG, R::Rationals, n) = rand(rng, make(R, n))
 
-rand(R::Rationals, n) = rand(Random.GLOBAL_RNG, R, n)
+rand(R::Rationals, n) = rand(Random.default_rng(), R, n)
 
 ###############################################################################
 #


### PR DESCRIPTION
Julia has this to say about `GLOBAL_RNG`:

> defined only for backward compatibility with pre-v1.3 code when
> `default_rng()` didn't exist; `GLOBAL_RNG` was never really
> documented, but was appearing in the docstring of `rand`