### PR TITLE
Add generic `is_trivial` method for `ResidueRing`

### DIFF
--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -64,6 +64,8 @@ function modulus(r::ResElem)
    return modulus(parent(r))
 end
 
+is_trivial(S::ResidueRing) = is_unit(modulus(S))
+
 data(a::ResElem) = a.data
 
 lift(a::ResElem) = data(a)

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -113,6 +113,17 @@ end
    @test !(y in keys(Dict(x => 1)))
 end
 
+@testset "EuclideanRingResidueRingElem.is_trivial" begin
+   R, = Generic.residue_ring(ZZ, 49)
+   @test !is_trivial(R)
+
+   R, = Generic.residue_ring(ZZ, 1)
+   @test is_trivial(R)
+
+   R, = Generic.residue_ring(ZZ, -1)
+   @test is_trivial(R)
+end
+
 @testset "EuclideanRingResidueRingElem.rand" begin
    R, = Generic.residue_ring(ZZ, 49)
 


### PR DESCRIPTION
Note that this does not render the new `is_trivial` methods for `ZZModRing` and `zzModRing` obsolete because they are not subtypes of `ResidueRing`, see https://github.com/Nemocas/Nemo.jl/pull/1819