### PR TITLE
Fix ownership in UnivPoly.jl

### DIFF
--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -257,7 +257,7 @@ function _ensure_variables(S::UniversalPolyRing, v::Vector{<:VarName})
       end
    end
    if length(S.S) > ngens(S.mpoly_ring)
-      S.mpoly_ring = AbstractAlgebra.polynomial_ring_only(base_ring(S), S.S; internal_ordering=S.ord, cached=false)
+      S.mpoly_ring = AbstractAlgebra.polynomial_ring_only(base_ring(S), copy(S.S); internal_ordering=S.ord, cached=false)
    end
    return idx
 end


### PR DESCRIPTION
```julia
julia> u = universal_polynomial_ring(ZZ;  cached=false)
Universal Polynomial Ring over Integer ring

julia> x = gen(u, :x)
x

julia> y = gen(u, :y)
y

julia> parent(x.p) === parent(y.p)
false

julia> parent(x.p).S === parent(y.p).S
true
```
The addition of new variables adapts a vector of symbols that has been passed as an argument to a previous invocation of `polynomial_ring_only`, thus violating the GOP. Indeed, it is even the first example for it given at https://docs.oscar-system.org/stable/DeveloperDocumentation/debugging/.

Debugged together with @lgoettgens 


