### PR TITLE
Fix a missing deepcopy in `echelon_form_with_transformation`

### DIFF
--- a/src/MatrixNormalForms.jl
+++ b/src/MatrixNormalForms.jl
@@ -42,9 +42,9 @@ See [`echelon_form`](@ref) for the keyword arguments.
 """
 function echelon_form_with_transformation(A::MatElem{<:FieldElement}; reduced::Bool = true, shape::Symbol = :upper)
   if shape === :upper
-    R = hcat(A, identity_matrix(base_ring(A), nrows(A)))
+    R = hcat(deepcopy(A), identity_matrix(base_ring(A), nrows(A)))
   else
-    R = hcat(identity_matrix(base_ring(A), nrows(A)), A)
+    R = hcat(identity_matrix(base_ring(A), nrows(A)), deepcopy(A))
   end
   echelon_form!(R, reduced = reduced, shape = shape)
   if shape === :upper
@@ -372,7 +372,7 @@ function howell_form_with_transformation(A::MatElem{<:RingElement}; reduced::Boo
   if shape === :lower
     B = hcat(reverse_cols(A), identity_matrix(A, nrows(A)))
   else
-    B = hcat(A, identity_matrix(A, nrows(A)))
+    B = hcat(deepcopy(A), identity_matrix(A, nrows(A)))
   end
   if nrows(B) < ncols(B)
     B = vcat(B, zero(A, ncols(B) - nrows(B), ncols(B)))

--- a/test/MatrixNormalForms-test.jl
+++ b/test/MatrixNormalForms-test.jl
@@ -24,6 +24,14 @@
   @test is_rref(R)
   @test U*M == S
   @test is_invertible(U)
+
+  # An aliasing bug fixed in #2154
+  K, t = rational_function_field(QQ, :t)
+  M = K[-t - 1 -t - 1; t + 1 2t - 2]
+  echelon_form_with_transformation(M)
+  @test M == K[-t - 1 -t - 1; t + 1 2t - 2]
+  echelon_form_with_transformation(M, shape = :lower)
+  @test M == K[-t - 1 -t - 1; t + 1 2t - 2]
 end
 
 @testset "Hermite form" begin


### PR DESCRIPTION
`echelon_form_with_transformation` would sometimes change the input:
```
julia> K, a = cyclotomic_field(4, :a);

julia> M = K[-a - 1 -a - 1; a + 1 2a - 2]
[-a - 1    -a - 1]
[ a + 1   2*a - 2]

julia> echelon_form_with_transformation(M);

julia> M
[-a - 1   -a - 1]
[ a + 1    a - 3]
```
~I don't know of an example in AbstractAlgebra for the tests.~
I added an AbstractAlgebra-only test.

(Apparently I assumed that `hcat` would copy when I wrote this.)
