### PR TITLE
chore: Bump to 0.44.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.44.8"
+version = "0.44.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Things I would like to see included:
- `pow!` fallback https://github.com/Nemocas/AbstractAlgebra.jl/pull/2023
- `reverse!` fallback https://github.com/Nemocas/AbstractAlgebra.jl/pull/2023
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2022 (not needed, just nice to have)