### PR TITLE
Support function call syntax for evaluate for more rings

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -616,20 +616,28 @@ end
 #
 ##############################################################################
 
-function evaluate(f::FracElem{T}, V::Vector{U}) where {T <: RingElement, U <: RingElement}
+function evaluate(f::FracElem, V::Vector{<:RingElement})
     return evaluate(numerator(f), V)//evaluate(denominator(f), V)
 end
   
-function evaluate(f::FracElem{T}, v::U) where {T <: RingElement, U <: RingElement}
+function evaluate(f::FracElem, v::RingElement)
     return evaluate(numerator(f), v)//evaluate(denominator(f), v)
 end
 
-function evaluate(f::FracElem{T}, v::U) where {T <: PolyRingElem, U <: Integer}
+function evaluate(f::FracElem{<:PolyRingElem}, v::Integer)
     return evaluate(numerator(f), v)//evaluate(denominator(f), v)
 end
 
-function evaluate(f::FracElem{T}, vars::Vector{Int}, vals::Vector{U}) where {T <: RingElement, U <: RingElement}
-     return evaluate(numerator(f), vars, vals)//evaluate(denominator(f), vars, vals)
+function evaluate(f::FracElem, vars::Vector{Int}, vals::Vector{<:RingElement})
+    return evaluate(numerator(f), vars, vals)//evaluate(denominator(f), vars, vals)
+end
+
+function (a::FracElem)(val::RingElement)
+   return evaluate(a, val)
+end
+
+function (a::FracElem)(vals::RingElement...)
+   return evaluate(a, [vals...])
 end
 
 ###############################################################################

--- a/src/generic/FactoredFraction.jl
+++ b/src/generic/FactoredFraction.jl
@@ -403,7 +403,7 @@ end
 #
 ##############################################################################
 
-function evaluate(f::FactoredFracFieldElem{T}, v::Vector{U}) where {T <: RingElement, U <: RingElement}
+function evaluate(f::FactoredFracFieldElem, v::Vector{<:RingElement})
     z = evaluate(unit(f), v)
     for (b, e) in f
         z *= evaluate(b, v)^e
@@ -411,12 +411,20 @@ function evaluate(f::FactoredFracFieldElem{T}, v::Vector{U}) where {T <: RingEle
     return z
 end
 
-function evaluate(f::FactoredFracFieldElem{T}, v::U) where {T <: RingElement, U <: RingElement}
+function evaluate(f::FactoredFracFieldElem, v::RingElement)
     z = evaluate(unit(f), v)
     for (b, e) in f
         z *= evaluate(b, v)^e
     end
     return z
+end
+
+function (a::FactoredFracFieldElem)(val::RingElement)
+   return evaluate(a, val)
+end
+
+function (a::FactoredFracFieldElem)(vals::RingElement...)
+   return evaluate(a, [vals...])
 end
 
 ##############################################################################

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -402,12 +402,20 @@ end
 #
 ##############################################################################
 
-function evaluate(f::RationalFunctionFieldElem{T, U}, v::V) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}, V <: RingElement}
+function evaluate(f::RationalFunctionFieldElem, v::RingElement)
     return evaluate(numerator(f), v)//evaluate(denominator(f), v)
 end
 
-function evaluate(f::RationalFunctionFieldElem{T, U}, v::Vector{V}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}, V <: RingElement}
+function evaluate(f::RationalFunctionFieldElem, v::Vector{<:RingElement})
    return evaluate(numerator(f), v)//evaluate(denominator(f), v)
+end
+
+function (a::RationalFunctionFieldElem)(val::RingElement)
+   return evaluate(a, val)
+end
+
+function (a::RationalFunctionFieldElem)(vals::RingElement...)
+   return evaluate(a, [vals...])
 end
 
 ###############################################################################

--- a/test/generic/FactoredFraction-test.jl
+++ b/test/generic/FactoredFraction-test.jl
@@ -45,15 +45,27 @@ end
 end
 
 @testset "Generic.FactoredFracFieldElem.ZZ.evaluate" begin
+    # univariate
     Zx, x = polynomial_ring(ZZ, "x")
     F = FactoredFractionField(Zx)
     x = F(x)
-    @test evaluate(x//(x+1), 2//3) == 2//5
 
+    f = x//(x+1)
+    @test f isa Generic.FactoredFracFieldElem
+
+    @test evaluate(f, 2//3) == 2//5
+    @test f(2//3) == 2//5
+
+    # multivariate
     Zxy, (x, y) = polynomial_ring(ZZ, ["x", "y"])
     F = FactoredFractionField(Zxy)
     (x, y) = (F(x), F(y))
-    @test evaluate(x//(x+y)^2, [1//3, 1//2]) == 12//25
+
+    f = x//(x+y)^2
+    @test f isa Generic.FactoredFracFieldElem
+
+    @test evaluate(f, [1//3, 1//2]) == 12//25
+    @test f(1//3, 1//2) == 12//25
 end
 
 @testset "Generic.FactoredFracFieldElem.ZZ.valuation" begin

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -281,17 +281,24 @@ end
 end
 
 @testset "Generic.FracFieldElem.evaluate" begin
+   # univariate
    R, = residue_ring(ZZ, 5)
    S, x = polynomial_ring(R, "x")
 
    f = (x^2 + 2)//(x + 1)
+   @test f isa Generic.FracFieldElem
 
    @test evaluate(f, 1) == R(4)
    @test evaluate(f, R(1)) == R(4)
 
+   @test f(1) == R(4)
+   @test f(R(1)) == R(4)
+
+   # multivariate
    R, (x, y) = polynomial_ring(ZZ, ["x", "y"])
 
    f = (x^2 + y)//(y + 2)
+   @test f isa Generic.FracFieldElem
 
    @test evaluate(f, [1, 2]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
@@ -299,16 +306,24 @@ end
    @test evaluate(f, [2, 1], [ZZ(2), ZZ(1)]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [1], [ZZ(2)]) == (y + 4)//(y + 2)
 
+   @test f(1, 2) == ZZ(3)//ZZ(4)
+   @test f(ZZ(1), ZZ(2)) == ZZ(3)//ZZ(4)
+
+   # universal
    R = universal_polynomial_ring(ZZ)
    x, y = gens(R, [:x, :y])
 
    f = (x^2 + y)//(y + 2)
+   @test f isa Generic.FracFieldElem
 
    @test evaluate(f, [1, 2]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [1, 2], [ZZ(1), ZZ(2)]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [2, 1], [ZZ(2), ZZ(1)]) == ZZ(3)//ZZ(4)
    @test evaluate(f, [1], [ZZ(2)]) == (y + 4)//(y + 2)
+
+   @test f(1, 2) == ZZ(3)//ZZ(4)
+   @test f(ZZ(1), ZZ(2)) == ZZ(3)//ZZ(4)
 end
 
 @testset "Generic.FracFieldElem.derivative" begin

--- a/test/generic/RationalFunctionField-test.jl
+++ b/test/generic/RationalFunctionField-test.jl
@@ -503,20 +503,28 @@ end
 
 @testset "Generic.RationalFunctionField.evaluate" begin
    # Univariate
-   R, x = polynomial_ring(QQ, "x")
+   R, x = rational_function_field(QQ, "x")
 
    f = (x^2 + 2)//(x + 1)
+   @test f isa Generic.RationalFunctionFieldElem
 
    @test evaluate(f, 1) == QQ(3, 2)
    @test evaluate(f, QQ(2)) == 2
 
+   @test f(1) == QQ(3, 2)
+   @test f(QQ(2)) == 2
+
    # Multivariate
-   R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+   R, (x, y) = rational_function_field(QQ, ["x", "y"])
 
    f = (x^2 + 2)//(y + 1)
+   @test f isa Generic.RationalFunctionFieldElem
 
    @test evaluate(f, [1, 2]) == 1
    @test evaluate(f, [QQ(2), QQ(1)]) == 3
+
+   @test f(1, 2) == 1
+   @test f(QQ(2), QQ(1)) == 3
 end
 
 @testset "Generic.RationalFunctionField.derivative" begin


### PR DESCRIPTION
Now rational function fields, fraction fields and factored fraction fields allow using "function call syntax" as a shorthand for `evaluate`.

This also resolves an issue in the RationalFunctionField tests for `evaluate` which did not actually work as intended, as the elements being evaluated action ended up being of type `FracElem`.