### PR TITLE
Allow `AbstractVector`s for more `matrix` and `diagonal_matrix` constructions

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6998,11 +6998,11 @@ function diagonal_matrix(x::AbstractVector{<:NCRingElement})
 end
 
 @doc raw"""
-    diagonal_matrix(V::AbstractVector{T}) where T <: MatElem -> MatElem
+    diagonal_matrix(V::Vector{T}) where T <: MatElem -> MatElem
 
 Returns a block diagonal matrix whose diagonal blocks are the matrices in $x$.
 """
-function diagonal_matrix(V::AbstractVector{T}) where {T<:MatElem}
+function diagonal_matrix(V::Vector{T}) where {T<:MatElem}
     return block_diagonal_matrix(V)
 end
 
@@ -7010,7 +7010,7 @@ function diagonal_matrix(x::T, xs::T...) where {T<:MatElem}
     return block_diagonal_matrix([x, xs...])
 end
 
-function diagonal_matrix(R::NCRing, V::AbstractVector{<:MatElem})
+function diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
     if length(V) == 0
         return zero_matrix(R, 0, 0)
     else

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6799,11 +6799,11 @@ function matrix(arr::AbstractVector{T}) where {T<:NCRingElement}
    return matrix(reshape(arr, length(arr), 1))
 end
 
-function matrix(arr::Vector{Vector{T}}) where {T<:NCRingElement}
+function matrix(arr::AbstractVector{<:AbstractVector{T}}) where {T<:NCRingElement}
     return matrix(permutedims(reduce(hcat, arr)))
 end
 
-function matrix(R::NCRing, arr::Vector{<:Vector})
+function matrix(R::NCRing, arr::AbstractVector{<:AbstractVector})
    return matrix(R, permutedims(reduce(hcat, arr)))
 end
 
@@ -6955,8 +6955,8 @@ diagonal_matrix(x::NCRingElement, m::Int) = diagonal_matrix(x, m, m)
 
 @doc raw"""
     diagonal_matrix(x::T...) where T <: NCRingElement -> MatElem{T}
-    diagonal_matrix(x::Vector{T}) where T <: NCRingElement -> MatElem{T}
-    diagonal_matrix(R::NCRing, x::Vector{T}) where T <: NCRingElement -> MatElem{T}
+    diagonal_matrix(x::AbstractVector{T}) where T <: NCRingElement -> MatElem{T}
+    diagonal_matrix(R::NCRing, x::AbstractVector{T}) where T <: NCRingElement -> MatElem{T}
 
 Returns a diagonal matrix whose diagonal entries are the elements of $x$.
 If a ring $R$ is given then it is used a parent for the entries of the created
@@ -6978,7 +6978,7 @@ julia> diagonal_matrix(ZZ, [5, 6])
 [0   6]
 ```
 """
-function diagonal_matrix(R::NCRing, x::Vector{<:NCRingElement})
+function diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
     x = R.(x)
     M = zero_matrix(R, length(x), length(x))
     for i = 1:length(x)
@@ -6991,17 +6991,17 @@ function diagonal_matrix(x::T, xs::T...) where {T<:NCRingElement}
     return diagonal_matrix([x, xs...])
 end
 
-function diagonal_matrix(x::Vector{<:NCRingElement})
+function diagonal_matrix(x::AbstractVector{<:NCRingElement})
    @req !isempty(x) "Cannot infer base ring from empty vector; consider passing the desired base ring as first argument to `diagonal_matrix`"
    return diagonal_matrix(parent(x[1]), x)
 end
 
 @doc raw"""
-    diagonal_matrix(V::Vector{T}) where T <: MatElem -> MatElem
+    diagonal_matrix(V::AbstractVector{T}) where T <: MatElem -> MatElem
 
 Returns a block diagonal matrix whose diagonal blocks are the matrices in $x$.
 """
-function diagonal_matrix(V::Vector{T}) where {T<:MatElem}
+function diagonal_matrix(V::AbstractVector{T}) where {T<:MatElem}
     return block_diagonal_matrix(V)
 end
 
@@ -7009,7 +7009,7 @@ function diagonal_matrix(x::T, xs::T...) where {T<:MatElem}
     return block_diagonal_matrix([x, xs...])
 end
 
-function diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
+function diagonal_matrix(R::NCRing, V::AbstractVector{<:MatElem})
     if length(V) == 0
         return zero_matrix(R, 0, 0)
     else

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6979,6 +6979,7 @@ julia> diagonal_matrix(ZZ, [5, 6])
 ```
 """
 function diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
+    Base.require_one_based_indexing(x)
     x = R.(x)
     M = zero_matrix(R, length(x), length(x))
     for i = 1:length(x)
@@ -6993,7 +6994,7 @@ end
 
 function diagonal_matrix(x::AbstractVector{<:NCRingElement})
    @req !isempty(x) "Cannot infer base ring from empty vector; consider passing the desired base ring as first argument to `diagonal_matrix`"
-   return diagonal_matrix(parent(x[1]), x)
+   return diagonal_matrix(parent(first(x)), x)
 end
 
 @doc raw"""

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6788,6 +6788,7 @@ function matrix(mat::MatrixElem{T}) where {T<:NCRingElement}
 end
 
 function matrix(arr::AbstractMatrix{T}) where {T<:NCRingElement}
+   Base.require_one_based_indexing(arr)
    r, c = size(arr)
    (r < 0 || c < 0) && error("Array must be non-empty")
    R = parent(arr[1, 1])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -212,6 +212,7 @@ end
       @test T[[1 2; 3 4];;] == matrix(T, [1 2; 3 4])
       @test T[[1; 3];; 2; 4] == matrix(T, [1 2; 3 4])
       @test T[1:4;; 5:8] == matrix(T, [1 5; 2 6; 3 7; 4 8])
+      @test T[1 2; 3 4] == matrix(T, [1:2, 3:4])
       @test_throws MethodError T[;;;]
       @test_throws MethodError T[1;;;]
 
@@ -297,6 +298,12 @@ end
          end
       end
    end
+
+   D4 = diagonal_matrix(R, 1:5)
+   @test size(D4) == (5, 5)
+   @test D4[1, 1] == R(1)
+   @test D4[5, 5] == R(5)
+   @test D4 isa Generic.MatSpaceElem{elem_type(R)}
 
    x = zero_matrix(R, 2, 2)
    y = zero_matrix(ZZ, 2, 3)


### PR DESCRIPTION
This would help for passing e.g. `Vector{PointVector{ZZRingElem}}` or similar types. Or is there any reason not to allow this?

This came up in slack when filtering lattice points and with this change works fine:
```julia
julia> matrix(ZZ, filter(v->v[1]==1, lattice_points(cube(2))))
[1   -1]
[1    0]
[1    1]
```