### PR TITLE
Fix `swap_cols!` for `Matrix{T}`

### DIFF
--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -112,7 +112,7 @@ end
 function swap_cols!(a::Matrix{T}, i::Int, j::Int) where T <: NCRingElement
    if i != j
       for k = 1:nrows(a)
-         a[k, i], a[k, j] = a[k, i], a[k, j]
+         a[k, i], a[k, j] = a[k, j], a[k, i]
       end
    end
    return a


### PR DESCRIPTION
This is also in PR #2051 (where we discovered the issue) but as that seems stalled let's apply this fix right now.