### PR TITLE
Don't use `inv` and `inv!` in ring conformance tests

### DIFF
--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -230,9 +230,11 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
       test_NCRing_interface(R; reps = reps)
 
       @testset "Basic functionality for commutative rings only" begin
-         @test isone(AbstractAlgebra.inv(one(R)))
-         test_mutating_op_like_neg(AbstractAlgebra.inv, inv!, one(R))
-         test_mutating_op_like_neg(AbstractAlgebra.inv, inv!, -one(R))
+         # FIXME: we can't expect general rings to support inv, not even for the one
+         # element, so don't test this
+         #@test isone(AbstractAlgebra.inv(one(R)))
+         #test_mutating_op_like_neg(AbstractAlgebra.inv, inv!, one(R))
+         #test_mutating_op_like_neg(AbstractAlgebra.inv, inv!, -one(R))
          for i in 1:reps
             a = generate_element(R)::T
             b = generate_element(R)::T


### PR DESCRIPTION
We can't expect general rings to support inv, not even for the ring's one element. These tests may be reactivated in a future version, e.g. if we add an `implements` trait.

Alternative to @HechtiDerLachs's PR #2077. May fix this "properly" in PR #1957 or a follow-up, but for now this is the obvious change to make.

@HechtiDerLachs of course you might run in further issues, let me know if that's the case.