### PR TITLE
Fix a JET issue in `iterate(::ProductIterator)`

### DIFF
--- a/src/misc/ProductIterator.jl
+++ b/src/misc/ProductIterator.jl
@@ -89,9 +89,10 @@ function Base.iterate(p::ProductIterator, (xs, states))
          # all previous entries had reached end-of-iteration, which therefore need
          # to be restarted; we don't do it in the `x_st === nothing` branch to not do
          # useless work when p's iteration is over
-         xs[j], states[j] = iterate(iters[j])
-                            # !== nothing, otherwise first iteration of p would have
-                            # yielded nothing (if p.iters are "well" behaved...)
+         xj_st = iterate(iters[j])
+         @assert !isnothing(xj_st) # otherwise first iteration of p would have
+                                   # yielded nothing (if p.iters are "well" behaved...)
+         xs[j], states[j] = xj_st
       end
       xs[i], states[i] = x_st
       break


### PR DESCRIPTION
Resolves the following issue reported by JET:
```julia
julia> @report_opt collect(AbstractAlgebra.ProductIterator([1:2, 1:3]))
═════ 2 possible errors found ═════
┌ collect(itr::AbstractAlgebra.ProductIterator{UnitRange{Int64}, 1}) @ Base ./array.jl:716
│┌ _collect(cont::UnitRange{…}, itr::AbstractAlgebra.ProductIterator{…}, ::Base.HasEltype, isz::Base.HasLength) @ Base ./array.jl:722
││┌ copyto!(dest::Vector{Vector{Int64}}, src::AbstractAlgebra.ProductIterator{UnitRange{Int64}, 1}) @ Base ./abstractarray.jl:939
│││┌ iterate(p::AbstractAlgebra.ProductIterator{UnitRange{Int64}, 1}, ::Tuple{Vector{Int64}, Vector{Int64}}) @ AbstractAlgebra /home/lgoe/code/julia/AbstractAlgebra.jl/src/misc/ProductIterator.jl:92
││││┌ indexed_iterate(I::Nothing, i::Int64) @ Base ./tuple.jl:162
│││││ runtime dispatch detected: iterate(I::Nothing)
││││└────────────────────
││││┌ indexed_iterate(I::Nothing, i::Int64, state::Int64) @ Base ./tuple.jl:167
│││││ runtime dispatch detected: iterate(I::Nothing, state::Int64)
││││└────────────────────
```