### PR TITLE
Remove `base_ring` methods returning `Union{}`

### DIFF
--- a/docs/src/real.md
+++ b/docs/src/real.md
@@ -100,7 +100,7 @@ true
 julia> iszero(f)
 false
 
-julia> U = base_ring(RR)
+julia> base_ring_type(RR)
 Union{}
 
 julia> T = parent(f)

--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -127,6 +127,8 @@ base_ring_type(::Type{MyParent})
 Return the type of the of base rings for parent objects with the given parent type.
 For example, `base_ring_type(Generic.PolyRing{T})` will return `parent_type(T)`.
 
+If the rings of this type are not parameterised by another ring, this function must return `Union{}`.
+
 ```julia
 base_ring(R::MyParent)
 ```
@@ -135,7 +137,7 @@ Given a parent object `R`, representing a ring, this function returns the parent
 of any base ring that parameterises this ring. For example, the base ring of the ring
 of polynomials over the integers would be the integer ring.
 
-If the ring is not parameterised by another ring, this function must return `Union{}`.
+If the ring is not parameterised by another ring, calling this function should rais an error.
 
 !!! note
 
@@ -144,6 +146,9 @@ If the ring is not parameterised by another ring, this function must return `Uni
     only base ring is $\mathbb{Z}$. We consider the ring $\mathbb{Z}/n\mathbb{Z}$ to have
     been constructed from the base ring $\mathbb{Z}$ by taking its quotient by a (principal)
     ideal.
+
+    There is no general mathematical definition for base ring, so to know what `base_ring`
+    does for any given type of ring, you need to consult its documentation.
 
 ```julia
 parent(f::MyElem)

--- a/src/fundamental_interface.jl
+++ b/src/fundamental_interface.jl
@@ -91,7 +91,7 @@ julia> R = GF(7)
 Finite field F_7
 
 julia> base_ring(R)
-Union{}
+ERROR: MethodError: no method matching base_ring(::AbstractAlgebra.GFField{Int64})
 ```
 """
 function base_ring end
@@ -119,6 +119,12 @@ true
 
 julia> base_ring_type(typeof(zero(R))) == typeof(base_ring(zero(R)))
 true
+
+julia> R = GF(7)
+Finite field F_7
+
+julia> base_ring_type(R)
+Union{}
 ```
 """
 base_ring_type(x) = base_ring_type(typeof(x))

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -20,9 +20,7 @@ elem_type(::Type{Floats{T}}) where T <: AbstractFloat = T
 
 parent_type(::Type{T}) where T <: AbstractFloat = Floats{T}
 
-base_ring_type(::Type{Floats{T}}) where T <: AbstractFloat = typeof(Union{})
-
-base_ring(a::Floats{T}) where T <: AbstractFloat = Union{}
+base_ring_type(::Type{Floats{T}}) where T <: AbstractFloat = Union{}   # no base ring
 
 is_domain_type(::Type{T}) where T <: AbstractFloat = true
 

--- a/src/julia/GF.jl
+++ b/src/julia/GF.jl
@@ -14,9 +14,7 @@ parent_type(::Type{GFElem{T}}) where T <: Integer = GFField{T}
 
 elem_type(::Type{GFField{T}}) where T <: Integer = GFElem{T}
 
-base_ring_type(::Type{<:GFField}) = typeof(Union{})
-
-base_ring(a::GFField) = Union{}
+base_ring_type(::Type{<:GFField}) = Union{}   # no base ring
 
 parent(a::GFElem) = a.parent
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -20,9 +20,7 @@ elem_type(::Type{Integers{T}}) where T <: Integer = T
 
 parent_type(::Type{T}) where T <: Integer = Integers{T}
 
-base_ring_type(::Type{<:Integers}) = typeof(Union{})
-
-base_ring(a::Integers{T}) where T <: Integer = Union{}
+base_ring_type(::Type{<:Integers}) = Union{}   # no base ring
 
 is_exact_type(::Type{T}) where T <: Integer = true
 


### PR DESCRIPTION
This is certainly a breaking change, in that it changes an explicitly documented behavior. But I suspect it won't actually break anything ; and if it does, I am glad to learn about it.

Rationale for this:
1. I suspect it is the cause of some JET warnings
2. returning the type `Union{}` for `base_ring` never made sense to me. Besides not fitting logically (a type is not a ring...): When would it even be used, and why?
3. even if something relies on testing that a given ring "has no base ring" (but *why*???) then it makes more sense to let `base_ring_type` return `Union{}` (a method which did not exist when the "`base_ring` may return `Union{}`" convention was introduced)


Alas, I was not there when this was was designed and perhaps there are serious downsides I am not aware of -- well, as usual I am happy to learn :-).

*If* we merge this then of course Nemo, Hecke, ... need some changes (but I think mostly of the variety "drop `base_ring` method returning `Union{}` and adjust its `base_ring_type` method" )