### PR TITLE
Fix check_parent in equality of MPoly

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2029,7 +2029,7 @@ end
 ###############################################################################
 
 function ==(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
-   fl = check_parent(a, b, false)
+   fl = check_parent(a, b)
    !fl && return false
    if a.length != b.length
       return false

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -186,6 +186,12 @@
       ) @test_throws (VERSION < v"1.7" ? LoadError : UndefVarError) let local_name = 3
          @macroexpand @polynomial_ring(QQ, :x => 1:local_name)
       end
+
+   let
+     Qx, (x, ) = polynomial_ring(QQ, [:x])
+     Qxy, (x2, y) = polynomial_ring(QQ, [:x, :y])
+     @test_throws ErrorException x == x2
+   end
 end
 
 # these variables need to be in global scope


### PR DESCRIPTION
Not sure why I changed this in https://github.com/Nemocas/AbstractAlgebra.jl/pull/285, but it looks very wrong.