### PR TITLE
Add generic dispatch for `ideal_type`

### DIFF
--- a/src/Ideal.jl
+++ b/src/Ideal.jl
@@ -41,3 +41,7 @@ end
 iszero(I::Ideal) = all(iszero, gens(I))
 
 base_ring_type(::Type{<:IdealSet{T}}) where T <: RingElement = parent_type(T)
+
+# fundamental interface, to be documented
+ideal_type(x) = ideal_type(typeof(x))
+ideal_type(T::DataType) = throw(MethodError(ideal_type, (T,)))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -260,6 +260,7 @@ export hooklength
 export howell_form
 export howell_form_with_transformation
 export ideal
+export ideal_type
 export identity_map
 export identity_matrix
 export image


### PR DESCRIPTION
Probably breaking because Hecke already declares this.

There should be more code and docstrings added, but since we are close to a breaking release I thought it would be sensible to get this tiny breaking bit in now, and worry about the rest later.
