### PR TITLE
Revert "Add `fraction_field_type` and define `fraction_field` method for fields"

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -55,8 +55,10 @@ function //(x::T, y::T) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    g = gcd(x, y)
    z = Generic.FracFieldElem{T}(divexact(x, g), divexact(y, g))
-   z.parent = get(Generic.FracDict, R) do
-      return Generic.fraction_field(R)
+   try
+      z.parent = Generic.FracDict[R]
+   catch
+      z.parent = Generic.fraction_field(R)
    end
    return z
 end
@@ -823,42 +825,6 @@ base ring $R$ is supplied.
 function fraction_field(R::Ring; cached::Bool=true)
    return Generic.fraction_field(R; cached=cached)
 end
-
-function fraction_field(F::Field; cached::Bool=true)
-   return F
-end
-
-
-@doc raw"""
-    fraction_field_type(a)
-
-Return the type of the fraction field of the given element, element type, parent or parent type $a$.
-
-# Examples
-```jldoctest
-julia> R, x = polynomial_ring(ZZ, :x)
-(Univariate polynomial ring in x over integers, x)
-
-julia> fraction_field_type(R) == typeof(fraction_field(R))
-true
-
-julia> fraction_field_type(zero(R)) == typeof(fraction_field(R))
-true
-
-julia> fraction_field_type(typeof(R)) == typeof(fraction_field(R))
-true
-
-julia> fraction_field_type(typeof(zero(R))) == typeof(fraction_field(R))
-true
-```
-"""
-fraction_field_type(x) = fraction_field_type(typeof(x))
-fraction_field_type(x::Type{<:RingElement}) = fraction_field_type(parent_type(x))
-fraction_field_type(T::DataType) = throw(MethodError(fraction_field_type, (T,)))
-
-fraction_field_type(::Type{T}) where {T <: Field} = T
-fraction_field_type(::Type{T}) where {T <: Ring} = AbstractAlgebra.Generic.FracField{elem_type(T)}
-
 
 @doc raw"""
     factored_fraction_field(R::Ring; cached::Bool=true)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -227,7 +227,6 @@ export find_pivot_popov
 export finish
 export fit!
 export fraction_field
-export fraction_field_type
 export free_associative_algebra
 export free_associative_algebra_type
 export free_module

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -480,7 +480,7 @@ end
 # a numerator and denominator
 function _rat_poly(p::Poly{RationalFunctionFieldElem{T, U}}, var=parent(p).S; cached::Bool=true) where {T <: FieldElement, U <: PolyRingElem}
    K = base_ring(p)
-   R = base_ring(underlying_fraction_field(K))
+   R = base_ring(fraction_field(K))
    S = elem_type(R)
 
    par = PolyRing{S}(R, var, cached)

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -22,8 +22,8 @@ parent(a::RationalFunctionFieldElem) = a.parent
 
 data(x::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}} = x.d::FracFieldElem{U}
 
-function underlying_fraction_field(a::RationalFunctionField{T, U}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
-   return a.fraction_field::FracField{U}
+function fraction_field(a::RationalFunctionField{T, U}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
+   return a.fraction_field::Union{FracField{U}}
 end
 
 function is_domain_type(::Type{S}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}, S <: RationalFunctionFieldElem{T, U}}
@@ -119,13 +119,13 @@ iszero(a::RationalFunctionFieldElem) = iszero(data(a))
 
 isone(a::RationalFunctionFieldElem) = isone(data(a))
 
-gen(R::RationalFunctionField) = R(gen(base_ring(underlying_fraction_field(R))))
+gen(R::RationalFunctionField) = R(gen(base_ring(R.fraction_field)))
 
-gen(R::RationalFunctionField, i::Int) = R(gen(base_ring(underlying_fraction_field(R)), i))
+gen(R::RationalFunctionField, i::Int) = R(gen(base_ring(R.fraction_field), i))
 
-gens(R::RationalFunctionField) = R.(gens(base_ring(underlying_fraction_field(R))))
+gens(R::RationalFunctionField) = R.(gens(base_ring(R.fraction_field)))
 
-number_of_generators(R::RationalFunctionField) = number_of_generators(base_ring(underlying_fraction_field(R)))
+number_of_generators(R::RationalFunctionField) = number_of_generators(base_ring(R.fraction_field))
 
 function deepcopy_internal(a::RationalFunctionFieldElem, dict::IdDict)
    R = parent(a)
@@ -136,7 +136,7 @@ function characteristic(R::RationalFunctionField)
    return characteristic(base_ring(R))
 end
 
-is_finite(R::RationalFunctionField) = is_finite(base_ring(underlying_fraction_field(R)))
+is_finite(R::RationalFunctionField) = is_finite(base_ring(R.fraction_field))
 
 function is_perfect(R::RationalFunctionField)
   if characteristic(R) == 0
@@ -525,7 +525,7 @@ mul!(c::T, a::T, b::T) where {T <: RationalFunctionFieldElem} =
 RandomExtensions.maketype(R::RationalFunctionField, _) = elem_type(R)
 
 function RandomExtensions.make(S::RationalFunctionField, vs...)
-   R = base_ring(underlying_fraction_field(S))
+   R = base_ring(fraction_field(S))
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1]) # forward to default Make constructor
    else
@@ -536,13 +536,13 @@ end
 function rand(rng::AbstractRNG,
               sp::SamplerTrivial{<:Make2{<:FieldElement, <:RationalFunctionField}})
    S, v = sp[][1:end]
-   R = base_ring(underlying_fraction_field(S))
+   R = base_ring(fraction_field(S))
    n = rand(rng, v)
    d = R()
    while iszero(d)
       d = rand(rng, v)
    end
-   return S(underlying_fraction_field(S)(n, d; reduce = true))
+   return S(fraction_field(S)(n, d; reduce = true))
 end
 
 rand(rng::AbstractRNG, S::RationalFunctionField, v...) =
@@ -581,13 +581,13 @@ end
 ###############################################################################
 
 function (a::RationalFunctionField{T, U})() where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
-   K = underlying_fraction_field(a)
+   K = fraction_field(a)
    z = RationalFunctionFieldElem{T, U}(K(), a)
    return z
 end
 
 function (a::RationalFunctionField{T, U})(b::FracFieldElem{U}) where {T <: FieldElement, U <: Union{PolyRingElem{T}, MPolyRingElem{T}}}
-   K = underlying_fraction_field(a)
+   K = fraction_field(a)
    parent(b) != K && error("Unable to coerce rational function")
    z = RationalFunctionFieldElem{T, U}(b, a)
    return z::RationalFunctionFieldElem{T, U}
@@ -601,8 +601,10 @@ function (a::RationalFunctionField{T, U})(n::U, d::U) where {T <: FieldElement, 
       d = divexact(d, g)
    end
    r = FracFieldElem{U}(n, d)
-   r.parent = get(FracDict, R) do
-      return underlying_fraction_field(R)
+   try
+      r.parent = FracDict[R]
+   catch
+      r.parent = fraction_field(R)
    end
    return a(r)
 end
@@ -613,19 +615,19 @@ function (a::RationalFunctionField{T, U})(b::RationalFunctionFieldElem{T, U}) wh
 end
 
 function (a::RationalFunctionField{T, U})(b::Integer) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
-   K = underlying_fraction_field(a)
+   K = fraction_field(a)
    z = RationalFunctionFieldElem{T, U}(K(b), a)
    return z
 end
 
 function (a::RationalFunctionField{T, U})(b::Rational{<:Integer}) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
-   K = underlying_fraction_field(a)
+   K = fraction_field(a)
    z = RationalFunctionFieldElem{T, U}(K(b), a)
    return z
 end
 
 function (a::RationalFunctionField)(b::RingElem)
-   return a(underlying_fraction_field(a)(b))
+   return a(fraction_field(a)(b))
 end
 
 ###############################################################################


### PR DESCRIPTION
Reverts Nemocas/AbstractAlgebra.jl#2092.

This could be one of the culprits for currently broken downstream tests.