### PR TITLE
Make building the package docs more convenient

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,7 @@ AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "1.0"
+Documenter = "1"
+
+[sources]
+AbstractAlgebra = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,36 @@
+#
+# Usage: from the package root directory, run
+#
+#    julia --proj=docs docs/make.jl
+#
+# To fix doctests instead of merely running them, use
+#
+#   DOCTEST=fix julia --proj=docs docs/make.jl
+#
+# To disable doctests, run
+#
+#   DOCTEST=off julia --proj=docs docs/make.jl
+#
+using Pkg
+Pkg.update()
+
+# parse some options
+doctest_arg = true
+if "--fix" in ARGS
+  doctest_arg = :fix
+else
+  tmp = get(ENV, "DOCTEST", "true")
+  if tmp == "true" || tmp == "on" || tmp == "yes"
+    doctest_arg = true
+  elseif tmp == "false" || tmp == "off" || tmp == "no"
+    doctest_arg = false
+  elseif tmp == "fix"
+    doctest_arg = :fix
+  else
+    error("invalid DOCTEST env var")
+  end
+end
+
 using Documenter, AbstractAlgebra
 
 DocMeta.setdocmeta!(AbstractAlgebra, :DocTestSetup, AbstractAlgebra.doctestsetup(); recursive = true)
@@ -10,7 +43,7 @@ makedocs(
          sitename = "AbstractAlgebra.jl",
          modules = [AbstractAlgebra],
          clean = true,
-         doctest = true,
+         doctest = doctest_arg,
          checkdocs = :none,
          pages    = [
              "index.md",


### PR DESCRIPTION
The `sources` entry in `docs/Project.toml` helps ensure the correct version of the package is used.

There is also now a way to override the `doctest` test setting, so that one can turn them off for a quick test, or enable the `fix` mode for updating examples.

This may need some discussion before it gets merged and rolled out to perhaps some more of our repos; I'll add some inline comments to relevant code sections