### PR TITLE
docs/Project.toml: set sources path for AbstractAlgebra

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,3 +4,6 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "1.0"
+
+[sources]
+AbstractAlgebra = {path = ".."}


### PR DESCRIPTION
This makes it a tad more convenient to build the docs.

This is also in PR #2173 but unlike that more ambitious PR it should be completely uncontroversial as it just eliminates one step one currently has to do when building the docs manually.