### PR TITLE
Move parts of Oscar's `MoveToAbstractAlgebra.jl` over

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -2688,6 +2688,25 @@ end
 ###############################################################################
 
 """
+    is_alternating(M::MatElem)
+
+Return whether the form corresponding to the matrix `M` is alternating,
+i.e. `M = -transpose(M)` and `M` has zeros on the diagonal.
+Return `false` if `M` is not a square matrix.
+"""
+function is_alternating(M::MatrixElem)
+  n = nrows(M)
+  n == ncols(M) || return false
+  for i in 1:n
+    is_zero_entry(M, i, i) || return false
+    for j in (i + 1):n
+      M[i, j] == -M[j, i] || return false
+    end
+  end
+  return true
+end
+
+"""
     is_skew_symmetric(M::MatrixElem)
 
 Return `true` if the given matrix is skew symmetric with respect to its main

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -2688,20 +2688,16 @@ end
 ###############################################################################
 
 """
-    is_alternating(M::MatElem)
+    is_alternating(M::MatrixElem)
 
 Return whether the form corresponding to the matrix `M` is alternating,
 i.e. `M = -transpose(M)` and `M` has zeros on the diagonal.
 Return `false` if `M` is not a square matrix.
 """
 function is_alternating(M::MatrixElem)
-  n = nrows(M)
-  n == ncols(M) || return false
-  for i in 1:n
+  is_skew_symmetric(M) || return false
+  for i in 1:nrows(M)
     is_zero_entry(M, i, i) || return false
-    for j in (i + 1):n
-      M[i, j] == -M[j, i] || return false
-    end
   end
   return true
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -282,6 +282,7 @@ export inverse_mat
 export invmod
 export iroot
 export is_abelian
+export is_alternating
 export is_associated
 export is_compatible
 export is_constant

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -27,7 +27,8 @@ var(R::LaurentPolyWrapRing) = var(R.polyring)
 
 symbols(R::LaurentPolyWrapRing) = symbols(R.polyring)
 
-number_of_variables(R::LaurentPolyWrapRing) = number_of_variables(R.polyring)
+number_of_variables(R::LaurentPolyWrapRing) = 1
+number_of_generators(R::LaurentPolyWrapRing) = number_of_variables(R)
 
 characteristic(R::LaurentPolyWrapRing) = characteristic(R.polyring)
 

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -34,6 +34,15 @@ function is_exact_type(a::Type{S}) where {T <: FieldElement, U <: Union{PolyRing
    return is_exact_type(T)
 end
 
+function symbols(a::RationalFunctionField)
+  S = a.S
+  if S isa Symbol
+    return [S]
+  else
+    return S
+  end
+end
+
 ###############################################################################
 #
 #   Constructors

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1641,6 +1641,23 @@ end
    @test is_symmetric(M + transpose(M))
 end
 
+@testset "Generic.Mat.is_alternating" begin
+
+  @testset "Test is_alternating for $R" for R in [GF(2), GF(3), ZZ, QQ]
+     @test is_alternating(matrix(R, [0 1 ; -1 0]))
+     @test !is_alternating(matrix(R, [1 1 ; -1 1]))
+     @test !is_alternating(matrix(R, [1 0 ; 1 1]))
+     @test !is_alternating(matrix(R, [0 1 0 ; -1 0 0]))
+  end
+
+  # Tests over noncommutative ring
+  R = matrix_ring(ZZ, 2)
+  S = matrix_space(R, 2, 2)
+  M = rand(S, -10:10)
+
+  @test is_alternating(M - transpose(M))
+end
+
 @testset "Generic.Mat.is_skew_symmetric" begin
 
    @testset "Test is_skew_symmetric for $R" for R in [GF(2), GF(3), ZZ, QQ]


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4867.

This is not breaking for any users of AbstractAlgebra.jl, just for Oscar.jl itself (due to the existence of multiple methods with exact signature). Users of Oscar.jl should experience no difference.