### PR TITLE
Compute Solve traits from types as args

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -262,8 +262,8 @@ object.
 First of all, one needs to implement the function
 
 ```julia
-function Solve.solve_context_type(::NewRing)
-  return Solve.solve_context_type(::NormalFormTrait, elem_type(NewRing))
+function Solve.solve_context_type(T::Type{<:NewRing})
+  return Solve.solve_context_type(::NormalFormTrait, elem_type(T))
 end
 ```
 

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -202,7 +202,7 @@ The available algorithms/normal forms are
 
 To select a normal form type for rings of type `NewRing`, implement the function
 ```julia
-Solve.matrix_normal_form_type(::NewRing) = Bla()
+Solve.matrix_normal_form_type(::Type{<:NewRing}) = Bla()
 ```
 where `Bla <: MatrixNormalFormTrait`.
 A new type trait can be added via

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -241,7 +241,7 @@ function solve_context_type(NF::MatrixNormalFormTrait, ::Type{T}) where {T <: NC
 end
 
 function solve_context_type(NF::MatrixNormalFormTrait, T::Type{<:MatElem})
-  return solve_context_type(base_ring_type(T))
+  return solve_context_type(NF, base_ring_type(T))
 end
 
 function solve_context_type(::FFLUTrait, ::Type{T}) where {T <: NCRingElement}

--- a/src/Solve.jl
+++ b/src/Solve.jl
@@ -88,22 +88,25 @@ struct LUTrait <: MatrixNormalFormTrait end # LU factoring for fields
 struct FFLUTrait <: MatrixNormalFormTrait end # "fraction free" LU factoring for fraction fields
 struct MatrixInterpolateTrait <: MatrixNormalFormTrait end # interpolate in fraction fields of polynomial rings
 
-function matrix_normal_form_type(R::Ring)
-  if is_domain_type(elem_type(R))
+function matrix_normal_form_type(T::Type{<:Ring})
+  if is_domain_type(T)
     return HermiteFormTrait()
   else
     return HowellFormTrait()
   end
 end
 
-matrix_normal_form_type(::Field) = RREFTrait()
+matrix_normal_form_type(::Type{<:Field}) = RREFTrait()
 
 # The fflu approach is the fastest over a fraction field (see benchmarks on PR 661)
-matrix_normal_form_type(::FracField) = FFLUTrait()
-matrix_normal_form_type(::AbstractAlgebra.Rationals{BigInt}) = FFLUTrait()
-matrix_normal_form_type(::FracField{T}) where {T <: PolyRingElem} = MatrixInterpolateTrait()
+matrix_normal_form_type(::Type{<:FracField}) = FFLUTrait()
+matrix_normal_form_type(::Type{<:AbstractAlgebra.Rationals{BigInt}}) = FFLUTrait()
+matrix_normal_form_type(::Type{<:FracField{T}}) where {T <: PolyRingElem} = MatrixInterpolateTrait()
 
-matrix_normal_form_type(A::MatElem) = matrix_normal_form_type(base_ring(A))
+matrix_normal_form_type(T::Type{<:MatElem}) = matrix_normal_form_type(base_ring_type(T))
+
+matrix_normal_form_type(x) = matrix_normal_form_type(typeof(x))
+matrix_normal_form_type(T::DataType) = throw(MethodError(matrix_normal_form_type, (T,)))
 
 ################################################################################
 #
@@ -252,7 +255,7 @@ solve_context_type(NF::MatrixNormalFormTrait, ::T) where {T <: NCRing} = solve_c
 solve_context_type(NF::MatrixNormalFormTrait, ::Type{<: MatElem{T}}) where T = solve_context_type(NF, T)
 solve_context_type(NF::MatrixNormalFormTrait, ::MatElem{T}) where T = solve_context_type(NF, T)
 
-matrix_normal_form_type(C::SolveCtx{T, NF}) where {T, NF} = NF()
+matrix_normal_form_type(::Type{<:SolveCtx{T, NF}}) where {T, NF} = NF()
 
 matrix(C::SolveCtx) = C.A
 

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -105,7 +105,9 @@ end
     C = solve_init(M)
     @test AbstractAlgebra.Solve.matrix_normal_form_type(typeof(C)) === NFTrait()
     @test AbstractAlgebra.Solve.matrix_normal_form_type(C) === NFTrait()
+    @test C isa AbstractAlgebra.solve_context_type(typeof(R))
     @test C isa AbstractAlgebra.solve_context_type(R)
+    @test C isa AbstractAlgebra.solve_context_type(typeof(M))
     @test C isa AbstractAlgebra.solve_context_type(M)
   end
 

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -103,6 +103,7 @@ end
 
   if is_default
     C = solve_init(M)
+    @test AbstractAlgebra.Solve.matrix_normal_form_type(typeof(C)) === NFTrait()
     @test AbstractAlgebra.Solve.matrix_normal_form_type(C) === NFTrait()
     @test C isa AbstractAlgebra.solve_context_type(R)
     @test C isa AbstractAlgebra.solve_context_type(M)
@@ -110,6 +111,7 @@ end
 
   C = solve_init(NFTrait(), M)
 
+  @test AbstractAlgebra.Solve.matrix_normal_form_type(typeof(C)) === NFTrait()
   @test AbstractAlgebra.Solve.matrix_normal_form_type(C) === NFTrait()
   @test C isa AbstractAlgebra.solve_context_type(NFTrait(), elem_type(R))
   @test C isa AbstractAlgebra.solve_context_type(NFTrait(), R(1))


### PR DESCRIPTION
My motivation for this is to be able to set a concrete type in the `@attr Any` call in https://github.com/oscar-system/Oscar.jl/pull/4915/files#diff-88ef12a4e6f091b2cc3dd521d7c8be444dab854cb7aef78f6837778a274315ffR489 (something along the lines of `@attr solve_context_type(base_ring_type(M))`).

I also copied over the two fallbacks (for `::Any` and for `::DataType`) over from all of the similar functions like `base_ring_type` and then removed some obsolete methods. 

@joschmitt does this change make sense to you?