### PR TITLE
More intuitive polynomial evaluation, e.g. `f(y=3)` to substitute 3 for the variable named `y` in the polynomial `f`

### DIFF
--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -876,7 +876,20 @@ function evaluate(a::S, vars::Vector{S}, vals::Vector{V}) where {S <: UnivPoly{T
    return evaluate(a, varidx, vals)
 end
 
-###############################################################################
+function (a::Union{MPolyRingElem, UniversalPolyRingElem})(;kwargs...)
+   S = parent(a)
+   vars = Array{Int}(undef, length(kwargs))
+   vals = Array{RingElement}(undef, length(kwargs))
+   for (i, (var, val)) in enumerate(kwargs)
+     vari = findfirst(isequal(var), S.S)
+     vari === nothing && error("Given polynomial has no variable $var")
+     vars[i] = vari
+     vals[i] = val
+   end
+   return evaluate(a, vars, vals)
+end
+
+########S,(a,b)=QQ[:a,:b]#######################################################################
 #
 #   GCD
 #

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1258,6 +1258,13 @@ end
 
    @test evaluate(f, [x, 0]) == 3x + 1 # see https://github.com/oscar-system/Oscar.jl/issues/2331
 
+   @test f(x=1, y=2) == 14
+   @test f(y=2, x=1) == 14
+   @test f(x=x+y, y=2y-x) ==
+               2*x^4 - 4*x^3*y - 6*x^2*y^2 + 8*x*y^3 + 2*x + 8*y^4 + 5*y + 1
+   @test f(y=2y-x, x=x+y) ==
+               2*x^4 - 4*x^3*y - 6*x^2*y^2 + 8*x*y^3 + 2*x + 8*y^4 + 5*y + 1
+
    S, z = polynomial_ring(R, "z")
 
    @test evaluate(f, [z + 1, z - 1]) == 2*z^4 - 4*z^2 + 4*z + 5

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -972,8 +972,11 @@ end
          @test evaluate(f, [1], [V[1]]) == evaluate(f, [1], [R(V[1])])
          @test evaluate(f, [1], [V[1]]) == evaluate(f, [1], [ZZ(V[1])])
          @test evaluate(f, [1], [V[1]]) == evaluate(f, [1], [U(V[1])])
+         @test evaluate(f, [1], [V[1]]) == f(x=V[1])
          @test evaluate(f, [1, 3], [V[1], V[2]]) == evaluate(f, [1, 3], [R(v) for v in V[1:2]])
          @test evaluate(f, [1, 3], [V[1], V[2]]) == evaluate(f, [1, 3], [ZZ(v) for v in V[1:2]])
+         @test evaluate(f, [1, 3], [V[1], V[2]]) == f(x=V[1], z=V[2])
+         @test evaluate(f, [1, 3], [V[1], V[2]]) == f(z=V[2], x=V[1])
 
          @test evaluate(g, [1], [V[1]]) == evaluate(g, [1], [R(V[1])])
          @test evaluate(g, [1], [V[1]]) == evaluate(g, [1], [ZZ(V[1])])


### PR DESCRIPTION
This fixes #2014. I'm not so sure about where to put this new method since there is no file for common `UnivPoly` and `MPoly` implementations.

```
julia> R,(x,y)=universal_polynomial_ring(QQ, [:x,:y])
(Universal Polynomial Ring over Rationals, AbstractAlgebra.Generic.UnivPoly{Rational{BigInt}}[x, y])

julia> S,(a,b)=QQ[:a,:b]
(Multivariate polynomial ring in 2 variables over rationals, AbstractAlgebra.Generic.MPoly{Rational{BigInt}}[a, b])

julia> f=3y^2-x*y+2x^3
2*x^3 - x*y + 3*y^2

julia> g=a^2-b
a^2 - b

julia> f(y=2)
2*x^3 - 2*x + 12

julia> f(y=2,x=3)
60

julia> g(a=2)
-b + 4

julia> f(x=3,y=2)
60

julia> f(x=y,y=x)
3*x^2 - x*y + 2*y^3

```