### PR TITLE
Bump version to 0.45.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.45.2"
+version = "0.45.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
To be merged and released immediately before https://github.com/Nemocas/AbstractAlgebra.jl/pull/2121 to make all previous changes avaliable to downstream without needing to wait for the breaking release to dripple down.