### PR TITLE
Enable `factor(::Rational)`

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -38,7 +38,7 @@ function gcdx(x::T, y::T) where {T <: FieldElem}
    end
 end
 
-function factor(x::FieldElem)
+function factor(x::FieldElement)
   @req !is_zero(x) "Element must be non-zero"
   return Fac(x, Dict{typeof(x), Int}())
 end

--- a/src/generic/Misc/Poly.jl
+++ b/src/generic/Misc/Poly.jl
@@ -28,7 +28,7 @@ function factor(R::Field, f::PolyRingElem)
     return factor(f1)
 end
 
-function factor(R::Ring, f::FracElem)
+function factor(R::Ring, f::Union{FracElem, Rational})
     fn = factor(R(numerator(f)))
     fd = factor(R(denominator(f)))
     fn.unit = divexact(fn.unit, fd.unit)

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -398,4 +398,11 @@ end
    @test length(f) == 0
    @test unit(f) == a
    @test_throws ArgumentError factor(zero(F))
+
+   F = QQ
+   a = 28//15
+   f = factor(a)
+   @test length(f) == 0
+   @test unit(f) == a
+   @test_throws ArgumentError factor(zero(F))
 end


### PR DESCRIPTION
Also enables `factor(ZZ, 28//15)` in Nemo, Hecke, Oscar. Alas, no tests for this here as we have no `factor` methods for any integer types here in AA.

Fixes https://github.com/thofma/Hecke.jl/issues/1110