### PR TITLE
Explicitely import `Base.Matrix`

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -39,6 +39,7 @@ import Base: >
 import Base: >=
 import Base: >>
 import Base: Array
+import Base: Matrix
 import Base: Rational
 import Base: ^
 import Base: abs


### PR DESCRIPTION
to silence the warnings introduced in https://github.com/JuliaLang/julia/pull/57311.