### PR TITLE
Wrap `MPoly` factorization for `UnivPoly`

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -226,6 +226,12 @@ include("algorithms/LaurentPoly.jl")
 include("algorithms/FinField.jl")
 include("algorithms/GenericFunctions.jl")
 
+include("Groups.jl")
+include("Rings.jl")
+include("NCRings.jl")
+include("Fields.jl")
+include("Factor.jl")
+
 include("CommonTypes.jl") # types needed by AbstractAlgebra and Generic
 include("Poly.jl")
 include("NCPoly.jl")
@@ -262,13 +268,6 @@ include("UnivPoly.jl")
 include("FreeAssociativeAlgebra.jl")
 include("LaurentMPoly.jl")
 include("MatrixNormalForms.jl")
-
-
-include("Groups.jl")
-include("Rings.jl")
-include("NCRings.jl")
-include("Fields.jl")
-include("Factor.jl")
 
 # More functionality for Julia types
 include("julia/Integer.jl")

--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -32,6 +32,25 @@ end
 
 ###############################################################################
 #
+#  Factorization
+#
+###############################################################################
+
+function _wrap_factorization(f::Fac{<:MPolyRingElem}, S::UniversalPolyRing)
+   res = Fac{elem_type(S)}()
+   res.unit = Generic.UnivPoly(f.unit, S)
+   for (fact, expo) in f
+      mulpow!(res, Generic.UnivPoly(fact, S), expo)
+   end
+   return res
+end
+
+factor_squarefree(f::UniversalPolyRingElem) = _wrap_factorization(factor_squarefree(data(f)), parent(f))
+
+factor(f::UniversalPolyRingElem) = _wrap_factorization(factor(data(f)), parent(f))
+
+###############################################################################
+#
 #   universal_polynomial_ring constructors
 #
 ###############################################################################


### PR DESCRIPTION
Since `factor` is supported for `MPoly` it should also be possible to factor `UnivPoly`. This PR adds this feature. Unfortunately I can't add tests for this to AbsractAlgebra itself since the actual factorization is implemented in Nemo.

Note that the reordering in `AbstractAlgebra.jl` was necessary to make `Fac` available early enough.