### PR TITLE
Add is_euclidean_type trait

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -6,6 +6,8 @@
 
 is_domain_type(::Type{T}) where {T <: FieldElem} = true
 
+is_euclidean_type(::Type{T}) where {T <: FieldElem} = true
+
 is_zero_divisor(a::T) where T <: FieldElem = is_zero(a)
 
 is_unit(a::FieldElem) = !iszero(a)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -16,13 +16,12 @@ coefficient_ring(R::PolyRing) = base_ring(R)
 
 dense_poly_type(::Type{T}) where T<:RingElement = Generic.Poly{T}
 
-function is_domain_type(::Type{T}) where {S <: RingElement, T <: PolyRingElem{S}}
-   return is_domain_type(S)
-end
+is_exact_type(::Type{<:PolyRingElem{T}}) where {T <: RingElement} = is_exact_type(T)
 
-function is_exact_type(a::Type{T}) where {S <: RingElement, T <: PolyRingElem{S}}
-   return is_exact_type(S)
-end
+is_domain_type(::Type{<:PolyRingElem{T}}) where {T <: RingElement} = is_domain_type(T)
+
+is_euclidean_type(::Type{<:PolyRingElem{T}}) where {T <: RingElem} = T <: FieldElem
+# TODO: what about polynomials over `Rational{BigInt}`?
 
 @doc raw"""
     var(a::PolyRing)

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -95,11 +95,27 @@ end
 
 # Type can only represent elements of an exact ring
 # true unless explicitly specified
+#
+# implementors should only implement this trait for RingElem subtypes, but for
+# convenience we support calling this also on Ring subtypes as well as Ring
+# and RingElem instances
 is_exact_type(R::Type{T}) where T <: RingElem = true
 
-# Type can only represent elements of domains
+is_exact_type(x) = is_exact_type(typeof(x))
+is_exact_type(x::Type{<:Ring}) = is_exact_type(elem_type(x))
+is_exact_type(T::DataType) = throw(MethodError(is_exact_type, (T,)))
+
+# Type can only represent elements of domains, i.e. without zero divisors
 # false unless explicitly specified
+#
+# implementors should only implement this trait for RingElem subtypes, but for
+# convenience we support calling this also on Ring subtypes as well as Ring
+# and RingElem instances
 is_domain_type(R::Type{T}) where T <: RingElem = false
+
+is_domain_type(x) = is_domain_type(typeof(x))
+is_domain_type(x::Type{<:Ring}) = is_domain_type(elem_type(x))
+is_domain_type(T::DataType) = throw(MethodError(is_domain_type, (T,)))
 
 ###############################################################################
 #

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -117,6 +117,19 @@ is_domain_type(x) = is_domain_type(typeof(x))
 is_domain_type(x::Type{<:Ring}) = is_domain_type(elem_type(x))
 is_domain_type(T::DataType) = throw(MethodError(is_domain_type, (T,)))
 
+# Type can only represent elements of euclidean rings (which do not need to be domains)
+# false unless explicitly specified
+#
+# implementors should only implement this trait for RingElem subtypes, but for
+# convenience we support calling this also on Ring subtypes as well as Ring
+# and RingElem instances
+is_euclidean_type(R::Type{T}) where T <: RingElem = false
+
+is_euclidean_type(x) = is_euclidean_type(typeof(x))
+is_euclidean_type(x::Type{<:Ring}) = is_euclidean_type(elem_type(x))
+is_euclidean_type(T::DataType) = throw(MethodError(is_euclidean_type, (T,)))
+
+
 ###############################################################################
 #
 #   Exponential function for generic rings


### PR DESCRIPTION
The idea is that this true for ring / ring elem types that explicitly support a euclidean division with remainder, and ideally also a euclidean degree (to be defined in the interface). This is just a draft to have a point for discussion and experiments: it is missing many things, including documentation as to what is_euclidean_type(x)==true means, which promises this incurs; and of course also code needs to be adapted to use it (e.g. the residue ring or ideal constructions or whatnot that only work sensible for euclidean rings should check this.

Most recent motivation for this is https://github.com/oscar-system/Oscar.jl/issues/4410 but there are many others.

Note that this is explicitly different from the *mathematical* property. I'd be happy to also add a function `is_euclidean_ring` resp. `is_euclidean(::Ring)` for the mathematical property, if someone wants it, but that's a separate thing.


Anyway, with that out of the way: let's get started with the flaming and bikeshedding :-)


(Includes PR #1942 for my convenience)