### PR TITLE
Fix some references in the Linear Solving docs

### DIFF
--- a/docs/src/linear_solving.md
+++ b/docs/src/linear_solving.md
@@ -31,7 +31,7 @@ Furthermore, there is a function [`kernel`](@ref kernel(::Union{MatElem, SolveCt
 
 Systems $xA = b_1,\dots, xA = b_k$ with the same matrix $A$, but several right hand sides $b_i$ can be solved more efficiently, by first initializing a "context object" `C`.
 ```@docs
-solve_init
+solve_init(::MatElem)
 ```
 Now the functions `solve`, `can_solve`, etc. can be used with `C` in place of $A$.
 This way the time-consuming part of the solving (i.e. computing a reduced form of $A$) is only done once and the result cached in `C` to be reused.
@@ -43,5 +43,5 @@ solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
 can_solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
 can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
 can_solve_with_solution_and_kernel(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
-kernel(:::Union{MatElem, SolveCtx})
+kernel(::Union{MatElem, SolveCtx})
 ```

--- a/docs/src/linear_solving.md
+++ b/docs/src/linear_solving.md
@@ -7,10 +7,10 @@ CurrentModule = AbstractAlgebra.Solve
 ## Overview of the functionality
 
 The module `AbstractAlgebra.Solve` provides the following four functions for solving linear systems:
-* `solve`
-* `can_solve`
-* `can_solve_with_solution`
-* `can_solve_with_solution_and_kernel`
+* [`solve`](@ref solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve`](@ref can_solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve_with_solution`](@ref can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve_with_solution_and_kernel`](@ref can_solve_with_solution_and_kernel(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
 
 All of these take the same set of arguments, namely:
 * a matrix $A$ of type `MatElem`;
@@ -25,6 +25,8 @@ The functionality of the functions can be summarized as follows.
 * `can_solve_with_solution`: return `true` and a solution, if this exists, and `false` and an empty vector or matrix otherwise.
 * `can_solve_with_solution_and_kernel`: like `can_solve_with_solution` and additionally return a matrix whose rows (respectively columns) give a basis of the kernel of $A$.
 
+Furthermore, there is a function [`kernel`](@ref kernel(::Union{MatElem, SolveCtx})) which computes the kernel of a matrix $A$.
+
 ## Solving with several right hand sides
 
 Systems $xA = b_1,\dots, xA = b_k$ with the same matrix $A$, but several right hand sides $b_i$ can be solved more efficiently, by first initializing a "context object" `C`.
@@ -37,9 +39,9 @@ This way the time-consuming part of the solving (i.e. computing a reduced form o
 ## Detailed documentation
 
 ```@docs
-solve
-can_solve
-can_solve_with_solution
-can_solve_with_solution_and_kernel
-kernel
+solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+can_solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+can_solve_with_solution_and_kernel(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+kernel(:::Union{MatElem, SolveCtx})
 ```

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -557,7 +557,7 @@ If no solution exists, an error is raised.
 
 If a context object `C` is supplied, then the above applies for `A = matrix(C)`.
 
-See also [`can_solve_with_solution`](@ref).
+See also [`can_solve_with_solution`](@ref can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T).
 """
 function solve(A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}}; side::Symbol = :left) where T
   return solve(matrix_normal_form_type(A), A, b; side)
@@ -580,7 +580,7 @@ Return `true` if the linear system $xA = b$ or $Ax = b$ with `side == :left`
 
 If a context object `C` is supplied, then the above applies for `A = matrix(C)`.
 
-See also [`can_solve_with_solution`](@ref).
+See also [`can_solve_with_solution`](@ref can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T).
 """
 function can_solve(A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}}; side::Symbol = :left) where T
   return can_solve(matrix_normal_form_type(A), A, b; side)
@@ -604,7 +604,7 @@ If `side == :right`, the system $Ax = b$ is solved.
 
 If a context object `C` is supplied, then the above applies for `A = matrix(C)`.
 
-See also [`solve`](@ref).
+See also [`solve`](@ref solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T).
 """
 function can_solve_with_solution(A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}}; side::Symbol = :left) where T
   return can_solve_with_solution(matrix_normal_form_type(A), A, b; side)
@@ -629,7 +629,7 @@ If `side == :right`, the system $Ax = b$ is solved.
 
 If a context object `C` is supplied, then the above applies for `A = matrix(C)`.
 
-See also [`solve`](@ref) and [`kernel`](@ref).
+See also [`solve`](@ref solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T) and [`kernel`](@ref kernel(::Union{MatElem, SolveCtx})).
 """
 function can_solve_with_solution_and_kernel(A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}}; side::Symbol = :left) where T
   return can_solve_with_solution_and_kernel(matrix_normal_form_type(A), A, b; side)

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -186,13 +186,13 @@ Linear solving context of matrix
   [0//1   3//1   0//1]
   [5//1   0//1   0//1]
 
-julia> solve(C, [QQ(1), QQ(1), QQ(1)], side = :left)
+julia> solve(C, [QQ(1), QQ(1), QQ(1)]; side = :left)
 3-element Vector{Rational{BigInt}}:
  1//3
  1//9
  2//15
 
-julia> solve(C, [QQ(1), QQ(1), QQ(1)], side = :right)
+julia> solve(C, [QQ(1), QQ(1), QQ(1)]; side = :right)
 3-element Vector{Rational{BigInt}}:
  1//5
  1//3
@@ -564,7 +564,7 @@ function solve(A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}
 end
 
 function solve(NF::MatrixNormalFormTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::Union{Vector{T}, MatElem{T}}; side::Symbol = :left) where T
-  fl, x = can_solve_with_solution(NF, A, b, side = side)
+  fl, x = can_solve_with_solution(NF, A, b; side = side)
   @req fl "Unable to solve linear system"
   return x
 end
@@ -750,7 +750,7 @@ function kernel(::RREFTrait, A::MatElem; side::Symbol = :left)
   check_option(side, [:right, :left], "side")
 
   if side === :left
-    KK = kernel(RREFTrait(), lazy_transpose(A), side = :right)
+    KK = kernel(RREFTrait(), lazy_transpose(A); side = :right)
     return lazy_transpose(KK)::typeof(A)
   end
 
@@ -769,12 +769,12 @@ function kernel(::RREFTrait, C::SolveCtx{T, <: MatrixNormalFormTrait}; side::Sym
 
   if side === :right
     if !isdefined(C, :kernel_right)
-      C.kernel_right = kernel(RREFTrait(), matrix(C), side = :right)
+      C.kernel_right = kernel(RREFTrait(), matrix(C); side = :right)
     end
     return C.kernel_right
   else
     if !isdefined(C, :kernel_left)
-      C.kernel_left = kernel(RREFTrait(), matrix(C), side = :left)
+      C.kernel_left = kernel(RREFTrait(), matrix(C); side = :left)
     end
     return C.kernel_left
   end
@@ -836,7 +836,7 @@ function _can_solve_internal(::NFTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::Ve
     check_linear_system_dim_left(A, b)
     B = matrix(base_ring(A), 1, ncols(A), b)
   end
-  fl, sol, K = _can_solve_internal_no_check(NFTrait(), A, B, task, side = side)
+  fl, sol, K = _can_solve_internal_no_check(NFTrait(), A, B, task; side = side)
   if isright
     x = eltype(b)[ sol[i, 1] for i in 1:nrows(sol) ]
   else # side == :left
@@ -856,7 +856,7 @@ function _can_solve_internal(::NFTrait, A::Union{MatElem{T}, SolveCtx{T}}, b::Ma
   else
     check_linear_system_dim_left(A, b)
   end
-  return _can_solve_internal_no_check(NFTrait(), A, b, task, side = side)
+  return _can_solve_internal_no_check(NFTrait(), A, b, task; side = side)
 end
 
 # Catch non-matching normal forms in solve context
@@ -870,7 +870,7 @@ function _can_solve_internal_no_check(::HowellFormTrait, A::MatElem{T}, b::MatEl
 
   if side === :left
     # For side == :left, we pretend that A and b are transposed
-    fl, _sol, _K = _can_solve_internal_no_check(HowellFormTrait(), lazy_transpose(A), lazy_transpose(b), task, side = :right)
+    fl, _sol, _K = _can_solve_internal_no_check(HowellFormTrait(), lazy_transpose(A), lazy_transpose(b), task; side = :right)
     return fl, lazy_transpose(_sol), lazy_transpose(_K)
   end
 
@@ -908,7 +908,7 @@ function _can_solve_internal_no_check(::HowellFormTrait, C::SolveCtx{T, HowellFo
       return fl, sol, zero(b, 0, 0)
     end
 
-    return fl, sol, kernel(C, side = :right)
+    return fl, sol, kernel(C; side = :right)
   else# side === :left
     A = matrix(C)
     B = reduced_matrix(C)
@@ -922,7 +922,7 @@ function _can_solve_internal_no_check(::HowellFormTrait, C::SolveCtx{T, HowellFo
       return fl, sol, zero(b, 0, 0)
     end
 
-    return fl, sol, kernel(C, side = :left)
+    return fl, sol, kernel(C; side = :left)
   end
 end
 
@@ -931,7 +931,7 @@ end
 function _can_solve_internal_no_check(::HermiteFormTrait, A::MatElem{T}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where T
   if side === :left
     # For side == :left, we pretend that A and b are transposed
-    fl, _sol, _K = _can_solve_internal_no_check(HermiteFormTrait(), lazy_transpose(A), lazy_transpose(b), task, side = :right)
+    fl, _sol, _K = _can_solve_internal_no_check(HermiteFormTrait(), lazy_transpose(A), lazy_transpose(b), task; side = :right)
     return fl, lazy_transpose(_sol), lazy_transpose(_K)
   end
 
@@ -956,7 +956,7 @@ function _can_solve_internal_no_check(::HermiteFormTrait, C::SolveCtx{T, Hermite
     return fl, sol, zero(b, 0, 0)
   end
 
-  return true, sol, kernel(C, side = side)
+  return true, sol, kernel(C; side = side)
 end
 
 ### RREFTrait
@@ -964,7 +964,7 @@ end
 function _can_solve_internal_no_check(::RREFTrait, A::MatElem{T}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where T
   if side === :left
     # For side == :left, we pretend that A and b are transposed
-    fl, _sol, _K = _can_solve_internal_no_check(RREFTrait(), lazy_transpose(A), lazy_transpose(b), task, side = :right)
+    fl, _sol, _K = _can_solve_internal_no_check(RREFTrait(), lazy_transpose(A), lazy_transpose(b), task; side = :right)
     return fl, lazy_transpose(_sol), lazy_transpose(_K)
   end
 
@@ -1062,7 +1062,7 @@ function _can_solve_internal_no_check(::LUTrait, C::SolveCtx{T, LUTrait}, b::Mat
     return fl, sol, zero(b, 0, 0)
   end
 
-  return true, sol, kernel(C, side = side)
+  return true, sol, kernel(C; side = side)
 end
 
 ### FFLUTrait / MatrixInterpolateTrait
@@ -1080,7 +1080,7 @@ end
 function _can_solve_internal_no_check(NF::Union{FFLUTrait, MatrixInterpolateTrait}, A::MatElem{T}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where T
 
   if side === :left
-    fl, _sol, _K = _can_solve_internal_no_check(NF, lazy_transpose(A), lazy_transpose(b), task, side = :right)
+    fl, _sol, _K = _can_solve_internal_no_check(NF, lazy_transpose(A), lazy_transpose(b), task; side = :right)
     # This does not return LazyTransposedMat for sol because the matrices are made integral
     return fl, transpose(_sol), lazy_transpose(_K)
   end
@@ -1112,7 +1112,7 @@ function _can_solve_internal_no_check(NF::Union{FFLUTrait, MatrixInterpolateTrai
 
   if task === :with_kernel
     # I don't know how to compute the kernel using an (ff)lu factoring
-    return flag, sol, kernel(A, side = :right)
+    return flag, sol, kernel(A; side = :right)
   else
     return flag, sol, zero(A, 0, 0)
   end
@@ -1148,7 +1148,7 @@ function _can_solve_internal_no_check_right(::FFLUTrait, C::SolveCtx{T, FFLUTrai
   end
   if task === :with_kernel
     # I don't know how to compute the kernel using an (ff)lu factoring
-    return fl, y, kernel(RREFTrait(), C, side = :right)
+    return fl, y, kernel(RREFTrait(), C; side = :right)
   else
     return fl, y, zero(b, 0, 0)
   end
@@ -1177,7 +1177,7 @@ function _can_solve_internal_no_check_left(::FFLUTrait, C::SolveCtx{T, FFLUTrait
   end
   if task === :with_kernel
     # I don't know how to compute the kernel using an (ff)lu factoring
-    return fl, y, kernel(RREFTrait(), C, side = :left)
+    return fl, y, kernel(RREFTrait(), C; side = :left)
   else
     return fl, y, zero(b, 0, 0)
   end


### PR DESCRIPTION
that are wrong / pull in too many docstrings when viewing the page as part of the Oscar docs.