### PR TITLE
Don't require base_ring in ring conformance tests

### DIFF
--- a/test/Rings-conformance-tests.jl
+++ b/test/Rings-conformance-tests.jl
@@ -284,10 +284,13 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
          @test is_domain_type(T) isa Bool
          @test is_exact_type(T) isa Bool
 
-         @test base_ring_type(R) == typeof(base_ring(R))
-         @test base_ring_type(zero(R)) == typeof(base_ring(zero(R)))
-         @test base_ring_type(typeof(R)) == typeof(base_ring(R))
-         @test base_ring_type(T) == typeof(base_ring(zero(R)))
+         # if the ring supports base_ring, verify it also supports base_ring_type and is consistent
+         if applicable(base_ring, R)
+           @test base_ring_type(R) == typeof(base_ring(R))
+           @test base_ring_type(zero(R)) == typeof(base_ring(zero(R)))
+           @test base_ring_type(typeof(R)) == typeof(base_ring(R))
+           @test base_ring_type(T) == typeof(base_ring(zero(R)))
+        end
 
          # some rings don't support characteristic and raise an exception (see issue #993)
          try ch = characteristic(R)


### PR DESCRIPTION
Not all rings provide this, nor should they have to. But *if* a ring provides it, it should be compatible with `base_ring_type`.

Resolves #1944