### PR TITLE
Collapse all docstrings in documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.47.2"
+version = "0.47.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/constructors.md
+++ b/docs/src/constructors.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Constructing mathematical objects in AbstractAlgebra.jl
 
 ## Constructing objects in Julia

--- a/docs/src/direct_sum.md
+++ b/docs/src/direct_sum.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/euclidean_interface.md
+++ b/docs/src/euclidean_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/extending_abstractalgebra.md
+++ b/docs/src/extending_abstractalgebra.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Extending the interface of AbstractAlgebra.jl
 
 In this section we will discuss on how to extend the interface of

--- a/docs/src/field.md
+++ b/docs/src/field.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Field functionality
 
 ## Abstract types for rings

--- a/docs/src/field_interface.md
+++ b/docs/src/field_interface.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Field Interface
 
 AbstractAlgebra.jl generic code makes use of a standardised set of functions which it

--- a/docs/src/field_introduction.md
+++ b/docs/src/field_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 A number of basic fields are provided, such as the rationals, finite

--- a/docs/src/finfield.md
+++ b/docs/src/finfield.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/fraction_interface.md
+++ b/docs/src/fraction_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -231,7 +231,7 @@ to the function, to only compute a partial Groebner basis.
 ```@docs
 groebner_basis(g::Vector{FreeAssociativeAlgebraElem{T}}, reduction_bound::Int = typemax(Int), remove_redundancies::Bool = false) where T <: FieldElement
 
-normal_form(f::FreeAssociativeAlgebraElem{T}, g::Vector{FreeAssociativeAlgebraElem{T}}, aut::AhoCorasickAutomaton) where T
+normal_form(f::FreeAssociativeAlgebraElem{T}, g::Vector{FreeAssociativeAlgebraElem{T}}, aut::Generic.AhoCorasickAutomaton) where T
 
 interreduce!(g::Vector{FreeAssociativeAlgebraElem{T}}) where T
 ```

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -229,11 +229,11 @@ Since such a Groebner basis is not necessarily finite, one can additionally pass
 to the function, to only compute a partial Groebner basis.
 
 ```@docs
-groebner_basis(g::Vector{FreeAssociativeAlgebraElem{T}}, reduction_bound::Int = typemax(Int), remove_redundancies::Bool = false) where T <: FieldElement
+AbstractAlgebra.groebner_basis(g::Vector{FreeAssociativeAlgebraElem{T}}, reduction_bound::Int = typemax(Int), remove_redundancies::Bool = false) where T <: FieldElement
 
-normal_form(f::FreeAssociativeAlgebraElem{T}, g::Vector{FreeAssociativeAlgebraElem{T}}, aut::Generic.AhoCorasickAutomaton) where T
+AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem{T}, g::Vector{FreeAssociativeAlgebraElem{T}}, aut::Generic.AhoCorasickAutomaton) where T
 
-interreduce!(g::Vector{FreeAssociativeAlgebraElem{T}}) where T
+AbstractAlgebra.interreduce!(g::Vector{FreeAssociativeAlgebraElem{T}}) where T
 ```
 
 The implementation uses a non-commutative version of the Buchberger algorithm as described in

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -1,5 +1,6 @@
 ```@meta
-CurrentModule = AbstractAlgebra.Generic
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/free_associative_algebra.md
+++ b/docs/src/free_associative_algebra.md
@@ -229,11 +229,11 @@ Since such a Groebner basis is not necessarily finite, one can additionally pass
 to the function, to only compute a partial Groebner basis.
 
 ```@docs
-AbstractAlgebra.groebner_basis(g::Vector{FreeAssociativeAlgebraElem{T}}, reduction_bound::Int = typemax(Int), remove_redundancies::Bool = false) where T <: FieldElement
+AbstractAlgebra.groebner_basis(g::Vector{Generic.FreeAssociativeAlgebraElem{T}}, reduction_bound::Int = typemax(Int), remove_redundancies::Bool = false) where T <: FieldElement
 
-AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem{T}, g::Vector{FreeAssociativeAlgebraElem{T}}, aut::Generic.AhoCorasickAutomaton) where T
+AbstractAlgebra.normal_form(f::Generic.FreeAssociativeAlgebraElem{T}, g::Vector{Generic.FreeAssociativeAlgebraElem{T}}, aut::Generic.AhoCorasickAutomaton) where T
 
-AbstractAlgebra.interreduce!(g::Vector{FreeAssociativeAlgebraElem{T}}) where T
+AbstractAlgebra.interreduce!(g::Vector{Generic.FreeAssociativeAlgebraElem{T}}) where T
 ```
 
 The implementation uses a non-commutative version of the Buchberger algorithm as described in

--- a/docs/src/free_module.md
+++ b/docs/src/free_module.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/function_field.md
+++ b/docs/src/function_field.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/functional_map.md
+++ b/docs/src/functional_map.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/ideal.md
+++ b/docs/src/ideal.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # AbstractAlgebra.jl
 
 ## Introduction

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/interface_introduction.md
+++ b/docs/src/interface_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 AbstractAlgebra defines a series of interfaces that can be extended with

--- a/docs/src/laurent_mpolynomial.md
+++ b/docs/src/laurent_mpolynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/laurent_polynomial.md
+++ b/docs/src/laurent_polynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/linear_solving.md
+++ b/docs/src/linear_solving.md
@@ -9,10 +9,10 @@ DocTestSetup = AbstractAlgebra.doctestsetup()
 ## Overview of the functionality
 
 The module `AbstractAlgebra.Solve` provides the following four functions for solving linear systems:
-* [`solve`](@ref solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
-* [`can_solve`](@ref can_solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
-* [`can_solve_with_solution`](@ref can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
-* [`can_solve_with_solution_and_kernel`](@ref can_solve_with_solution_and_kernel(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`solve`](@ref solve(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve`](@ref can_solve(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve_with_solution`](@ref can_solve_with_solution(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
+* [`can_solve_with_solution_and_kernel`](@ref can_solve_with_solution_and_kernel(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T)
 
 All of these take the same set of arguments, namely:
 * a matrix $A$ of type `MatElem`;
@@ -27,7 +27,7 @@ The functionality of the functions can be summarized as follows.
 * `can_solve_with_solution`: return `true` and a solution, if this exists, and `false` and an empty vector or matrix otherwise.
 * `can_solve_with_solution_and_kernel`: like `can_solve_with_solution` and additionally return a matrix whose rows (respectively columns) give a basis of the kernel of $A$.
 
-Furthermore, there is a function [`kernel`](@ref kernel(::Union{MatElem, SolveCtx})) which computes the kernel of a matrix $A$.
+Furthermore, there is a function [`kernel`](@ref kernel(::Union{MatElem, Solve.SolveCtx})) which computes the kernel of a matrix $A$.
 
 ## Solving with several right hand sides
 

--- a/docs/src/linear_solving.md
+++ b/docs/src/linear_solving.md
@@ -41,9 +41,9 @@ This way the time-consuming part of the solving (i.e. computing a reduced form o
 ## Detailed documentation
 
 ```@docs
-solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
-can_solve(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
-can_solve_with_solution(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
-kernel(::Union{MatElem, SolveCtx})
-can_solve_with_solution_and_kernel(::Union{MatElem{T}, SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+solve(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+can_solve(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+can_solve_with_solution(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
+kernel(::Union{MatElem, Solve.SolveCtx})
+can_solve_with_solution_and_kernel(::Union{MatElem{T}, Solve.SolveCtx{T}}, ::Union{Vector{T}, MatElem{T}}) where T
 ```

--- a/docs/src/linear_solving.md
+++ b/docs/src/linear_solving.md
@@ -1,5 +1,7 @@
 ```@meta
-CurrentModule = AbstractAlgebra.Solve
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
 # [Linear solving](@id solving_chapter)

--- a/docs/src/map_cache.md
+++ b/docs/src/map_cache.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/map_interface.md
+++ b/docs/src/map_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/map_introduction.md
+++ b/docs/src/map_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 Maps in AbstractAlgebra model maps on sets $f : D \to C$ for some domain $D$

--- a/docs/src/map_with_inverse.md
+++ b/docs/src/map_with_inverse.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/matrix_algebras.md
+++ b/docs/src/matrix_algebras.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/matrix_implementation.md
+++ b/docs/src/matrix_implementation.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/matrix_interface.md
+++ b/docs/src/matrix_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/matrix_introduction.md
+++ b/docs/src/matrix_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 AbstractAlgebra provides matrix spaces ($m\times n$ matrices) and matrix algebras

--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -258,7 +258,7 @@ These can be extended for a ring of type `NewRing` as follows.
 
 #### Solve context type
 
-For a new ring type, one may have to define the type parameters of a `SolveCtx`
+For a new ring type, one may have to define the type parameters of a `Solve.SolveCtx`
 object.
 First of all, one needs to implement the function
 
@@ -290,8 +290,8 @@ To initialize the solve context functionality for a new normal form `NewTrait`,
 one needs to implement the functions
 
 ```julia
-Solve._init_reduce(C::SolveCtx{T, NewTrait}) where T
-Solve._init_reduce_transpose(C::SolveCtx{T, NewTrait}) where T
+Solve._init_reduce(C::Solve.SolveCtx{T, NewTrait}) where T
+Solve._init_reduce_transpose(C::Solve.SolveCtx{T, NewTrait}) where T
 ```
 
 These should fill the corresponding fields of the solve context `C` with a
@@ -306,7 +306,7 @@ As above, one finally needs to implement the functions
 
 ```julia
 Solve._can_solve_internal_no_check(
-  ::NewTrait, C::SolveCtx{T, NewTrait}, b::MatElem{T}, task::Symbol;
+  ::NewTrait, C::Solve.SolveCtx{T, NewTrait}, b::MatElem{T}, task::Symbol;
   side::Symbol = :left
   ) where T
 ```
@@ -314,5 +314,5 @@ Solve._can_solve_internal_no_check(
 and
 
 ```julia
-kernel(::NewTrait, C::SolveCtx{T, NewTrait}; side::Symbol = :left)
+kernel(::NewTrait, C::Solve.SolveCtx{T, NewTrait}; side::Symbol = :left)
 ```

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/module.md
+++ b/docs/src/module.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/module_homomorphism.md
+++ b/docs/src/module_homomorphism.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/module_interface.md
+++ b/docs/src/module_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/module_introduction.md
+++ b/docs/src/module_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 As with many generic constructions in AbstractAlgebra, the modules that are

--- a/docs/src/mpoly_interface.md
+++ b/docs/src/mpoly_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/mseries.md
+++ b/docs/src/mseries.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/ncpolynomial.md
+++ b/docs/src/ncpolynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/ncring_interface.md
+++ b/docs/src/ncring_interface.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Noncommutative ring Interface
 
 AbstractAlgebra.jl supports commutative rings through its `Ring` interface.

--- a/docs/src/perm.md
+++ b/docs/src/perm.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/poly_interface.md
+++ b/docs/src/poly_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/quotient_module.md
+++ b/docs/src/quotient_module.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/rand.md
+++ b/docs/src/rand.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/real.md
+++ b/docs/src/real.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/residue_interface.md
+++ b/docs/src/residue_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/ring.md
+++ b/docs/src/ring.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Ring functionality
 
 AbstractAlgebra has both commutative and noncommutative rings. Together we

--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Ring Interface
 
 AbstractAlgebra.jl generic code makes use of a standardised set of functions which it

--- a/docs/src/ring_introduction.md
+++ b/docs/src/ring_introduction.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Introduction
 
 A rich ring hierarchy is provided, supporting both commutative and

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/series_interface.md
+++ b/docs/src/series_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/submodule.md
+++ b/docs/src/submodule.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/total_fraction.md
+++ b/docs/src/total_fraction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Type interface of AbstractAlgebra.jl
 
 Apart from how we usually think of types in programming, we shall in this

--- a/docs/src/univpolynomial.md
+++ b/docs/src/univpolynomial.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 

--- a/docs/src/visualizing_types.md
+++ b/docs/src/visualizing_types.md
@@ -1,3 +1,8 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
 # Visualization of the types of AbstractAlgebra.jl
 
 AbstractAlgebra.jl implements a couple of abstract types which can be extended.

--- a/docs/src/ytabs.md
+++ b/docs/src/ytabs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 DocTestFilters = r"[0-9\.]+ seconds \(.*\)"
 ```


### PR DESCRIPTION
I think it would be great to get this released before Oscar 1.5, such that all of the included pages in the Oscar docs are consistent with collapsed docstrings. I therefore added a version bump as well.

(I don't know what git has about `docs/src/matrix_implementation.md` that file should just have the same change as all the other ones)