### PR TITLE
Add `identity_map` to excluded imports

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -16,6 +16,7 @@ const import_exclude = [:import_exclude, :QQ, :ZZ,
                   :promote_rule,
                   :Set, :Module, :Group,
                   :InfiniteDimensionError, # remove in next breaking release, see #2135
+                  :identity_map, # see #5188 in Oscar.jl
                  ]
 
 


### PR DESCRIPTION
This PR adds `identity_map` to `import_exclude` as part of consolidating `identity_map` and `id_hom` across packages (see https://github.com/oscar-system/Oscar.jl/issues/5188).