### PR TITLE
Enabled poly ring caching in charpoly/minpoly (when no poly ring passed in)

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -4311,7 +4311,7 @@ end
 
 function charpoly(Y::MatrixElem)
    R = base_ring(Y)
-   Rx, x = polynomial_ring(R; cached=false)
+   Rx, x = polynomial_ring(R; cached=true)  # true: so that charpoly(M) == charpoly(M) works without triggering parent mismatch error
    return charpoly(Rx, Y)
 end
 
@@ -4561,7 +4561,7 @@ end
 
 function minpoly(M::MatElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
    R = base_ring(M)
-   Rx, x = polynomial_ring(R; cached=false)
+   Rx, x = polynomial_ring(R; cached=true)  # true: so that minpoly(M) == minpoly(M) works without triggering parent mismatch error
    return minpoly(Rx, M, charpoly_only)
 end
 


### PR DESCRIPTION
After discussion in triage meeting today: now `characteristic_polynomial(M) == characteristic_polynomial(M)` works, and similarly for `minpoly(M)`.  The automatically created polynomial ring is cached.  I also commented why caching is enabled.