### PR TITLE
chore: Bump version to 0.44.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.44.10"
+version = "0.44.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
To release the following PRs:
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2042
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2043