### PR TITLE
Add generic `shift_left!` and `shift_right!` for univariate polynomials

### DIFF
--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -493,6 +493,16 @@ function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
         reverse!(p, 2)
         @test p == 2
       end
+      
+      @testset "shifting" begin
+        p = x^2 + 2*x + 3
+        @test shift_left!(p, 1) == x^3 + 2*x^2 + 3*x
+        @test shift_left!(p, 3) == x^6 + 2*x^5 + 3*x^4
+        
+        p = x^2 + 2*x + 3
+        @test shift_right!(p, 1) == x + 2
+        @test shift_right!(p, 2) == zero(Rx)
+      end
    end
 
    return nothing

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1197,11 +1197,11 @@ function shift_left(f::PolynomialElem, n::Int)
   shift_left!(parent(f)(), f, n)
 end
 
-function shift_left!(x::PolyRingElem, n::Int)
+function shift_left!(x::PolynomialElem, n::Int)
   return shift_left!(x, x, n)
 end
 
-function shift_left!(z::PolyRingElem{T}, x::PolyRingElem{T}, n::Int) where {T<:RingElement}
+function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {T<:RingElement}
   len = length(x) + n
   fit!(z, len)
   for i in 0:(length(x) - 1)
@@ -1225,11 +1225,11 @@ function shift_right(f::PolynomialElem, n::Int)
   return shift_right!(parent(f)(), f, n)
 end
 
-function shift_right!(x::PolyRingElem, n::Int)
+function shift_right!(x::PolynomialElem, n::Int)
   return shift_right!(x, x, n)
 end
 
-function shift_right!(z::PolyRingElem{T}, x::PolyRingElem{T}, n::Int) where {T<:RingElement}
+function shift_right!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {T<:RingElement}
   len = max(0, length(x) - n)
   fit!(z, len)
   for i in 0:(len - 1)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1201,7 +1201,7 @@ function shift_left!(x::PolynomialElem, n::Int)
   return shift_left!(x, x, n)
 end
 
-function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {T<:RingElement}
+function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where T
   len = length(x) + n
   fit!(z, len)
   for i in 0:(length(x) - 1)
@@ -1229,7 +1229,7 @@ function shift_right!(x::PolynomialElem, n::Int)
   return shift_right!(x, x, n)
 end
 
-function shift_right!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {T<:RingElement}
+function shift_right!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where T
   len = max(0, length(x) - n)
   fit!(z, len)
   for i in 0:(len - 1)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -396,11 +396,11 @@ end
 struct PolyCoeffs{T <: RingElement}
    f::T
 end
- 
+
 function coefficients(f::PolyRingElem)
    return PolyCoeffs(f)
 end
- 
+
 function Base.iterate(PC::PolyCoeffs{<:PolyRingElem}, st::Int = -1)
    st += 1
    if st > degree(PC.f)
@@ -419,17 +419,17 @@ function Base.iterate(PCR::Iterators.Reverse{<:PolyCoeffs{<:PolyRingElem}},
       return coeff(PCR.itr.f, st), st
    end
 end
- 
+
 Base.eltype(::Type{<:PolyRingElem{T}}) where {T} = T
 
 Base.eltype(::Type{PolyCoeffs{T}}) where {T} = Base.eltype(T)
- 
+
 Base.length(M::PolyCoeffs{<:PolyRingElem}) = length(M.f)
- 
+
 function Base.lastindex(a::PolyCoeffs{<:PolyRingElem})
    return degree(a.f)
 end
- 
+
 function Base.getindex(a::PolyCoeffs{<:PolyRingElem}, i::Int)
    return coeff(a.f, i)
 end
@@ -1201,15 +1201,15 @@ function shift_left!(x::PolynomialElem, n::Int)
   return shift_left!(x, x, n)
 end
 
-function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where T
+function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {T}
   if iszero(x)
     z = zero!(z)
     return z
   end
-  
+
   len = length(x) + n
   fit!(z, len)
-  for i in 0:(length(x) - 1)
+  for i in (length(x) - 1):-1:0
     z = setcoeff!(z, i + n, coeff(x, i))
   end
   for i in 0:(n - 1)
@@ -2311,7 +2311,7 @@ function compose(f::PolyRingElem, g::PolyRingElem; inner = nothing)
             Alternatively, use directly f(g) or g(f)
              """)
   end
-            
+
   if inner == :second
     return _compose_right(f, g)
   elseif inner == :first
@@ -3054,7 +3054,7 @@ with given sums of powers of roots. The list must be nonempty and contain
 `degree(f)` entries where $f$ is the polynomial to be recovered. The list
 must start with the sum of first powers of the roots.
 """
-function power_sums_to_polynomial(P::Vector{T}; 
+function power_sums_to_polynomial(P::Vector{T};
                            parent::PolyRing{T}=PolyRing(parent(P[1]))) where T <: RingElement
    return power_sums_to_polynomial(P, parent)
 end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1202,6 +1202,11 @@ function shift_left!(x::PolynomialElem, n::Int)
 end
 
 function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where T
+  if iszero(x)
+    z = zero!(z)
+    return z
+  end
+  
   len = length(x) + n
   fit!(z, len)
   for i in 0:(length(x) - 1)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -396,11 +396,11 @@ end
 struct PolyCoeffs{T <: RingElement}
    f::T
 end
-
+ 
 function coefficients(f::PolyRingElem)
    return PolyCoeffs(f)
 end
-
+ 
 function Base.iterate(PC::PolyCoeffs{<:PolyRingElem}, st::Int = -1)
    st += 1
    if st > degree(PC.f)
@@ -419,17 +419,17 @@ function Base.iterate(PCR::Iterators.Reverse{<:PolyCoeffs{<:PolyRingElem}},
       return coeff(PCR.itr.f, st), st
    end
 end
-
+ 
 Base.eltype(::Type{<:PolyRingElem{T}}) where {T} = T
 
 Base.eltype(::Type{PolyCoeffs{T}}) where {T} = Base.eltype(T)
-
+ 
 Base.length(M::PolyCoeffs{<:PolyRingElem}) = length(M.f)
-
+ 
 function Base.lastindex(a::PolyCoeffs{<:PolyRingElem})
    return degree(a.f)
 end
-
+ 
 function Base.getindex(a::PolyCoeffs{<:PolyRingElem}, i::Int)
    return coeff(a.f, i)
 end
@@ -1204,10 +1204,10 @@ end
 function shift_left!(z::PolyRingElem{T}, x::PolyRingElem{T}, n::Int) where {T<:RingElement}
   len = length(x) + n
   fit!(z, len)
-  for i in 0:length(x)-1
+  for i in 0:(length(x) - 1)
     z = setcoeff!(z, i + n, coeff(x, i))
   end
-  for i in 0:n-1
+  for i in 0:(n - 1)
     z = setcoeff!(z, i, zero(coefficient_ring(z)))
   end
   set_length!(z, len)

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -1210,7 +1210,7 @@ function shift_left!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where {
   len = length(x) + n
   fit!(z, len)
   for i in (length(x) - 1):-1:0
-    z = setcoeff!(z, i + n, coeff(x, i))
+    z = setcoeff!(z, i + n, deepcopy(coeff(x, i)))
   end
   for i in 0:(n - 1)
     z = setcoeff!(z, i, zero(coefficient_ring(z)))
@@ -1238,7 +1238,7 @@ function shift_right!(z::PolynomialElem{T}, x::PolynomialElem{T}, n::Int) where 
   len = max(0, length(x) - n)
   fit!(z, len)
   for i in 0:(len - 1)
-    z = setcoeff!(z, i, coeff(x, i + n))
+    z = setcoeff!(z, i, deepcopy(coeff(x, i + n)))
   end
   set_length!(z, len)
   return z

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -530,7 +530,9 @@ export set_valuation!
 export setcoeff!
 export setpermstyle
 export shift_left
+export shift_left!
 export shift_right
+export shift_right!
 export similarity!
 export size
 export snf


### PR DESCRIPTION
... and also fixes a bug in the current `shift_left` and `shift_right`.