### PR TITLE
Add `rank` method for `DirectSumModule`

### DIFF
--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -26,6 +26,8 @@ number_of_generators(N::DirectSumModule{T}) where T <: RingElement = sum(ngens(M
 
 gens(N::DirectSumModule{T}) where T <: RingElement = [gen(N, i) for i = 1:ngens(N)]
 
+rank(M::DirectSumModule{T}) where T = sum(rank(summand) for summand in summands(M))
+
 function gen(N::DirectSumModule{T}, i::Int) where T <: RingElement
    @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index is out of range"))
    R = base_ring(N)

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -26,7 +26,7 @@ number_of_generators(N::DirectSumModule{T}) where T <: RingElement = sum(ngens(M
 
 gens(N::DirectSumModule{T}) where T <: RingElement = [gen(N, i) for i = 1:ngens(N)]
 
-rank(M::DirectSumModule{T}) where T = sum(rank(summand) for summand in summands(M))
+rank(M::DirectSumModule{T}) where T = sum(rank, summands(M); init=0)
 
 function gen(N::DirectSumModule{T}, i::Int) where T <: RingElement
    @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index is out of range"))

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -24,6 +24,8 @@ number_of_generators(N::QuotientModule{T}) where T <: RingElement = length(N.gen
 
 gens(N::QuotientModule{T}) where T <: RingElement = elem_type(N)[gen(N, i) for i = 1:ngens(N)]
 
+rank(M::QuotientModule{T}) where T <: FieldElement = dim(M)
+
 function gen(N::QuotientModule{T}, i::Int) where T <: RingElement
    @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -22,6 +22,7 @@
    F = free_module(QQ,2)
    D, inj, pro = direct_sum(F, F)
    f = D([gen(F, 1), gen(F,2)])
+   @test rank(D) == 4
    @test gen(D, 1) == D[1]
    @test isa(f, Generic.DirectSumModuleElem)
    @test f == inj[1](gen(F,1)) + inj[2](gen(F, 2))

--- a/test/generic/QuotientModule-test.jl
+++ b/test/generic/QuotientModule-test.jl
@@ -71,6 +71,35 @@
    @test dim(Q) == 1
 end
 
+@testset "Generic.QuotientModule.rank" begin
+    F = free_module(QQ, 3)
+    S1, _ = sub(F, elem_type(F)[])
+    Q1, _ = quo(F, S1)
+    @test rank(Q1) == 3
+
+    S2, _ = sub(F, gens(F))
+    Q2, _ = quo(F, S2)
+    @test rank(Q2) == 0
+
+    S3, _ = sub(F, [gen(F, 1)])
+    Q3, _ = quo(F, S3)
+    @test rank(Q3) == 2
+
+    S4, _ = sub(F, [gen(F, 1), gen(F, 2)])
+    Q4, _ = quo(F, S4)
+    @test rank(Q4) == 1
+
+    for iter = 1:40
+        n = rand(1:20)
+        F = free_module(QQ, n)
+        k = rand(0:n)
+        gens = [rand(F, -10:10) for i in 1:k]
+        S, _ = sub(F, gens)
+        Q, _ = quo(F, S)
+        @test rank(Q) == n - dim(S)
+    end
+end
+
 @testset "Generic.QuotientModule.manipulation" begin
    R = ZZ
    M = free_module(R, 2)


### PR DESCRIPTION
When computing the total complex of a tensor product of chain complexes in `Oscar.jl`, it called `rank(M)` where M was a `DirectSumModule`. However, no method for `rank` was defined for this type, causing the following MRE

MRE: 
```
julia> L = 2;
julia> F = GF(2);
julia> H = matrix(F, 1, L, ones(Int, L));
julia> V1 = free_module(F, L-1);
julia> V0 = free_module(F, L);
julia> ∂C = hom(V1, V0, H);
julia> C = chain_complex([∂C]);
julia> ∂D = hom(V0, V1, transpose(H));
julia> D = chain_complex([∂D]);
julia> dc = tensor_product(C, D);
julia> E = total_complex(dc);
julia> dc_2d = tensor_product(C, D);
julia> E_2d = total_complex(dc_2d);
julia> dc_3d = tensor_product(E_2d, D);
julia> F_3d = total_complex(dc_3d)
ERROR: MethodError: no method matching rank(::AbstractAlgebra.Generic.DirectSumModule{FqFieldElem})
The function `rank` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  rank(::Matroid)
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/src/Combinatorics/Matroids/properties.jl:258                                                                   
  rank(::Matroid, ::Union{AbstractSet, AbstractVector})
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/src/Combinatorics/Matroids/properties.jl:273                                                                   
  rank(::QuadSpaceWithIsom)
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/QuadFormAndIsom/src/spaces_with_isometry.jl:86                                                    
  ...

Stacktrace:
 [1] (::Oscar.VerticalTensorMapFactory{…})(dc::Oscar.DoubleComplexOfMorphisms{…}, i::Int64, j::Int64)
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/vector_spaces.jl:64                                           
 [2] (::Oscar.var"#8658#8659"{Oscar.DoubleComplexOfMorphisms{…}, Int64, Int64})()
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Attributes.jl:272                                             
 [3] get!(default::Oscar.var"#8658#8659"{…}, h::Dict{…}, key::Tuple{…})
   @ Base ./dict.jl:458
 [4] vertical_map(D::Oscar.DoubleComplexOfMorphisms{…}, i::Int64, j::Int64)
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Attributes.jl:270                                             
 [5] map
   @ ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Attributes.jl:308 [inlined]                                         
 [6] vertical_map
   @ ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Types.jl:226 [inlined]                                              
 [7] _total_chain_complex(dc::Oscar.DoubleComplexOfMorphisms{…})
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl:54                                                 
 [8] total_complex(D::Oscar.DoubleComplexOfMorphisms{…})
   @ Oscar ~/.julia/packages/Oscar/T5Jnd/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl:15                                                 
 [9] top-level scope
   @ REPL[20]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Fix: 
```
julia> F_3d = total_complex(dc_3d)
F_3d_0 <---- F_3d_1 <---- F_3d_2 <---- F_3d_3
```

**Edit:** Reference PR that is utilizing these changes is [here ](https://github.com/QuantumSavory/QuantumClifford.jl/pull/534)

I hope this is the right place to define the fix after looking through `Oscar`, `AA`