### PR TITLE
Fix stack overflow when constructing non-implemented views

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -464,30 +464,31 @@ function getindex(M::MatElem, rows::AbstractVector{Int}, j::Int)
    return A
  end
 
-getindex(M::MatElem,
-         rows::Union{Int,Colon,AbstractVector{Int}},
-         cols::Union{Int,Colon,AbstractVector{Int}}) = M[_to_indices(M, rows, cols)...]
+getindex(M::MatElem, ::Colon, cols) = getindex(M, 1:nrows(M), cols)
 
-function _to_indices(x, rows, cols)
-   if rows isa Integer
-      rows = rows
-   elseif rows isa Colon
-      rows = 1:nrows(x)
-   end
-   if cols isa Integer
-      cols = cols
-   elseif cols isa Colon
-      cols = 1:ncols(x)
-   end
-   (rows, cols)
-end
+getindex(M::MatElem, rows, ::Colon) = getindex(M, rows, 1:ncols(M))
+
+getindex(M::MatElem, ::Colon, ::Colon) = getindex(M, 1:nrows(M), 1:ncols(M))
+
 
 sub(M::MatElem, r::AbstractVector{<:Integer}, c::AbstractVector{<:Integer}) = M[r, c]
 
-function Base.view(M::MatElem,
-         rows::Union{Int,Colon,AbstractVector{Int}},
-         cols::Union{Int,Colon,AbstractVector{Int}})
-   return view(M, _to_indices(M, rows, cols)...)
+# fallback method that converts Colons to UnitRanges
+function Base.view(M::MatElem, rows, cols)
+   # indirection to avoid ambiguities
+   return _view(M, rows, cols)
+end
+
+function _view(M::MatElem, ::Colon, cols)
+   return view(M, 1:nrows(M), cols)
+end
+
+function _view(M::MatElem, rows, ::Colon)
+   return view(M, rows, 1:ncols(M))
+end
+
+function _view(M::MatElem, ::Colon, ::Colon)
+   return view(M, 1:nrows(M), 1:ncols(M))
 end
 
 Base.firstindex(M::MatrixElem{T}, i::Int) where T <: NCRingElement = 1


### PR DESCRIPTION
This changes the stackoverflow observed e.g. in https://github.com/Nemocas/AbstractAlgebra.jl/issues/1718 to a MethodError.

This stackoverflow currently happens for all sensible inputs to `view` that are not implemented, in particular
- point views of AA's `Generic.MatSpaceElem` (x-ref https://github.com/Nemocas/AbstractAlgebra.jl/pull/2048)
- point views of Nemo mats
- views of Nemo mats where any arg is a `AbstractVector{Int}` that is not a `AbstractUnitRange{Int}`

I implemented this via a method indirection to not create any ambiguities with existing `view` methods that handle `::Colon` args themselves.