### PR TITLE
Equal `FPModule`s must have the same `hash` value

### DIFF
--- a/src/Module.jl
+++ b/src/Module.jl
@@ -254,6 +254,9 @@ function ==(M::FPModule{T}, N::FPModule{T}) where T <: RingElement
    return true
 end
 
+# Equal `FPModule`s must have the same `hash` value.
+Base.hash(M::FPModule, h::UInt) = h # FIXME
+
 ###############################################################################
 #
 #   Isomorphism

--- a/test/generic/Module-test.jl
+++ b/test/generic/Module-test.jl
@@ -19,6 +19,16 @@ end
    test_rand(F, 1:9)
 end
 
+@testset "Generic.Module.hash" begin
+   # equal objects in the sense of `isequal` must have the same `hash` values
+   F = free_module(QQ, 2)
+   M1 = sub(F, [])[1]
+   M2 = sub(F, [])[1]
+   @test objectid(M1) != objectid(M2)
+   @test isequal(M1, M2)
+   @test hash(M1) == hash(M2)
+end
+
 @testset "Generic.Module.manipulation" begin
    for R in [ZZ, QQ]
       for iter = 1:100


### PR DESCRIPTION
There is a `==` method for two `FPModule`s that compares w.r.t. equality as sets.
The default `hash` method compares the `objectid`s.
In order to satisfy the general rule that `isequal(x, y)` implies `hash(x) == hash(y)`, we need a special `hash` method.