### PR TITLE
Change `getindex` for `Fac` to never throw an error

### DIFF
--- a/src/Factor.jl
+++ b/src/Factor.jl
@@ -79,16 +79,9 @@ end
     getindex(a::Fac, b) -> Int
 
 If $b$ is a factor of $a$, the corresponding exponent is returned. Otherwise
-an error is thrown.
+return zero.
 """
-function getindex(a::Fac{T}, b) where {T}
-  b = convert(T, b)
-  if haskey(a.fac, b)
-    return a.fac[b]
-  else
-    error("$b is not a factor of $a")
-  end
-end
+getindex(a::Fac, b) = get(a.fac, b, 0)
 
 @doc raw"""
     setindex!(a::Fac{T}, c::Int, b::T)

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -397,6 +397,7 @@ end
    f = factor(a)
    @test length(f) == 0
    @test unit(f) == a
+   @test f[2] == 0
    @test_throws ArgumentError factor(zero(F))
 
    F = QQ
@@ -404,5 +405,6 @@ end
    f = factor(a)
    @test length(f) == 0
    @test unit(f) == a
+   @test f[2] == 0
    @test_throws ArgumentError factor(zero(F))
 end


### PR DESCRIPTION
For a `Fac` object `f`, we allow using `f[p]` to get the exponent for the "prime" `p`. But if `p` is not in the list of factors, then so far an error is thrown. With this patch we instead return 0. This is useful in practice and arguably not very surprising (i.e., "5 divides 12 exactly 0 times" is correct). Also shouldn't be breaking as I don't think code should be relying on this throwing an exception.

Before:

    julia> f = factor(ZZ(12))
    1 * 2^2 * 3

    julia> f[5]
    ERROR: 5 is not a factor of 1 * 2^2 * 3

After:

    julia> f = factor(ZZ(12))
    1 * 2^2 * 3

    julia> f[5]
    0

