### PR TITLE
Add `falling_factorial`

### DIFF
--- a/docs/src/ring.md
+++ b/docs/src/ring.md
@@ -248,3 +248,13 @@ getindex(a::Fac, b)
 setindex!(a::Fac{Int}, c::Int, b::Int)
 ```
 
+## Miscellaneous
+
+There are some miscellaneous functions for rings to ease up certain computations.
+
+```@docs
+falling_factorial
+rising_factorial
+rising_factorial2
+```
+

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -216,6 +216,7 @@ export extended_weak_popov_with_transform
 export exterior_power
 export factor
 export factor_squarefree
+export falling_factorial
 export fflu
 export fflu!
 export find_pivot_popov

--- a/src/generic/Misc/Rings.jl
+++ b/src/generic/Misc/Rings.jl
@@ -29,6 +29,29 @@ function root(a::RingElem, n::Int)
 end
 
 @doc raw"""
+    falling_factorial(x::RingElement, n::Integer)
+
+Return the falling factorial of $x$, i.e. $x(x - 1)(x - 2)\cdots (x - n + 1)$.
+If $n < 0$ we throw a `DomainError()`.
+
+# Examples
+
+```jldoctest
+julia> R, x = ZZ[:x];
+
+julia> falling_factorial(x, 1)
+x
+
+julia> falling_factorial(x, 2)
+x^2 - x
+
+julia> falling_factorial(4, 2)
+12
+```
+"""
+falling_factorial(x::RingElement, n::Integer) = (-1)^n*rising_factorial(-x, n)
+
+@doc raw"""
     rising_factorial(x::RingElement, n::Integer)
 
 Return the rising factorial of $x$, i.e. $x(x + 1)(x + 2)\cdots (x + n - 1)$.

--- a/src/generic/exports.jl
+++ b/src/generic/exports.jl
@@ -26,6 +26,7 @@ export exp_gcd
 export exponent
 export exponent_vector
 export exponent_word
+export falling_factorial
 export finish
 export fit!
 export function_field


### PR DESCRIPTION
While playing around with modular polynomial interpolation I noticed that we don't have a `falling_factorial` method.