### PR TITLE
Don't mention charpoly_only in docstrings

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -4428,8 +4428,8 @@ function minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) whe
 end
 
 @doc raw"""
-    minpoly(M::MatElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
-    minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
+    minpoly(M::MatElem{T}) where {T <: RingElement}
+    minpoly(S::PolyRing{T}, M::MatElem{T}) where {T <: RingElement}
 
 Return the minimal polynomial $p$ of the square matrix $M$.
 If a polynomial ring $S$ over the same base ring as $Y$ is supplied,

--- a/src/generic/MatRing.jl
+++ b/src/generic/MatRing.jl
@@ -72,7 +72,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    minpoly(S::Ring, M::MatRingElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
+    minpoly(S::Ring, M::MatRingElem{T}) where {T <: RingElement}
 
 Return the minimal polynomial $p$ of the matrix $M$. The polynomial ring $S$
 of the resulting polynomial must be supplied and the matrix must be square.


### PR DESCRIPTION
Actually I wonder if we need the `charpoly_only` option at all.
Is anyone using this? I found nothing.