### PR TITLE
refactor: evaluate/subst for univariate polynomials

### DIFF
--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -764,7 +764,7 @@ p = primpart(k*(x^2 + 1))
 ### Evaluation, composition and substitution
 
 ```@docs
-evaluate(::PolyRingElem, b::T) where T <: RingElement
+evaluate(::PolyRingElem, b)
 ```
 
 ```@docs

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -2219,16 +2219,20 @@ function evaluate_brent_kung(f::PolyRingElem{T}, a::U) where {T <: RingElement, 
    for j = 1:min(n - d1*d, d - 1)
       c = coeff(f, d1*d + j)
       if !iszero(c)
-         s = addmul!(s, c, A[j + 1])
+         s = s + c * A[j + 1]
+         # s = addmul!(s, c, A[j + 1])
       end
    end
    for i = 1:d1
-      s = mul!(s, s, A[d + 1])
-      s = addmul!(s, coeff(f, (d1 - i)*d), A[1])
+      s = s * A[d + 1]
+      # s = mul!(s, s, A[d + 1])
+      s = s + coeff(f, (d1 - i)*d) * A[1]
+      # s = addmul!(s, coeff(f, (d1 - i)*d), A[1])
       for j = 1:min(n - (d1 - i)*d, d - 1)
          c = coeff(f, (d1 - i)*d + j)
          if !iszero(c)
-            s = addmul!(s, c, A[j + 1])
+            s = s + c * A[j + 1]
+            # s = addmul!(s, c, A[j + 1])
          end
       end
    end


### PR DESCRIPTION
- rename `subst` to `evaluate_brent_kung` and add a hard alias
  for backwards compatibility
- introduce `evaluate_horner`
- use in-place operations where possible

(Ideally we can phase out `subst`.)