### PR TITLE
clean up `monomial_isless` for `Generic.MPoly`

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -394,60 +394,10 @@ function monomial_isequal(A::Matrix{UInt}, i::Int, j::Int, N::Int)
    return true
 end
 
-# Returns true if the i-th exponent vector of the array A is less than that of
-# the j-th, according to the ordering of R
-function monomial_isless(A::Matrix{UInt}, i::Int, j::Int, N::Int, R::MPolyRing{T}, drmask::UInt) where {T <: RingElement}
-   if R.ord == :degrevlex
-      if (xor(A[N, i], drmask)) < (xor(A[N, j], drmask))
-         return true
-      elseif (xor(A[N, i], drmask)) > (xor(A[N, j], drmask))
-         return false
-      end
-      for k = N-1:-1:1
-         if A[k, i] > A[k, j]
-            return true
-         elseif A[k, i] < A[k, j]
-            return false
-         end
-      end
-   else
-      for k = N:-1:1
-         if A[k, i] < A[k, j]
-            return true
-         elseif A[k, i] > A[k, j]
-            return false
-         end
-      end
-   end
-   return false
-end
-
 # Return true if the i-th exponent vector of the array A is less than the j-th
 # exponent vector of the array B
 function monomial_isless(A::Matrix{UInt}, i::Int, B::Matrix{UInt}, j::Int, N::Int, R::MPolyRing{T}, drmask::UInt) where {T <: RingElement}
-   if R.ord == :degrevlex
-      if xor(A[N, i], drmask) < xor(B[N, j], drmask)
-         return true
-      elseif xor(A[N, i], drmask) > xor(B[N, j], drmask)
-         return false
-      end
-      for k = N-1:-1:1
-         if A[k, i] > B[k, j]
-            return true
-         elseif A[k, i] < B[k, j]
-            return false
-         end
-      end
-   else
-      for k = N:-1:1
-         if A[k, i] < B[k, j]
-            return true
-         elseif A[k, i] > B[k, j]
-            return false
-         end
-      end
-   end
-   return false
+  return monomial_cmp(A, i, B, j, N, R, drmask) < 0
 end
 
 # Set the i-th exponent vector of the array A to the word by word minimum of
@@ -1406,7 +1356,7 @@ function heapinsert!(xs::Vector{heap_s}, ys::Vector{heap_t}, m::Int, exp::Int, e
          ys[m] = heap_t(ys[m].i, ys[m].j, xs[j].n)
          xs[j] = heap_s(xs[j].exp, m)
          return false
-      elseif monomial_isless(exps, xs[j].exp, exp, N, R, drmask)
+      elseif monomial_isless(exps, xs[j].exp, exps, exp, N, R, drmask)
          i = j
       else
          break
@@ -1433,7 +1383,7 @@ function nheapinsert!(xs::Vector{heap_s}, ys::Vector{nheap_t}, m::Int, exp::Int,
          ys[m] = nheap_t(ys[m].i, ys[m].j, p, xs[j].n)
          xs[j] = heap_s(xs[j].exp, m)
          return false
-      elseif monomial_isless(exps, xs[j].exp, exp, N, R, drmask)
+      elseif monomial_isless(exps, xs[j].exp, exps, exp, N, R, drmask)
          i = j
       else
          break
@@ -1454,7 +1404,7 @@ function heappop!(xs::Vector{heap_s}, exps::Matrix{UInt}, N::Int, R::MPolyRing{T
    i = 1
    j = 2
    @inbounds while j < s
-      if !monomial_isless(exps, xs[j + 1].exp, xs[j].exp, N, R, drmask)
+      if !monomial_isless(exps, xs[j + 1].exp, exps, xs[j].exp, N, R, drmask)
          j += 1
       end
       xs[i] = xs[j]
@@ -1463,7 +1413,7 @@ function heappop!(xs::Vector{heap_s}, exps::Matrix{UInt}, N::Int, R::MPolyRing{T
    end
    exp = xs[s].exp
    j = i >> 1
-   @inbounds while i > 1 && monomial_isless(exps, xs[j].exp, exp, N, R, drmask)
+   @inbounds while i > 1 && monomial_isless(exps, xs[j].exp, exps, exp, N, R, drmask)
       xs[i] = xs[j]
       i = j
       j >>= 1


### PR DESCRIPTION
`monomial_isless` is functionally identical to `monomial_cmp`, this PR removes the duplicated code.