### PR TITLE
feat: do not print `1` in factorizations

### DIFF
--- a/src/Factor.jl
+++ b/src/Factor.jl
@@ -152,7 +152,9 @@ end
 function expressify(@nospecialize(a::Fac); context = nothing)
    prod = Expr(:call, :cdot)
    if isdefined(a, :unit)
-      push!(prod.args, expressify(a.unit, context = context))
+      if !is_one(a.unit)
+         push!(prod.args, expressify(a.unit, context = context))
+      end
    else
       push!(prod.args, Expr(:call, :*, "[unit not set]"))
    end


### PR DESCRIPTION
With Nemo:
```
julia> factor(ZZ(6))
2 * 3
```
instead of
```
julia> factor(ZZ(6))
1 * 2 * 3
```
Will be breaking I suppose.