### PR TITLE
feat: store (additional) array in Fac

### DIFF
--- a/test/Factor-test.jl
+++ b/test/Factor-test.jl
@@ -1,14 +1,21 @@
 @testset "Fac.constructors" begin
    f = Fac(-1, Dict{Int, Int}(2 => 3, 3 => 1))
+   ff = Fac(-1, [2 => 3, 3 => 1])
 
    @test -24 == evaluate(f)
+   @test -24 == evaluate(ff)
    @test -24 == unit(f)*prod([p^e for (p, e) in f])
+   @test -24 == unit(ff)*prod([p^e for (p, e) in ff])
+
+   @test collect(ff) == [2 => 3, 3 => 1]
 end
 
 @testset "Fac.printing" begin
    f = Fac(-1, Dict{Int, Int}(2 => 3, 3 => 1))
+   ff = Fac(-1, [(2, 3), (3, 1)])
 
    @test string(f) == "-1 * 2^3 * 3" || string(f) == "-1 * 3 * 2^3"
+   @test string(ff) == "-1 * 2^3 * 3"
 
    @test string(Fac{BigInt}()) isa String
 


### PR DESCRIPTION
This adds a small hook to back the `Fac` object with an array instead of a dictionary. This does not change the current interface. There might be a small runtime penalty in the iteration, since the state of the iterator is not type stable anymore (the element type still is). But I don't expect this to be noticeable (compared to the time it takes to factor things).