### PR TITLE
Replace uses of elem_type(coefficient_ring(R))

### DIFF
--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -126,7 +126,7 @@ end
 function is_unit(a::FreeAssociativeAlgebraElem{T}) where T
    if is_constant(a)
       return is_unit(leading_coefficient(a))
-   elseif is_domain_type(elem_type(coefficient_ring(a)))
+   elseif is_domain_type(T)
       return false
    elseif length(a) == 1
       return false

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1185,10 +1185,10 @@ end
 Return the coefficients of p, which is assumed to be univariate,
 as an array in ascending order.
 """
-function coefficients_of_univariate(p::MPolyRingElem,
-                                    check_univariate::Bool=true)
-
-   coeffs = Vector{elem_type(coefficient_ring(p))}(undef, 0)
+function coefficients_of_univariate(p::MPolyRingElem{T},
+                                    check_univariate::Bool=true) where T
+   R = coefficient_ring(p)
+   coeffs = Vector{T}(undef, 0)
    var_index = -1
    for (c, v) in zip(coefficients(p), exponent_vectors(p))
       e = 0
@@ -1205,7 +1205,7 @@ function coefficients_of_univariate(p::MPolyRingElem,
       end
 
       while length(coeffs) <= e
-         push!(coeffs, zero(coefficient_ring(p)))
+         push!(coeffs, zero(R))
       end
       coeffs[1 + e] = c
 

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -546,8 +546,7 @@ mutable struct LaurentMPolyBuildCtx{T, S}
     parent::S
 end
 
-function MPolyBuildCtx(R::AbstractAlgebra.LaurentMPolyRing)
-    T = elem_type(coefficient_ring(R))
+function MPolyBuildCtx(R::AbstractAlgebra.LaurentMPolyRing{T}) where T
     return LaurentMPolyBuildCtx{T, typeof(R)}(T[], Vector{Int}[], R)
 end
 

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -327,8 +327,7 @@ mutable struct PolyBuildCtx{T, S}
 end
 
 # TODO the MPolyBuildCtx function should be renamed BuildCtx
-function MPolyBuildCtx(R::AbstractAlgebra.PolyRing)
-   T = elem_type(coefficient_ring(R))
+function MPolyBuildCtx(R::AbstractAlgebra.PolyRing{T}) where T
    S = typeof(R)
    return PolyBuildCtx{T, S}(T[], R)
 end


### PR DESCRIPTION
... by equivalent compile-time constructs
