### PR TITLE
Fix weird return type in evaluate via call syntax

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3348,17 +3348,13 @@ function (a::MPoly{T})(vals::Union{NCRingElem, RingElement}...) where T <: RingE
    powers = [Dict{Int, Any}() for i in 1:length(vals)]
    # First work out types of products
    r = R()
-   c = zero(R)
-   U = Vector{Any}(undef, length(vals))
    for j = 1:length(vals)
       W = typeof(vals[j])
       if ((W <: Integer && W !== BigInt) ||
           (W <: Rational && W !== Rational{BigInt}))
-         c = c*zero(W)
-         U[j] = parent(c)
+         r = r*zero(W)
       else
-         U[j] = parent(vals[j])
-         c = c*zero(parent(vals[j]))
+         r = r*zero(parent(vals[j]))
       end
    end
    cvzip = zip(coefficients(a), exponent_vectors(a))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1322,6 +1322,10 @@ end
    P,(x,y) = polynomial_ring(F, [:x, :y])
    @test x(t,y) == t
    @test x == gen(P, 1) # evaluation used to modify the polynomial
+
+   # Issue #1219
+   Qx, (x, y) = QQ["x", "y"];
+   @test typeof(zero(Qx)(x, y)) == typeof(one(Qx)(x, y)) == typeof((x+y)(x, y))
 end
 
 @testset "Generic.MPoly.valuation" begin


### PR DESCRIPTION
Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/1219.

That issue talks about *the new evaluate code*, but since that hasn't happened in 2+ years, maybe we can just add this bandaid for the meantime