### PR TITLE
Revert "Revert "Add `fraction_field_type` and define `fraction_field` method for fields""

### DIFF
--- a/src/Fraction.jl
+++ b/src/Fraction.jl
@@ -55,10 +55,8 @@ function //(x::T, y::T) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    g = gcd(x, y)
    z = Generic.FracFieldElem{T}(divexact(x, g), divexact(y, g))
-   try
-      z.parent = Generic.FracDict[R]
-   catch
-      z.parent = Generic.fraction_field(R)
+   z.parent = get(Generic.FracDict, R) do
+      return Generic.fraction_field(R)
    end
    return z
 end
@@ -825,6 +823,42 @@ base ring $R$ is supplied.
 function fraction_field(R::Ring; cached::Bool=true)
    return Generic.fraction_field(R; cached=cached)
 end
+
+function fraction_field(F::Field; cached::Bool=true)
+   return F
+end
+
+
+@doc raw"""
+    fraction_field_type(a)
+
+Return the type of the fraction field of the given element, element type, parent or parent type $a$.
+
+# Examples
+```jldoctest
+julia> R, x = polynomial_ring(ZZ, :x)
+(Univariate polynomial ring in x over integers, x)
+
+julia> fraction_field_type(R) == typeof(fraction_field(R))
+true
+
+julia> fraction_field_type(zero(R)) == typeof(fraction_field(R))
+true
+
+julia> fraction_field_type(typeof(R)) == typeof(fraction_field(R))
+true
+
+julia> fraction_field_type(typeof(zero(R))) == typeof(fraction_field(R))
+true
+```
+"""
+fraction_field_type(x) = fraction_field_type(typeof(x))
+fraction_field_type(x::Type{<:RingElement}) = fraction_field_type(parent_type(x))
+fraction_field_type(T::DataType) = throw(MethodError(fraction_field_type, (T,)))
+
+fraction_field_type(::Type{T}) where {T <: Field} = T
+fraction_field_type(::Type{T}) where {T <: Ring} = AbstractAlgebra.Generic.FracField{elem_type(T)}
+
 
 @doc raw"""
     factored_fraction_field(R::Ring; cached::Bool=true)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -227,6 +227,7 @@ export find_pivot_popov
 export finish
 export fit!
 export fraction_field
+export fraction_field_type
 export free_associative_algebra
 export free_associative_algebra_type
 export free_module

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -480,7 +480,7 @@ end
 # a numerator and denominator
 function _rat_poly(p::Poly{RationalFunctionFieldElem{T, U}}, var=parent(p).S; cached::Bool=true) where {T <: FieldElement, U <: PolyRingElem}
    K = base_ring(p)
-   R = base_ring(fraction_field(K))
+   R = base_ring(underlying_fraction_field(K))
    S = elem_type(R)
 
    par = PolyRing{S}(R, var, cached)


### PR DESCRIPTION
Reverts Nemocas/AbstractAlgebra.jl#2128 and thus re-lands https://github.com/Nemocas/AbstractAlgebra.jl/pull/2092.

Short summary for @fingolfin: Once Oscar was compatible with AA v0.47, we had errors in the OscarCI tests in this repo. Reverting https://github.com/Nemocas/AbstractAlgebra.jl/pull/2092 fixed that, so we did it. In this PR, you now have the opportunity to work on https://github.com/Nemocas/AbstractAlgebra.jl/pull/2092 again, but this time with working downstream tests.