### PR TITLE
swap_cols and swap_rows for Julia matrices

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6060,7 +6060,7 @@ end
 
 ###############################################################################
 #
-#   Row swapping
+#   Row & column permutations
 #
 ###############################################################################
 
@@ -6120,12 +6120,9 @@ julia> M  # was modified
 ```
 """
 function swap_rows!(a::MatrixElem{T}, i::Int, j::Int) where T <: NCRingElement
-   (1 <= i <= nrows(a) && 1 <= j <= nrows(a)) || throw(BoundsError())
    if i != j
       for k = 1:ncols(a)
-         x = a[i, k]
-         a[i, k] = a[j, k]
-         a[j, k] = x
+         a[i, k], a[j, k] = a[j, k], a[i, k]
       end
    end
    return a
@@ -6153,9 +6150,7 @@ matrix (since matrices are assumed to be mutable in AbstractAlgebra.jl).
 function swap_cols!(a::MatrixElem{T}, i::Int, j::Int) where T <: NCRingElement
    if i != j
       for k = 1:nrows(a)
-         x = a[k, i]
-         a[k, i] = a[k, j]
-         a[k, j] = x
+         a[k, i], a[k, j] = a[k, j], a[k, i]
       end
    end
    return a

--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -79,3 +79,41 @@ function zeros(R::NCRing, r::Int...)
    end
    return A
 end
+
+###############################################################################
+#
+#   Row & column permutations
+#
+###############################################################################
+
+function swap_rows(a::Matrix{T}, i::Int, j::Int) where T <: NCRingElement
+   (1 <= i <= nrows(a) && 1 <= j <= nrows(a)) || throw(BoundsError())
+   b = deepcopy(a)
+   swap_rows!(b, i, j)
+   return b
+end
+
+function swap_rows!(a::Matrix{T}, i::Int, j::Int) where T <: NCRingElement
+   if i != j
+      for k = 1:ncols(a)
+         a[i, k], a[j, k] = a[j, k], a[i, k]
+      end
+   end
+   return a
+end
+
+function swap_cols(a::Matrix{T}, i::Int, j::Int) where T <: NCRingElement
+   (1 <= i <= ncols(a) && 1 <= j <= ncols(a)) || throw(BoundsError())
+   b = deepcopy(a)
+   swap_cols!(b, i, j)
+   return b
+end
+
+function swap_cols!(a::Matrix{T}, i::Int, j::Int) where T <: NCRingElement
+   if i != j
+      for k = 1:nrows(a)
+         a[k, i], a[k, j] = a[k, i], a[k, j]
+      end
+   end
+   return a
+end

--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -811,6 +811,24 @@ function test_MatSpace_interface(S::MatSpace; reps = 20)
             @test a == A
          end
       end
+
+      @testset "Row & column permutations" begin
+          a = matrix(R, [1 2 ; 3 4])
+          b = swap_rows(a, 1, 2)
+          @test b == matrix(R, [3 4 ; 1 2])
+          @test a == matrix(R, [1 2 ; 3 4])
+
+          a = matrix(R, [1 2 ; 3 4])
+          b = swap_cols(a, 1, 2)
+          @test b == matrix(R, [2 1 ; 4 3])
+          @test a == matrix(R, [1 2 ; 3 4])
+
+          # TODO: reverse_rows, reverse_cols
+          # TODO: add_column, add_row
+          # TODO: multiply_column, multiply_row
+          # TODO: ! variants (such as `swap_cols!` etc.) of all of the above
+      end
+
    end
 
    return nothing


### PR DESCRIPTION
Also remove a bounds check in `swap_rows!` for MatrixElem, to match `swap_cols!`. This follows our general principle that `!` methods don't perform such tests, it is up to the caller to ensure such preconditions are satisfied.

Also test these functions as part of the ring conformance tests

Resolves #1730