### PR TITLE
Implement conj & comm for matrices

### DIFF
--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -289,6 +289,17 @@ end
 
 ###############################################################################
 #
+#   Convenience
+#
+###############################################################################
+
+# allow conj and comm also on matrices elements -- of course this may fail when
+# trying to invert things
+conj(x::MatElem, y::MatElem) = inv(y)*x*y
+comm(x::MatElem, y::MatElem) = inv(y*x)*x*y
+
+###############################################################################
+#
 #   Scalar for broadcasting
 #
 ###############################################################################

--- a/test/Groups-test.jl
+++ b/test/Groups-test.jl
@@ -1,3 +1,20 @@
 include("generic/YoungTabs-test.jl")
 include("generic/Perm-test.jl")
 include("generic/PermGroupAPI-test.jl")
+
+@testset "Convenience methods for comm and conj" begin
+   # square and invertible
+   m = matrix(ZZ, [1 -1 ; 0 1])
+   @test conj(m, m) == m
+   @test is_one(comm(m, m))
+
+   # square but not invertible
+   m2 = matrix(ZZ, [1 -1 ; 0 0])
+   @test_throws ErrorException conj(m, m2)
+   @test_throws ErrorException comm(m, m2)
+
+   # not square
+   m3 = matrix(ZZ, [1 2 3; 4 5 6])
+   @test_throws DomainError conj(m, m3)
+   @test_throws ErrorException comm(m, m3)
+end


### PR DESCRIPTION
When doing experimental math on matrices and matrix groups these are
very handy. E.g. while trying to understand how certain matrices act
on each / what their commutators are, it can be cumbersome to first
wrap them into matrix groups. Notably doing that requires OSCAR, and
when I use matrices over universal polynomial rings I even run into
errors there are as we do not support mapping those to GAP just yet.
