### PR TITLE
Alias `ispositive`/`isnegative` in recent enough julia versions

### DIFF
--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -15,6 +15,11 @@
 @alias is_zero iszero
 @alias number_of_digits ndigits
 
+if VERSION >= v"1.13.0-DEV.534" # https://github.com/JuliaLang/julia/pull/53677
+  @alias is_positive ispositive
+  @alias is_negative isnegative
+end
+
 
 # alternative names for some functions from LinearAlgebra
 # we don't use the `@alias` macro here because we provide custom

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -44,9 +44,10 @@ canonical_unit(a::AbstractFloat) = iszero(a) ? copysign(one(a), a) : a
 
 characteristic(a::Floats{T}) where T <: AbstractFloat = 0
 
-is_negative(n::T) where T<:Real = n < zero(T)
-
-is_positive(n::T) where T<:Real = n > zero(T)
+if VERSION < v"1.13.0-DEV.534" # https://github.com/JuliaLang/julia/pull/53677
+  is_negative(n::T) where T<:Real = n < zero(T)
+  is_positive(n::T) where T<:Real = n > zero(T)
+end
 
 ###############################################################################
 #


### PR DESCRIPTION
We just ran into this in https://github.com/oscar-system/Oscar.jl/pull/4908#discussion_r2097393871 (on nightly), so better to just alias them on available julia versions.