### PR TITLE
Enable multivariate factorization in characteristic 0 (at least over coefficient rings for which univariate factorization is implemented)

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1341,6 +1341,28 @@ end
 
 ###############################################################################
 #
+#  Factorization
+#
+###############################################################################
+
+function factor_squarefree(f::MPolyRingElem{<: FieldElement})
+  if characteristic(coefficient_ring(f)) == 0
+    return MPolyFactor.mfactor_squarefree_char_zero(f)
+  else
+    throw(NotImplementedError(:factor_squarefree, f))
+  end
+end
+
+function factor(f::MPolyRingElem{<: FieldElement})
+  if characteristic(coefficient_ring(f)) == 0
+    return MPolyFactor.mfactor_char_zero(f)
+  else
+    throw(NotImplementedError(:factor, f))
+  end
+end
+
+###############################################################################
+#
 #   Parent object overload (with coercion)
 #
 ###############################################################################


### PR DESCRIPTION
It was already there, so we might as well use it. Cannot be tested, but enables things like this in Oscar:
```
julia> K = algebraic_closure(QQ)
Field of algebraic numbers

julia> Kx, (x, y) = K["x", "y"];

julia> factor(x^2*y^2 + 1)
1 * (x*y + Root -1.00000*im of x^2 + 1) * (x*y + Root 1.00000*im of x^2 + 1)

julia> factor_squarefree(x^2*y^2 + 1)
1 * (x^2*y^2 + 1)
```