### PR TITLE
Add `image` and `preimage` to generic Map types

### DIFF
--- a/src/generic/Map.jl
+++ b/src/generic/Map.jl
@@ -16,7 +16,11 @@ map1(f::CompositeMap) = f.map1
 map2(f::CompositeMap) = f.map2
 
 function (f::CompositeMap{D, C})(a) where {D, C}
-   return f.map2(f.map1(a))::elem_type(C)
+  return image(f, a)::elem_type(C)
+end
+
+function image(f::Generic.CompositeMap{D, C}, a) where {D, C}
+  return f.map2(f.map1(a))::elem_type(C)
 end
 
 function preimage(f::Generic.CompositeMap{D, C}, a) where {D, C}
@@ -106,10 +110,13 @@ codomain(f::FunctionalMap) = f.codomain
 image_fn(f::FunctionalMap) = f.image_fn
 
 function (f::FunctionalMap{D, C})(a) where {D, C}
-   parent(a) != domain(f) && throw(DomainError(f))
-   return image_fn(f)(a)::elem_type(C)
+  return image(f, a)::elem_type(C)
 end
 
+function image(f::FunctionalMap{D, C}, a) where {D, C}
+  parent(a) != domain(f) && throw(DomainError(f))
+  return image_fn(f)(a)::elem_type(C)
+end
 
 function Base.show(io::IO, M::FunctionalMap)
    if is_terse(io)
@@ -164,7 +171,11 @@ map1(f::FunctionalCompositeMap) = f.map1
 map2(f::FunctionalCompositeMap) = f.map2
 
 function (f::FunctionalCompositeMap{D, C})(a) where {D, C}
-   return image_fn(f)(a)::elem_type(C)
+  return image(f, a)::elem_type(C)
+end
+
+function image(f::FunctionalCompositeMap{D, C}, a) where {D, C}
+  return image_fn(f)(a)::elem_type(C)
 end
 
 function show(io::IO, M::FunctionalCompositeMap)

--- a/src/generic/MapWithInverse.jl
+++ b/src/generic/MapWithInverse.jl
@@ -19,8 +19,15 @@ image_map(f::MapWithSection) = f.map
 preimage_map(f::MapWithSection) = f.section # for convenience only
 section_map(f::MapWithSection) = f.section
 
-(f::MapWithSection{D, C})(a) where {D, C} = (f.map)(a)::elem_type(C)
+(f::MapWithSection{D, C})(a) where {D, C} = image(f, a)::elem_type(C)
 
+function preimage(f::MapWithSection{D, C}, a) where {D, C}
+  return inverse_fn(f)(a)::elem_type(D)
+end
+
+function image(f::MapWithSection{D, C}, a) where {D, C}
+  return image_fn(f)(a)::elem_type(C)
+end
 
 function Base.show(io::IO, M::MapWithSection)
    if is_terse(io)
@@ -64,7 +71,15 @@ retraction_map(f::MapWithRetraction) = f.retraction
 
 retraction_map(f::MapCache) = retraction_map(f.map)
 
-(f::MapWithRetraction{D, C})(a) where {D, C} = (f.map)(a)::elem_type(C)
+(f::MapWithRetraction{D, C})(a) where {D, C} = image(f, a)::elem_type(C)
+
+function preimage(f::MapWithRetraction{D, C}, a) where {D, C}
+  return inverse_fn(f)(a)::elem_type(D)
+end
+
+function image(f::MapWithRetraction{D, C}, a) where {D, C}
+  return image_fn(f)(a)::elem_type(C)
+end
 
 function Base.show(io::IO, M::MapWithRetraction)
    if is_terse(io)

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -138,6 +138,7 @@ import ..AbstractAlgebra: gens
 import ..AbstractAlgebra: get_cached!
 import ..AbstractAlgebra: hom
 import ..AbstractAlgebra: identity_matrix
+import ..AbstractAlgebra: image
 import ..AbstractAlgebra: image_fn
 import ..AbstractAlgebra: inflate
 import ..AbstractAlgebra: integral


### PR DESCRIPTION
This PR implements missing `image` and `preimage` functions (where possible) for generic Map types, as mentioned in #1446.