### PR TITLE
Add `InfiniteDimensionError` exception for vector spaces

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -15,6 +15,7 @@ const import_exclude = [:import_exclude, :QQ, :ZZ,
                   :numerator, :denominator,
                   :promote_rule,
                   :Set, :Module, :Group,
+                  :InfiniteDimensionError,
                  ]
 
 

--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -15,7 +15,7 @@ const import_exclude = [:import_exclude, :QQ, :ZZ,
                   :numerator, :denominator,
                   :promote_rule,
                   :Set, :Module, :Group,
-                  :InfiniteDimensionError,
+                  :InfiniteDimensionError, # remove in next breaking release, see #2135
                  ]
 
 

--- a/src/error.jl
+++ b/src/error.jl
@@ -88,3 +88,17 @@ function Base.showerror(io::IO, e::ErrorConstrDimMismatch)
     print(io, "got $(e.get_l)")
   end
 end
+
+struct InfiniteDimensionError <: Exception
+  check_available::Bool
+  InfiniteDimensionError(; check_available::Bool = false) = new(check_available)
+end
+
+function Base.showerror(io::IO, e::InfiniteDimensionError)
+  if e.check_available
+    println(io, "Infinite-dimensional vector space")
+    print(io, "You may check finiteness with `is_finite_dimensional_vector_space`")
+  else
+    println(io, "Infinite-dimensional vector space")  
+  end
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -50,6 +50,7 @@ export GroupElem
 export Ideal
 export IdealSet
 export IdentityMap
+export InfiniteDimensionError
 export InfiniteOrderError
 export IntExt
 export ItemQuantity


### PR DESCRIPTION
Add `InfiniteDimensionError` exception for vector spaces with an optional argument `check_available` to check if the method `is_finite_dimensional_vector_space` is available in the current context, in which case it will be suggested in the error message. This is rounding out oscar-system/Oscar.jl#5056 .

cc @fingolfin 