### PR TITLE
doctests: add verbose output, disable Matrix-Strassen doctest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,7 @@ jobs:
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
             using Documenter
+            include("docs/documenter_helpers.jl")
             using AbstractAlgebra
             DocMeta.setdocmeta!(AbstractAlgebra, :DocTestSetup, AbstractAlgebra.doctestsetup(); recursive = true)
             doctest(AbstractAlgebra)'

--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -1,0 +1,12 @@
+# this function is slightly more specific than the one from documenter, print the corresponding code location
+# calls the original function via invoke and prints a timing for the doctest
+function Documenter.eval_repl(block, sandbox::Module, meta::Dict, doc::Documenter.Document, page)
+  src_lines = Documenter.find_block_in_file(block.code, meta[:CurrentFile])
+  # skip stats if there was a failure
+  if length(doc.internal.errors) > 0
+    invoke(Documenter.eval_repl, Tuple{Any,Any,Dict,Documenter.Document,Any}, block, sandbox, meta, doc, page)
+  else
+    println("page: $(Documenter.locrepr(meta[:CurrentFile], src_lines))")
+    @time invoke(Documenter.eval_repl, Tuple{Any,Any,Dict,Documenter.Document,Any}, block, sandbox, meta, doc, page)
+  end
+end

--- a/src/Matrix-Strassen.jl
+++ b/src/Matrix-Strassen.jl
@@ -1,3 +1,6 @@
+# FIXME: the doctest below is disabled because it takes way too long,
+# especially on macOS, see https://github.com/Nemocas/AbstractAlgebra.jl/issues/2083
+
 """
 Provides generic asymptotically fast matrix methods:
   - `mul` and `mul!` using the Strassen scheme
@@ -12,7 +15,7 @@ The speedup depends on the ring and the entry sizes.
 
 # Examples
 
-```jldoctest
+```julia
 julia> m = matrix(ZZ, rand(-10:10, 1000, 1000));
 
 julia> n1 = similar(m); n2 = similar(m); n3 = similar(m);


### PR DESCRIPTION
see https://github.com/Nemocas/AbstractAlgebra.jl/issues/2083 for details
cc: @lgoettgens

I can remove the documenter helper again if requested but it makes it a lot easier to debug such issues.