### PR TITLE
feat: relax signature for map_coefficients

### DIFF
--- a/src/NCPoly.jl
+++ b/src/NCPoly.jl
@@ -667,7 +667,7 @@ _make_parent(g::T, p::NCPolyRingElem, cached::Bool) where {T} =
 
 function map_coefficients(g::T, p::NCPolyRingElem{<:NCRingElement};
                     cached::Bool = true,
-		    parent::NCPolyRing = _make_parent(g, p, cached)) where {T}
+		    parent = _make_parent(g, p, cached)) where {T}
    return _map(g, p, parent)
 end
 

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3280,7 +3280,7 @@ via the `cached` keyword argument.
 """
 function map_coefficients(g::T, p::PolyRingElem{<:RingElement};
                     cached::Bool = true,
-                    parent::PolyRing = _make_parent(g, p, cached)) where T
+                    parent = _make_parent(g, p, cached)) where T
    return _map(g, p, parent)
 end
 

--- a/test/generic/NCPoly-test.jl
+++ b/test/generic/NCPoly-test.jl
@@ -434,3 +434,14 @@ end
    @test_throws Exception dense_poly_ring_type(Char)
    @test_throws ArgumentError dense_poly_type(Char)
 end
+
+@testset "Generic.NCPoly.map_coefficients" begin
+   let
+      Q = matrix_ring(QQ, 2) 
+      Qz, z = Q[:z]
+      Qx, x = QQ[:x]
+      f = map_coefficients(c -> c[1, 1], 2*z; parent = Qx)
+      @test f == 2*x
+      @test parent(f) === Qx
+   end
+end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -2992,6 +2992,15 @@ end
    F = GF(11)
    P, y = polynomial_ring(F, 'x')
    @test map_coefficients(t -> F(t) + 2, f) == 3y^2 + 5y^3 + 4y^6
+
+   let
+      Q = matrix_ring(QQ, 2) 
+      Qz, z = Q[:z]
+      Qx, x = QQ[:x]
+      f = map_coefficients(c -> c * (2*one(Q)), x; parent = Qz)
+      @test f == 2*z
+      @test parent(f) === Qz
+   end
 end
 
 @testset "Generic.Poly.polynomial_to_power_sums" begin


### PR DESCRIPTION
- allow mapping `PolyRingElem` to `NCPolyRingElem` and vice versa
