### PR TITLE
Optimize `gen(::MPolyRing, ::Int)` for :deglex and :degrevlex

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -61,17 +61,20 @@ function gen(a::MPolyRing{T}, i::Int) where {T <: RingElement}
 
    ord = internal_ordering(a)
    if ord == :lex
-      return a([one(base_ring(a))], reshape(UInt[UInt(j == n - i + 1)
-              for j = 1:n], n, 1))
+      exps = zeros(UInt, n, 1)
+      exps[n - i + 1] = 1
    elseif ord == :deglex
-      return a([one(base_ring(a))], reshape(UInt[(UInt(j == n - i + 1)
-              for j in 1:n)..., UInt(1)], n + 1, 1))
+      exps = zeros(UInt, n + 1, 1)
+      exps[n - i + 1] = 1
+      exps[end] = 1
    elseif ord == :degrevlex
-      return a([one(base_ring(a))], reshape(UInt[(UInt(j == i)
-              for j in 1:n)..., UInt(1)], n + 1, 1))
+      exps = zeros(UInt, n + 1, 1)
+      exps[i] = 1
+      exps[end] = 1
    else
       error("invalid ordering")
    end
+   return a([one(base_ring(a))], exps)
 end
 
 function vars(p::MPoly{T}) where {T <: RingElement}


### PR DESCRIPTION
Before:

    julia> R, _ = polynomial_ring(QQ, 2);

    julia> @b gen($R, 1)
    79.036 ns (9 allocs: 304 bytes)

    julia> R, _ = polynomial_ring(QQ, 10; internal_ordering=:degrevlex);

    julia> @b gen($R, 1)
    613.239 ns (21 allocs: 752 bytes)

After:

    julia> R, _ = polynomial_ring(QQ, 2);

    julia> @b gen($R, 1)
    71.306 ns (9 allocs: 304 bytes)

    julia> R, _ = polynomial_ring(QQ, 10; internal_ordering=:degrevlex);

    julia> @b gen($R, 1)
    75.127 ns (9 allocs: 368 bytes)