### PR TITLE
Remove broken `is_unit` and `is_nilpotent` for `NCPolyRingElem`

### DIFF
--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -234,9 +234,6 @@ y
 julia> g = is_gen(y)
 true
 
-julia> m = is_unit(b)
-true
-
 julia> n = degree(d)
 2
 

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -416,13 +416,14 @@ end
 iszero(x::MPolyRingElem{T}) where T <: RingElement = length(x) == 0
 
 function is_unit(f::T) where {T <: MPolyRingElem}
-  # for constant polynomials we delegate to the coefficient ring:
-  is_constant(f) && return is_unit(constant_coefficient(f))
-  # Here deg(f) > 0; over an integral domain, non-constant polynomials are never units:
-  is_domain_type(T) && return false
   # A polynomial over a commutative ring is a unit iff its
   # constant term is a unit and all other coefficients are nilpotent:
   # see e.g. <https://kconrad.math.uconn.edu/blurbs/ringtheory/polynomial-properties.pdf> for a proof.
+  # For constant polynomials we delegate to the coefficient ring:
+  is_constant(f) && return is_unit(constant_coefficient(f))
+  # Here deg(f) > 0.
+  # Over an integral domain, non-constant polynomials are never units:
+  is_domain_type(T) && return false
   constant_term_is_unit = false
   for (c, expv) in zip(coefficients(f), exponent_vectors(f))
     if is_zero(expv)
@@ -432,7 +433,7 @@ function is_unit(f::T) where {T <: MPolyRingElem}
       is_nilpotent(c) || return false
     end
   end
-  return constant_term_is_unit
+  return constant_term_is_unit  # handles the case that there is no constant term
 end
 
 function content(a::MPolyRingElem{T}) where T <: RingElement
@@ -445,6 +446,7 @@ end
 
 
 function is_nilpotent(f::T) where {T <: MPolyRingElem}
+  # Over a commutative ring a poly is nilpotent iff all coeffs are nilpotent.
   is_domain_type(T) && return is_zero(f)
   return all(is_nilpotent, coefficients(f))
 end

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -784,38 +784,3 @@ polynomial_ring_only(R::T, s::Symbol; cached::Bool=true) where T<:NCRing =
 
 PolyRing(R::NCRing) = polynomial_ring_only(R, :x; cached=false)
 
-
-
-###############################################################################
-#
-#   is_unit & is_nilpotent
-#
-###############################################################################
-
-# ASSUMES structural interface is analogous to that for univariate polynomials
-
-# # This implementation is NOT GENERALLY CORRECT for NC coefficients:
-# # see counter-example in AbstractAlgebra issue 2032 [2025-03-10]; try 1+f^3
-# # The implementation is correct if the coeffs are in a local ring.
-# function is_unit(f::T) where {T <: PolynomialElem}
-#   # constant coeff must itself be a unit
-#   is_unit(constant_coefficient(f)) || return false
-#   is_constant(f) && return true
-#   # Here deg(f) > 0; over an integral domain, non-constant polynomials are never units:
-#   is_domain_type(T) && return false
-#   for i in 1:degree(f) # we have already checked coeff(f,0)
-#     if !is_nilpotent(coeff(f, i))
-#       return false
-#     end
-#   end
-#   return true
-# end
-
-# # This implementation is NOT GENERALLY CORRECT for NC coefficients:
-# # see counter-example in AbstractAlgebra issue 2032 [2025-03-10].
-# # The implementation is correct if the coeffs are in a local ring.
-# # **NOTE** the function "coefficients" does not exist for PolynomialElem.
-# function is_nilpotent(f::T) where {T <: PolynomialElem}
-#   is_domain_type(T) && return is_zero(f)
-#   return all(is_nilpotent, coefficients(f))
-# end

--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -794,23 +794,28 @@ PolyRing(R::NCRing) = polynomial_ring_only(R, :x; cached=false)
 
 # ASSUMES structural interface is analogous to that for univariate polynomials
 
-# This function handles both PolyRingElem & NCPolyRingElem
-function is_unit(f::T) where {T <: PolynomialElem}
-  # constant coeff must itself be a unit
-  is_unit(constant_coefficient(f)) || return false
-  is_constant(f) && return true
-  # Here deg(f) > 0; over an integral domain, non-constant polynomials are never units:
-  is_domain_type(T) && return false
-  for i in 1:degree(f) # we have already checked coeff(f,0)
-    if !is_nilpotent(coeff(f, i))
-      return false
-    end
-  end
-  return true
-end
+# # This implementation is NOT GENERALLY CORRECT for NC coefficients:
+# # see counter-example in AbstractAlgebra issue 2032 [2025-03-10]; try 1+f^3
+# # The implementation is correct if the coeffs are in a local ring.
+# function is_unit(f::T) where {T <: PolynomialElem}
+#   # constant coeff must itself be a unit
+#   is_unit(constant_coefficient(f)) || return false
+#   is_constant(f) && return true
+#   # Here deg(f) > 0; over an integral domain, non-constant polynomials are never units:
+#   is_domain_type(T) && return false
+#   for i in 1:degree(f) # we have already checked coeff(f,0)
+#     if !is_nilpotent(coeff(f, i))
+#       return false
+#     end
+#   end
+#   return true
+# end
 
-# This function handles both PolyRingElem & NCPolyRingElem
-function is_nilpotent(f::T) where {T <: PolynomialElem}
-  is_domain_type(T) && return is_zero(f)
-  return all(is_nilpotent, coefficients(f))
-end
+# # This implementation is NOT GENERALLY CORRECT for NC coefficients:
+# # see counter-example in AbstractAlgebra issue 2032 [2025-03-10].
+# # The implementation is correct if the coeffs are in a local ring.
+# # **NOTE** the function "coefficients" does not exist for PolynomialElem.
+# function is_nilpotent(f::T) where {T <: PolynomialElem}
+#   is_domain_type(T) && return is_zero(f)
+#   return all(is_nilpotent, coefficients(f))
+# end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -226,7 +226,10 @@ function is_unit(f::T) where {T <: PolyRingElem}
   # A polynomial over a commutative ring is a unit iff its
   # constant term is a unit and all other coefficients are nilpotent:
   # see e.g. <https://kconrad.math.uconn.edu/blurbs/ringtheory/polynomial-properties.pdf> for a proof.
-  # constant coeff must itself be a unit
+  # This implementation is NOT GENERALLY CORRECT for NC coefficients:
+  # see counter-example in AbstractAlgebra issue 2032 [2025-03-10]; try 1+f^3
+
+  # Constant coeff must itself be a unit:
   is_unit(constant_coefficient(f)) || return false
   is_constant(f) && return true
   # Here deg(f) > 0
@@ -242,6 +245,8 @@ end
 function is_nilpotent(f::T) where {T <: PolyRingElem}
   # Makes essential use of the fact that sum of 2 nilpotents is nilpotent.
   # This is true when the coeffs are commutative.
+  # This implementation is NOT GENERALLY CORRECT for NC coefficients:
+  # see counter-example in AbstractAlgebra issue 2032 [2025-03-10].
   is_domain_type(T) && return is_zero(f)
   return all(is_nilpotent, coefficients(f))
 end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -222,8 +222,29 @@ function is_monic(a::PolynomialElem)
     return isone(leading_coefficient(a))
 end
 
-# function is_unit(...)      see NCPoly.jl
-# function is_nilpotent(...) see NCPoly.jl
+function is_unit(f::T) where {T <: PolyRingElem}
+  # A polynomial over a commutative ring is a unit iff its
+  # constant term is a unit and all other coefficients are nilpotent:
+  # see e.g. <https://kconrad.math.uconn.edu/blurbs/ringtheory/polynomial-properties.pdf> for a proof.
+  # constant coeff must itself be a unit
+  is_unit(constant_coefficient(f)) || return false
+  is_constant(f) && return true
+  # Here deg(f) > 0
+  is_domain_type(T) && return false # over an integral domain, non-constant polynomials are never units
+  for i in 1:degree(f) # we have already checked coeff(f,0)
+    if !is_nilpotent(coeff(f, i))
+      return false
+    end
+  end
+  return true
+end
+
+function is_nilpotent(f::T) where {T <: PolyRingElem}
+  # Makes essential use of the fact that sum of 2 nilpotents is nilpotent.
+  # This is true when the coeffs are commutative.
+  is_domain_type(T) && return is_zero(f)
+  return all(is_nilpotent, coefficients(f))
+end
 
 
 is_zero_divisor(a::PolynomialElem) = is_zero_divisor(content(a))

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -72,8 +72,6 @@ end
 
    @test is_gen(gen(S))
 
-   @test is_unit(one(S))
-
    f = 2*y + 1
 
    @test leading_coefficient(f) == 2


### PR DESCRIPTION
The fix is just to disable `is_nilpotent` and `is_unit` for polynomials over non-commutative rings.
I believe the algorithms are correct for non-commutative local rings (since sums of nilpotents are nilpotent in such rings).