### PR TITLE
Bump version to 0.44.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.44.2"
+version = "0.44.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
In particular, this makes https://github.com/Nemocas/AbstractAlgebra.jl/pull/1946 and https://github.com/Nemocas/AbstractAlgebra.jl/pull/1958 available downstream (e.g. for https://github.com/thofma/Hecke.jl/pull/1707).

And I think it is a good idea to make an release before and one shortly after merging https://github.com/Nemocas/AbstractAlgebra.jl/pull/1954.