### PR TITLE
Restructure `@varnames_interface` calls

### DIFF
--- a/src/AbsMSeries.jl
+++ b/src/AbsMSeries.jl
@@ -215,3 +215,7 @@ when it was created.
 function rand(S::MSeriesRing, term_range, v...)
    rand(Random.default_rng(), S, term_range, v...)
 end
+
+@varnames_interface Generic.power_series_ring(R::Ring, prec::Int, s)
+@varnames_interface Generic.power_series_ring(R::Ring, weights::Vector{Int}, prec::Int, s) macros=:no # use keyword `weights=...` instead
+@varnames_interface Generic.power_series_ring(R::Ring, prec::Vector{Int}, s) n=:no macros=:no # `n` variant would clash with line above; macro would be the same as for `prec::Int`    

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -187,6 +187,7 @@ include("ConcreteTypes.jl")
 ###############################################################################
 
 include("fundamental_interface.jl")
+include("misc/VarNames.jl")
 
 ################################################################################
 #
@@ -355,7 +356,6 @@ end
 
 include("misc/ProductIterator.jl")
 include("misc/Evaluate.jl")
-include("misc/VarNames.jl")
 
 ###############################################################################
 #

--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -294,6 +294,9 @@ function free_associative_algebra(
   return (parent_obj, gens(parent_obj))
 end
 
+@varnames_interface free_associative_algebra(R::Ring, s)
+
+
 free_associative_algebra_type(::Type{T}) where T<:RingElement = Generic.FreeAssociativeAlgebra{T}
 
 free_associative_algebra_type(::Type{S}) where S<:Ring = free_associative_algebra_type(elem_type(S))

--- a/src/LaurentMPoly.jl
+++ b/src/LaurentMPoly.jl
@@ -190,3 +190,5 @@ For information about the many ways to specify `varnames...` refer to [`polynomi
 specification in [`AbstractAlgebra.@varnames_interface`](@ref).
 """
 laurent_polynomial_ring(R::Ring, s::Vector{Symbol})
+
+@varnames_interface Generic.laurent_polynomial_ring(R::Ring, s)

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1484,6 +1484,8 @@ function polynomial_ring(R::Ring, s::Vector{Symbol}; kw...)
    (S, gens(S))
 end
 
+@varnames_interface polynomial_ring(R::Ring, s)
+
 """
     polynomial_ring(R::Ring, varnames...; cached=true, internal_ordering=:lex)
     polynomial_ring(R::Ring, varnames::Tuple; cached=true, internal_ordering=:lex)

--- a/src/RationalFunctionField.jl
+++ b/src/RationalFunctionField.jl
@@ -13,3 +13,5 @@
 function rational_function_field(k::Field, s::VarName; cached::Bool=true)
    return Generic.rational_function_field(k, Symbol(s); cached=cached)
 end
+
+@varnames_interface Generic.rational_function_field(K::Field, s)

--- a/src/misc/VarNames.jl
+++ b/src/misc/VarNames.jl
@@ -474,13 +474,3 @@ macro varnames_interface(e::Expr, options::Expr...)
         $(varnames_macro(d[:f], length(d[:argnames]), opts[:macros], opts[:n], opts[:range]))
     end
 end
-
-@varnames_interface free_associative_algebra(R::Ring, s)
-@varnames_interface Generic.laurent_polynomial_ring(R::Ring, s)
-@varnames_interface Generic.rational_function_field(K::Field, s)
-
-@varnames_interface Generic.power_series_ring(R::Ring, prec::Int, s)
-@varnames_interface Generic.power_series_ring(R::Ring, weights::Vector{Int}, prec::Int, s) macros=:no # use keyword `weights=...` instead
-@varnames_interface Generic.power_series_ring(R::Ring, prec::Vector{Int}, s) n=:no macros=:no # `n` variant would clash with line above; macro would be the same as for `prec::Int`
-
-@varnames_interface polynomial_ring(R::Ring, s)


### PR DESCRIPTION
Moves the `@varnames_interface` calls into the files of the type the call belongs to.
This loosens the restriction of inclusion order in `AbstractAlgebra.jl` as before it was not possible to use the macro inside of `Generic`.

This PR was extracted as part of https://github.com/Nemocas/AbstractAlgebra.jl/pull/1809.