### PR TITLE
Prepare deprecations of some mixed methods of julia/oscar matrices and entries

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -67,10 +67,11 @@ end
 import Base: contains
 @deprecate contains(I::Ideal{T}, J::Ideal{T}) where {T <: RingElement} issubset(J, I)
 
-@deprecate zero_matrix(::Type{Int}, r, c) zeros(Int, r, c)
-@deprecate Array(R::NCRing, r::Int...) Array{elem_type(R)}(undef, r)
+# to be deprecated in the next breaking release
+zero_matrix(::Type{Int}, r, c) = zeros(Int, r, c)
+Array(R::NCRing, r::Int...) = Array{elem_type(R)}(undef, r)
 function zeros(R::NCRing, r::Int...)
-    Base.depwarn("`zeros(R::NCRing, r::Int...)` is deprecated, use `zero_matrix(R, r...)` instead.", :zeros)
+    #Base.depwarn("`zeros(R::NCRing, r::Int...)` is deprecated, use `zero_matrix(R, r...)` instead.", :zeros)
     T = elem_type(R)
     A = Array{T}(undef, r)
     for i in eachindex(A)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -66,3 +66,15 @@ end
 # deprecated in 0.45.2
 import Base: contains
 @deprecate contains(I::Ideal{T}, J::Ideal{T}) where {T <: RingElement} issubset(J, I)
+
+@deprecate zero_matrix(::Type{Int}, r, c) zeros(Int, r, c)
+@deprecate Array(R::NCRing, r::Int...) Array{elem_type(R)}(undef, r)
+function zeros(R::NCRing, r::Int...)
+    Base.depwarn("`zeros(R::NCRing, r::Int...)` is deprecated, use `zero_matrix(R, r...)` instead.", :zeros)
+    T = elem_type(R)
+    A = Array{T}(undef, r)
+    for i in eachindex(A)
+        A[i] = R()
+    end
+    return A
+end

--- a/src/algorithms/MPolyFactor.jl
+++ b/src/algorithms/MPolyFactor.jl
@@ -476,7 +476,7 @@ function hlift_have_lcs(
   @assert n > 0
   @assert r > 1
 
-  lc_evals = zeros(R, n + 1, r)
+  lc_evals = Matrix{elem_type(R)}(undef, n + 1, r)
   for j in 1:r
     lc_evals[n + 1, j] = lcs[j]
     for i in n:-1:1
@@ -484,13 +484,13 @@ function hlift_have_lcs(
     end
   end
 
-  A_evals = zeros(R, n + 1)
+  A_evals = Vector{elem_type(R)}(undef, n + 1)
   A_evals[n + 1] = A
   for i in n:-1:1
     A_evals[i] = eval_one(A_evals[i + 1], minorvars[i], alphas[i])
   end
 
-  fac = zeros(R, r)
+  fac = Vector{elem_type(R)}(undef, r)
   for j in 1:r
     @assert is_constant(lc_evals[1, j])
     fac[j] = Auf[j]*divexact(lc_evals[1, j], get_lc(Auf[j], mainvar))
@@ -574,7 +574,7 @@ function hliftstep_quartic2(
   a, t = divrem(a, xalpha)
   @assert t == B[1][1] * B[2][1]
 
-  M = zeros(R, liftdegs[m] + 1)
+  M = Vector{elem_type(R)}(undef, liftdegs[m] + 1)
 
   for j in 1:liftdegs[m]
     a, t = divrem(a, xalpha)
@@ -1156,8 +1156,8 @@ function mfactor_irred_mvar_char_zero(
   K = base_ring(R)
   @assert length(A) > 0
 
-  evals = zeros(R, n + 1)
-  alphas = zeros(K, n)
+  evals = Vector{elem_type(R)}(undef, n + 1)
+  alphas = Vector{elem_type(K)}(undef, n)
   alpha_modulus = 0
   lcc_fails_remaining = 3
 

--- a/src/algorithms/MPolyFactor.jl
+++ b/src/algorithms/MPolyFactor.jl
@@ -1157,7 +1157,7 @@ function mfactor_irred_mvar_char_zero(
   @assert length(A) > 0
 
   evals = Vector{elem_type(R)}(undef, n + 1)
-  alphas = Vector{elem_type(K)}(undef, n)
+  alphas = [zero(K) for _ in 1:n]
   alpha_modulus = 0
   lcc_fails_remaining = 3
 

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -838,10 +838,10 @@ function evaluate(a::UnivPoly{T}, A::Vector{V}) where {T <: RingElement, V <: Ri
    if n < num
       if n == 0
          R = base_ring(a)
-         return evaluate(data(a), zeros(R, num))
+         return evaluate(data(a), [zero(R) for _ in 1:num])
       else
          R = parent(A[1])
-         A = vcat(A, zeros(R, num - n))
+         A = vcat(A, [zero(R) for _ in 1:num-n])
          return evaluate(data(a), A)
      end
    end

--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -7,8 +7,6 @@
 number_of_rows(A::Matrix{T}) where {T} = size(A)[1]
 number_of_columns(A::Matrix{T}) where {T} = size(A)[2]
 
-zero_matrix(::Type{Int}, r, c) = zeros(Int, r, c)
-
 ###############################################################################
 #
 #   Conversion from MatrixElem
@@ -61,24 +59,6 @@ julia> Array(A)
 ```
 """
 Array(M::MatrixElem{T}) where {T<:NCRingElement} = Matrix(M)
-
-
-###############################################################################
-#
-#   Array creation functions
-#
-###############################################################################
-
-Array(R::NCRing, r::Int...) = Array{elem_type(R)}(undef, r)
-
-function zeros(R::NCRing, r::Int...)
-   T = elem_type(R)
-   A = Array{T}(undef, r)
-   for i in eachindex(A)
-      A[i] = R()
-   end
-   return A
-end
 
 ###############################################################################
 #

--- a/test/Solve-test.jl
+++ b/test/Solve-test.jl
@@ -73,7 +73,7 @@
   end
 
   N = zero_matrix(R, 2, 1)
-  b = zeros(R, 2)
+  b = [zero(R), zero(R)]
   fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
   @test fl
   @test N*x == b
@@ -82,7 +82,7 @@
   @test K == identity_matrix(R, 1)
 
   N = zero_matrix(R, 1, 2)
-  b = zeros(R, 1)
+  b = [zero(R)]
   fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(N, b, side = :right)
   @test fl
   @test N*x == b
@@ -184,7 +184,7 @@ end
 
   N = zero_matrix(R, 2, 1)
   C = AbstractAlgebra.Solve.solve_init(N)
-  b = zeros(R, 2)
+  b = [zero(R), zero(R)]
   fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test N*x == b
@@ -194,7 +194,7 @@ end
 
   N = zero_matrix(R, 1, 2)
   C = AbstractAlgebra.Solve.solve_init(N)
-  b = zeros(R, 1)
+  b = [zero(R)]
   fl, x, K = @inferred AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test N*x == b


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/2231 by deprecating the already existing functionality.
The consensus of https://github.com/oscar-system/Oscar.jl/issues/2231 seems to be that it is better to not have these methods at all than to add more of them for a full feature parity.

Closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/1886.