### PR TITLE
Add some `is_known` methods, use one in conformance tests

### DIFF
--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -48,6 +48,9 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 15)
             @test iszero(characteristic(R) * one(R))
             @test iszero(one(R) * characteristic(R))
          catch
+            # could not compute characteristic, so verify that is_known
+            # reflects this
+            @test is_known(characteristic, R) == false
          end
       end
 
@@ -300,6 +303,13 @@ function test_Field_interface(R::AbstractAlgebra.Field; reps = 15)
    @testset "Field interface for $(R) of type $(typeof(R))" begin
 
       test_Ring_interface(R, reps = reps)
+
+      # We implicitly assume all genuine fields (i.e. of type `Field`, not
+      # just rings that happen to be fields) know their characteristic. So
+      # test for that. We may relax this in the future if we have need for it.
+      # But for now if the next tests fail this usually means someone forgot
+      # to implement `characteristic` for their ring type properly.
+      @test is_known(characteristic, R) == true
 
       @test iszero(R(characteristic(R)))
       @test iszero(characteristic(R) * one(R))

--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -44,13 +44,14 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 15)
 
          # some rings don't support characteristic and raise an exception (see issue #993)
          try ch = characteristic(R)
+            @test AbstractAlgebra.is_known(characteristic, R)
             @test iszero(R(characteristic(R)))
             @test iszero(characteristic(R) * one(R))
             @test iszero(one(R) * characteristic(R))
          catch
             # could not compute characteristic, so verify that is_known
             # reflects this
-            @test is_known(characteristic, R) == false
+            @test AbstractAlgebra.is_known(characteristic, R) == false
          end
       end
 
@@ -309,7 +310,7 @@ function test_Field_interface(R::AbstractAlgebra.Field; reps = 15)
       # test for that. We may relax this in the future if we have need for it.
       # But for now if the next tests fail this usually means someone forgot
       # to implement `characteristic` for their ring type properly.
-      @test is_known(characteristic, R) == true
+      @test AbstractAlgebra.is_known(characteristic, R) == true
 
       @test iszero(R(characteristic(R)))
       @test iszero(characteristic(R) * one(R))

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -229,6 +229,13 @@ function characteristic(R::NCRing)
    error("Characteristic not known")
 end
 
+# All rings are supposed to implement characteristic if they can. If they
+# can not, or only can do it with an expensive computation (e.g. a Groebner
+# basis), then instead they should implement an `is_known` method indicating
+# this. To enforce this via the ring conformance tests, we add this default
+# method for `is_known(characteristic, ::NCRing)`
+is_known(::typeof(characteristic), ::NCRing) = true
+
 ###############################################################################
 #
 #   One and zero


### PR DESCRIPTION
- ~~**Implement is_known(characteristic, ::NCRing)**~~ (already merged)
- ~~**Implement is_known(is_perfect, ::Field)**~~ (already merged)
- **Implement is_known(is_finite, ::NCRing)**
- **Use is_known in conformance tests**
- **Add a fallback for is_known(characteristic, ::NCRing)**

This PR is my own experiment to see how much work it takes to make `is_known`
(and related functions like my `_implements` / `can_compute`) work. Turns out
quite a few methods need to be added here in AA, but luckily these then cover
many different ring implementations. Only further "leaf ring types" need to
provide further `is_known` methods.

One problem that remains is how to prevent people from adding a fast method
for `foobar` but then forgetting to add a matching `is_known(foobar, x)`
method. This can happen easily, and in fact it will be the case right now for
many rings in Nemo/Hecke/Oscar simply because they existed before we created
`is_known`.

We really want to avoid that because otherwise `is_known` becomes much less
useful. One way to tackle this would be by using the conformance tests to
enforce this to a level.

The final two commits in this PR try to do this for `characteristic`. But they
might be controversial, so please have a close look at them specifically.

