### PR TITLE
feat: improvements for function fields

### DIFF
--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -94,21 +94,35 @@ function (a::FracField{T})(b::T) where {T <: RingElement}
    return z
 end
 
-function (a::FracField{T})(b::T, c::T) where {T <: RingElement}
+function _reduce_fraction(x, y)
+   iszero(y) && throw(DivideError())
+   g = gcd(x, y)
+   return divexact(x, g), divexact(y, g)
+end
+
+function (a::FracField{T})(b::T, c::T; reduce::Bool = false) where {T <: RingElement}
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
+   if reduce
+     b, c = _reduce_fraction(b, c)
+   end
    z = FracFieldElem{T}(b, c)
    z.parent = a
    return z
 end
 
-function (a::FracField{T})(b::T, c::T) where {U <: FieldElem, T <: PolyRingElem{U}}
+function (a::FracField{T})(b::T, c::T; reduce::Bool = false) where {U <: FieldElem, T <: PolyRingElem{U}}
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
-   u = canonical_unit(c)
-   if !isone(u)
-      b = divexact(b, u)
-      c = divexact(c, u)
+
+   if reduce
+      b, c = _reduce_fraction(b, c)
+   else
+      u = canonical_unit(c)
+      if !isone(u)
+         b = divexact(b, u)
+         c = divexact(c, u)
+      end
    end
    z = FracFieldElem{T}(b, c)
    z.parent = a

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -675,7 +675,7 @@ end
 
 function factor_squarefree(f::Union{PolyRingElem{T}, MPolyRingElem{T}}) where {T <: RationalFunctionFieldElem}
   R = base_ring(f)
-  return _transport_factor(factor, f, data, R)
+  return _transport_factor(factor_squarefree, f, data, R)
 end
 
 function is_squarefree(f::Union{PolyRingElem{T}, MPolyRingElem{T}}) where {T <: RationalFunctionFieldElem}

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -515,7 +515,7 @@ function rand(rng::AbstractRNG,
    while iszero(d)
       d = rand(rng, v)
    end
-   return S(fraction_field(S)(n, d))
+   return S(fraction_field(S)(n, d; reduce = true))
 end
 
 rand(rng::AbstractRNG, S::RationalFunctionField, v...) =
@@ -649,4 +649,35 @@ function rational_function_field(k::Field, s::Vector{Symbol}; cached::Bool=true)
    end
 
    return par_object, t
+end
+
+################################################################################
+#
+#  Factoring
+#
+################################################################################
+
+function _transport_factor(factorfun::F, f, fwd::G, bwd::H) where {F, G, H}
+  R = parent(f)
+  g = map_coefficients(fwd, f; cached = false)
+  facg = factorfun(g)
+  D = Dict{typeof(f), Int}()
+  for (pg, e) in facg
+    D[map_coefficients(bwd, pg; parent = R)] = e
+  end
+  return Fac(map_coefficients(bwd, unit(facg); parent = R), D)
+end
+
+function factor(f::Union{PolyRingElem{T}, MPolyRingElem{T}}) where {T <: RationalFunctionFieldElem}
+  R = base_ring(f)
+  return _transport_factor(factor, f, data, R)
+end
+
+function factor_squarefree(f::Union{PolyRingElem{T}, MPolyRingElem{T}}) where {T <: RationalFunctionFieldElem}
+  R = base_ring(f)
+  return _transport_factor(factor, f, data, R)
+end
+
+function is_squarefree(f::Union{PolyRingElem{T}, MPolyRingElem{T}}) where {T <: RationalFunctionFieldElem}
+  is_squarefree(map_coefficients(data, f; cached = false))
 end

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -152,6 +152,7 @@ import ..AbstractAlgebra: is_monomial
 import ..AbstractAlgebra: is_nilpotent
 import ..AbstractAlgebra: is_power
 import ..AbstractAlgebra: is_square
+import ..AbstractAlgebra: is_squarefree
 import ..AbstractAlgebra: is_square_with_sqrt
 import ..AbstractAlgebra: is_term
 import ..AbstractAlgebra: is_terse

--- a/test/generic/RationalFunctionField-test.jl
+++ b/test/generic/RationalFunctionField-test.jl
@@ -133,6 +133,11 @@ end
    K, (x, y) = rational_function_field(QQ, ["x", "y"])
 
    test_rand(K, 0:3, 0:3, -3:3)
+
+   # test that results are reduced
+   K, x = rational_function_field(GF(2), "x")
+   f = rand(K, 1:1)
+   @test is_unit(gcd(numerator(f), denominator(f)))
 end
 
 @testset "Generic.RationalFunctionField.manipulation" begin


### PR DESCRIPTION
- delegate factorization to `FracField` over polynomial rings
- make `rand` produce reduced fractions like `t//t` or `0//(t + 2)`

The `reduce` is kind of a hack, since the only official way to get reduced fractions is `//`, but this gives the wrong parent.