### PR TITLE
Remove `content(::PolyRingElem{<:FieldElem})` method which always returns 1, as this disagrees with the definition of `content` over some fields

### DIFF
--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1946,10 +1946,6 @@ function content(a::PolyRingElem)
    return z
 end
 
-function content(a::PolyRingElem{<:FieldElem})
-   return one(base_ring(a))
-end
-
 @doc raw"""
     primpart(a::PolyRingElem)
 


### PR DESCRIPTION
I have multiple issues with this method:
1. The zero polynomial is in all other cases in AA defined to have content 0. This method would set it to 1 instead.
2. We have fields, where the gcd is not defined as 1. E.g. for `QQFieldElem` in Nemo, see https://flintlib.org/doc/fmpq.html#c._fmpq_gcd
3. The same is true for the field `AbstractAlgebra.Rationals`, it also has a non-trivial gcd definition. (I did not check if it coincides with the one from fmpq, but that shouldn't be relevant here). But for technical reasons, polynomials over this field, don't even take this method but instead the generic one.

All in all, this seems to be more prone to confusion as it is useful. What are your opinions?