### PR TITLE
fix: docstring for divides promises too much

### DIFF
--- a/src/algorithms/GenericFunctions.jl
+++ b/src/algorithms/GenericFunctions.jl
@@ -146,7 +146,7 @@ end
 
 Return a pair, `flag, q`, where `flag` is set to `true` if $g$ divides $f$, in which
 case `q` is set to the quotient, or `flag` is set to `false` and `q`
-is set to `zero(f)`.
+is undefined.
 """
 function divides(a::T, b::T) where T <: RingElem
    check_parent(a, b)


### PR DESCRIPTION
As observed in https://github.com/oscar-system/Oscar.jl/pull/4497#discussion_r1928608529:
```
julia> divides(5, 2)
(false, 2)
```
CC: @joschmitt