### PR TITLE
Make is_exact_type and is_domain_type more convenient

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -95,11 +95,27 @@ end
 
 # Type can only represent elements of an exact ring
 # true unless explicitly specified
+#
+# implementors should only implement this trait for RingElem subtypes, but for
+# convenience we support calling this also on Ring subtypes as well as Ring
+# and RingElem instances
 is_exact_type(R::Type{T}) where T <: RingElem = true
 
-# Type can only represent elements of domains
+is_exact_type(x) = is_exact_type(typeof(x))
+is_exact_type(x::Type{<:Ring}) = is_exact_type(elem_type(x))
+is_exact_type(T::DataType) = throw(MethodError(is_exact_type, (T,)))
+
+# Type can only represent elements of domains, i.e. without zero divisors
 # false unless explicitly specified
+#
+# implementors should only implement this trait for RingElem subtypes, but for
+# convenience we support calling this also on Ring subtypes as well as Ring
+# and RingElem instances
 is_domain_type(R::Type{T}) where T <: RingElem = false
+
+is_domain_type(x) = is_domain_type(typeof(x))
+is_domain_type(x::Type{<:Ring}) = is_domain_type(elem_type(x))
+is_domain_type(T::DataType) = throw(MethodError(is_domain_type, (T,)))
 
 ###############################################################################
 #


### PR DESCRIPTION
For examples, this now works:

    julia> is_domain_type(ZZ)
    true

    julia> is_domain_type(ZZ(2))
    true

    julia> is_domain_type(residue_ring(ZZ,6)[1])
    false
