### PR TITLE
Improve univariate conversion

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1133,6 +1133,35 @@ function to_univariate(R::PolyRing{T}, p::MPolyRingElem{T}) where T <: RingEleme
 end
 
 @doc raw"""
+    is_univariate_with_data(p::MPolyRingElem)
+
+Returns `(true,i)` if $p$ is a univariate polynomial in the `i`-th variable
+of its parent i.e. involves exactly one variable. If $p$ is constant,
+`(true,0)` is returned. Otherwise `(false,0)` is returned. The result
+depends on the terms of the polynomial, not simply on the number of
+variables in the polynomial ring.
+"""
+function is_univariate_with_data(p::MPolyRingElem{T}) where T <: RingElement
+   if is_constant(p)
+      return (true, 0)
+   end
+   var = -1
+   for v in exponent_vectors(p)
+      n = count(x -> x != 0, v)
+      if n > 1
+         return (false, 0)
+      elseif n == 1
+         if var == -1
+            var = findfirst(x -> x != 0, v)
+         elseif v[var] == 0
+            return (false, 0)
+         end
+      end
+   end
+   return (true, var)
+end
+
+@doc raw"""
     is_univariate(p::MPolyRingElem)
 
 Returns `true` if $p$ is a univariate polynomial, i.e. involves at most one
@@ -1141,23 +1170,7 @@ otherwise. The result depends on the terms of the polynomial, not simply on
 the number of variables in the polynomial ring.
 """
 function is_univariate(p::MPolyRingElem{T}) where T <: RingElement
-   if is_constant(p)
-      return true
-   end
-   var = -1
-   for v in exponent_vectors(p)
-      n = count(x -> x != 0, v)
-      if n > 1
-         return false
-      elseif n == 1
-         if var == -1
-            var = findfirst(x -> x != 0, v)
-         elseif v[var] == 0
-            return false
-         end
-      end
-   end
-   return true
+   return is_univariate_with_data(p)[1]
 end
 
 @doc raw"""

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1130,6 +1130,29 @@ function to_univariate(R::PolyRing{T}, p::MPolyRingElem{T}) where T <: RingEleme
 end
 
 @doc raw"""
+    to_univariate(p::MPolyRingElem)
+
+Assuming the polynomial $p$ is actually a univariate polynomial in the
+variable $x$, convert the polynomial to a univariate polynomial in a
+univariate polynomial ring over the same base ring in the variable $x$.
+If $p$ is constant, it is considered to be a polynomial in the first
+variable of its parent. An exception is raised if the polynomial $p$
+involves more than one variable or if its parent has no variables.
+"""
+function to_univariate(p::MPolyRingElem)
+   S = parent(p)
+   iszero(ngens(S)) && error("Parent has no variables.")
+   is_uni, var = is_univariate_with_data(p)
+   is_uni || error("Polynomial is not univariate.")
+   if iszero(var)
+      var = 1
+   end
+   x = symbols(S)[var]
+   R, _ = base_ring(S)[x]
+   return to_univariate(R, p)
+end
+
+@doc raw"""
     is_univariate_with_data(p::MPolyRingElem)
 
 Returns `(true,i)` if $p$ is a univariate polynomial in the `i`-th variable

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1123,9 +1123,6 @@ $R$. An exception is raised if the polynomial $p$ involves more than one
 variable.
 """
 function to_univariate(R::PolyRing{T}, p::MPolyRingElem{T}) where T <: RingElement
-   if !is_univariate(p)
-      error("Can only convert univariate polynomials of type MPoly.")
-   end
    if is_constant(p)
       return R(leading_coefficient(p))
    end

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1155,30 +1155,30 @@ end
 @doc raw"""
     is_univariate_with_data(p::MPolyRingElem)
 
-Returns `(true,i)` if $p$ is a univariate polynomial in the `i`-th variable
+Returns `(true, i)` if $p$ is a univariate polynomial in the `i`-th variable
 of its parent i.e. involves exactly one variable. If $p$ is constant,
-`(true,0)` is returned. Otherwise `(false,0)` is returned. The result
+`(true, 0)` is returned. Otherwise `(false, 0)` is returned. The result
 depends on the terms of the polynomial, not simply on the number of
 variables in the polynomial ring.
 """
 function is_univariate_with_data(p::MPolyRingElem{T}) where T <: RingElement
    if is_constant(p)
-      return (true, 0)
+      return true, 0
    end
    var = -1
    for v in exponent_vectors(p)
       n = count(x -> x != 0, v)
       if n > 1
-         return (false, 0)
+         return false, 0
       elseif n == 1
          if var == -1
             var = findfirst(x -> x != 0, v)
          elseif v[var] == 0
-            return (false, 0)
+            return false, 0
          end
       end
    end
-   return (true, var)
+   return true, var
 end
 
 @doc raw"""

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -343,6 +343,7 @@ export is_trivial
 export is_unicode_allowed
 export is_unit
 export is_univariate
+export is_univariate_with_data
 export is_upper_triangular
 export is_valid
 export is_weak_popov

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -932,6 +932,8 @@ end
 
 is_univariate(p::UnivPoly) = is_univariate(data(p))
 
+is_univariate_with_data(p::UnivPoly) = is_univariate_with_data(data(p))
+
 is_univariate(R::UniversalPolyRing) = is_univariate(mpoly_ring(R))
 
 function coefficients_of_univariate(p::UnivPoly, check_univariate::Bool=true)

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -930,6 +930,8 @@ function to_univariate(R::AbstractAlgebra.PolyRing{T}, p::UnivPoly{T}) where {T 
    return to_univariate(R, data(p))
 end
 
+to_univariate(p::UnivPoly) = to_univariate(data(p))
+
 is_univariate(p::UnivPoly) = is_univariate(data(p))
 
 is_univariate_with_data(p::UnivPoly) = is_univariate_with_data(data(p))

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -160,6 +160,7 @@ import ..AbstractAlgebra: is_terse
 import ..AbstractAlgebra: is_trivial
 import ..AbstractAlgebra: is_unit
 import ..AbstractAlgebra: is_univariate
+import ..AbstractAlgebra: is_univariate_with_data
 import ..AbstractAlgebra: is_zero_divisor
 import ..AbstractAlgebra: is_zero_divisor_with_annihilator
 import ..AbstractAlgebra: isreduced_form

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1553,6 +1553,11 @@ end
       @test zero(R_univ) == to_univariate(R_univ, zero(R))
       @test one(R_univ) == to_univariate(R_univ, one(R))
 
+      p = to_univariate(vars_R[1])
+      Rp = parent(p)
+
+      @test string(symbols(Rp)[1]) == var_names[1]
+
       for iter in 1:10
          f = zero(R)
          f_univ = zero(R_univ)

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -452,6 +452,10 @@ end
    @test !is_univariate(x^3 + 3x + y + 1)
    @test !is_univariate(x^3 + 3x + y)
    @test !is_univariate(y^4 + 3x + 1)
+
+   @test is_univariate_with_data(y) == (true, 2)
+   @test is_univariate_with_data(R()) == (true, 0)
+   @test is_univariate_with_data(x + y) == (false, 0)
 end
 
 

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -1066,6 +1066,10 @@ end
       @test !is_univariate(g)
       @test is_univariate(h)
 
+      @test is_univariate_with_data(y) == (true, 2)
+      @test is_univariate_with_data(S()) == (true, 0)
+      @test is_univariate_with_data(x + y) == (false, 0)
+
       f1 = to_univariate(U, f)
       h1 = to_univariate(U, h)
 

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -1072,6 +1072,10 @@ end
       @test length(f) == length(f1)
       @test length(h) == length(h1)
 
+      p = to_univariate(x)
+      Rp = parent(p)
+      @test symbols(Rp)[1] == :x
+
       @test coefficients_of_univariate(f) == [R(4), R(1), R(2), R(3)]
       @test coefficients_of_univariate(h) == [R(1), R(2), R(3)]
    end


### PR DESCRIPTION
Currently, `is_univariate` already computes the index of the variable involved in the respective polynomial. It can be useful to obtain this information to create a fitting univariate polynomial ring where the symbol of the variable matches the variable symbol of the original multivariate polynomial. In fact this could be combined with `to_univariate`.