### PR TITLE
Throw for `leading/trailing_coefficient` of zero in multivariate setting

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -253,20 +253,18 @@ end
 Return the leading coefficient of the polynomial $p$.
 """
 function leading_coefficient(p::MPolyRingElem{T}) where T <: RingElement
-   if iszero(p)
-      return zero(base_ring(p))
-   else
-      return first(coefficients(p))
-   end
+   @req !iszero(p) "Zero polynomial does not have a leading monomial"
+   return first(coefficients(p))
 end
 
 @doc raw"""
     trailing_coefficient(p::MPolyRingElem)
 
 Return the trailing coefficient of the polynomial $p$, i.e. the coefficient of
-the last nonzero term, or zero if the polynomial is zero.
+the last nonzero term.
 """
 function trailing_coefficient(p::MPolyRingElem{T}) where T <: RingElement
+   @req !iszero(p) "Zero polynomial does not have a leading monomial"
    coeff = zero(base_ring(p))
    for c in coefficients(p)
       coeff = c

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -202,7 +202,8 @@ function Base.iterate(a::FreeAssAlgExponentWords, state = 0)
 end
 
 function leading_coefficient(a::FreeAssociativeAlgebraElem{T}) where T
-    return a.length > 0 ? coeff(a, 1) : zero(base_ring(a))
+    @req !is_zero(a) "Zero polynomial does not have a leading monomial"
+    return coeff(a, 1)
 end
 
 function leading_monomial(a::FreeAssociativeAlgebraElem{T}) where T
@@ -244,6 +245,7 @@ end
 ###############################################################################
 
 function canonical_unit(a::FreeAssociativeAlgebraElem{T}) where T <: RingElement
+    iszero(a) && return one(base_ring(a))
     return canonical_unit(leading_coefficient(a))
 end
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -636,11 +636,8 @@ function coeff(x::MPoly, i::Int)
 end
 
 function trailing_coefficient(p::MPoly{T}) where T <: RingElement
-   if iszero(p)
-      return zero(base_ring(p))
-   else
-      return coeff(p, length(p))
-   end
+   @req !iszero(p) "Zero polynomial does not have a leading monomial"
+   return coeff(p, length(p))
 end
 
 @doc raw"""

--- a/test/generic/FreeAssociativeAlgebra-test.jl
+++ b/test/generic/FreeAssociativeAlgebra-test.jl
@@ -97,13 +97,14 @@
       if !iszero(f1)
          @test leading_term(f1) == leading_coefficient(f1)*leading_monomial(f1)
          @test total_degree(f1) >= total_degree(f1 - leading_term(f1))
+         @test canonical_unit(f1) == canonical_unit(leading_coefficient(f1))
       else
+         @test_throws ArgumentError leading_coefficient(f1)
          @test_throws ArgumentError leading_term(f1)
          @test_throws ArgumentError leading_monomial(f1)
          @test_throws ArgumentError leading_exponent_word(f1)
+         @test canonical_unit(f1) == one(R)
       end
-
-      @test canonical_unit(f1) == canonical_unit(leading_coefficient(f1))
 
       @test !is_gen(zero(S))
       @test !is_gen(one(S))

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -515,15 +515,16 @@ end
          f = rand(S, 0:4, 0:5, -10:10)
          g = rand(S, 0:4, 0:5, -10:10)
 
-         @test leading_coefficient(f*g) ==
-               leading_coefficient(f)*leading_coefficient(g)
+         if !is_zero(f) && !is_zero(g)
+            @test parent(leading_coefficient(f)) == base_ring(f)
+            @test leading_coefficient(f*g) == leading_coefficient(f)*leading_coefficient(g)
+         end
          @test leading_coefficient(one(S)) == one(base_ring(S))
 
          for v in varlist
             @test leading_coefficient(v) == one(base_ring(S))
          end
 
-         @test parent(leading_coefficient(f)) == base_ring(f)
       end
    end
 

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -251,8 +251,8 @@ end
       @test !is_monomial(S())
       @test is_constant(S())
       @test !is_term(S())
-      @test trailing_coefficient(S()) == 0
-      @test leading_coefficient(S()) == 0
+      @test_throws ArgumentError trailing_coefficient(S())
+      @test_throws ArgumentError leading_coefficient(S())
       @test constant_coefficient(S()) == 0
       @test total_degree(S()) == -1
       @test length(gens(S)) == 0


### PR DESCRIPTION
This is the AA part of the discussion result of  https://github.com/oscar-system/Oscar.jl/pull/5231.