### PR TITLE
Add stub for isomorphism(::Type{<:Group}, ::Group)

### DIFF
--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -310,8 +310,8 @@ function isomorphism(::Type{T}, G::T; on_gens::Bool=false) where T <: Group
     return identity_map(A)
   end
   # Known isomorphisms are cached in the attribute `:isomorphisms`.
-  # The key is a tuple `(T, on_gens)`, where `on_gens` is `true` if the isomorphism
-  # maps generators to generators.
+  # The key is a tuple `(T, on_gens)`, where `on_gens` is `true` if the stored
+  # isomorphism `f` maps `gen(domain(f),i)` to `gen(codomain(f),i)` for each `i`.
   on_gens = true # we ignore the on_gens flag, the identity will *always* map gens onto gens
   isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, T, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
   return get!(isos, (T, on_gens)) do

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -316,6 +316,22 @@ function isomorphism(::Type{T}, G::T; on_gens::Bool=false) where T <: Group
   end::AbstractAlgebra.Generic.IdentityMap{T}
 end
 
+"""
+    isomorphism(::Type{T}, G::Group; on_gens=false) where T <: Group
+
+Return an isomorphism from `G` to a group `H` of type `T`.
+An exception is thrown if no such isomorphism exists.
+
+If `on_gens` is `true` then `gens(G)` is guaranteed to correspond to
+`gens(H)`;
+an exception is thrown if this is not possible.
+
+Isomorphisms are cached in `G`, subsequent calls of `isomorphism` with the
+same `T` (and the same value of `on_gens`) yield identical results.
+
+If only the image of such an isomorphism is needed, use `T(G)`;
+but this will assume `on_gens=false`.
+"""
 function isomorphism(::Type{T}, G::Group; on_gens::Bool=false) where T <: Group
   throw(NotImplementedError(:isomorphism, T, G))
 end

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -306,6 +306,9 @@ function (::Type{T})(G::Group) where T <: Group
 end
 
 function isomorphism(::Type{T}, G::T; on_gens::Bool=false) where T <: Group
+  if !_is_attribute_storing_type(T)
+    return identity_map(A)
+  end
   # Known isomorphisms are cached in the attribute `:isomorphisms`.
   # The key is a tuple `(T, on_gens)`, where `on_gens` is `true` if the isomorphism
   # maps generators to generators.
@@ -326,7 +329,7 @@ If `on_gens` is `true` then `gens(G)` is guaranteed to correspond to
 `gens(H)`;
 an exception is thrown if this is not possible.
 
-Isomorphisms are cached in `G`, subsequent calls of `isomorphism` with the
+Isomorphisms are usually cached in `G`, subsequent calls of `isomorphism` with the
 same `T` (and the same value of `on_gens`) yield identical results.
 
 If only the image of such an isomorphism is needed, use `T(G)`;

--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -294,3 +294,28 @@ end
 ###############################################################################
 
 Base.broadcastable(x::GroupElem) = Ref(x)
+
+###############################################################################
+#
+#   Changing group type
+#
+###############################################################################
+
+function (::Type{T})(G::Group) where T <: Group
+  return codomain(isomorphism(T, G))
+end
+
+function isomorphism(::Type{T}, G::T; on_gens::Bool=false) where T <: Group
+  # Known isomorphisms are cached in the attribute `:isomorphisms`.
+  # The key is a tuple `(T, on_gens)`, where `on_gens` is `true` if the isomorphism
+  # maps generators to generators.
+  on_gens = true # we ignore the on_gens flag, the identity will *always* map gens onto gens
+  isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, T, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
+  return get!(isos, (T, on_gens)) do
+    return identity_map(A)
+  end::AbstractAlgebra.Generic.IdentityMap{T}
+end
+
+function isomorphism(::Type{T}, G::Group; on_gens::Bool=false) where T <: Group
+  throw(NotImplementedError(:isomorphism, T, G))
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -351,6 +351,7 @@ export is_zero_divisor
 export is_zero_divisor_with_annihilator
 export is_zero_entry
 export is_zero_row
+export isomorphism
 export kernel
 export kronecker_product
 export laurent_polynomial_ring


### PR DESCRIPTION
This is the AA part of https://github.com/oscar-system/Oscar.jl/pull/4616.

For the time being, this PR only exists to run changes in Oscar, Hecke, and AA in one CI; and to demonstrate the proof-of-concept.