### PR TITLE
Remove bad generic sqrt method

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -179,15 +179,6 @@ function Base.sqrt(a::FieldElem; check::Bool=true)
   error("Element $a does not have a square root")
 end
 
-# assumes the existence of sqrt without check argument for input
-function Base.sqrt(a::RingElem; check::Bool=true)
-  s = sqrt(a)
-  if check
-    s != a^2 && error("Element $a does not have a square root")
-  end
-  return s
-end  
-
 # assumes the existence of is_square and sqrt for input  
 function is_square_with_sqrt(a::RingElem)
   if is_square(a)


### PR DESCRIPTION
Method dispatch does not take keyword arguments into account. Therefore the kind of dispatch used by this method is risky and can result in an infinite recursion.

Discovered while looking at test failures in PR #2051