### PR TITLE
Improved doc for polynomial ring element constructors

### DIFF
--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -96,7 +96,7 @@ the usual ways of constructing an element of a ring.
 (R::PolyRing{T})(a::T) where T <: RingElement
 ```
 The third constructor above cannot be used to coerce a polynomial from one ring
-to another; instead use a call like `map_coefficients(identity,f; parent=dest_ring))`,
+to another; instead use a call like `map_coefficients(identity, f; parent=dest_ring))`,
 or alternatively, for _small polynomials_ one can simply use evaluation:
 namely, `f(y)` where `y` is the generator of the destination polynomial ring.
 The fourth constructor creates a constant polynomial from an element of the coefficient ring.


### PR DESCRIPTION
Added a comment about how to coerce a polynomial from one ring to another; and stating that the constructors will not do this.  See [https://github.com/oscar-system/Oscar.jl/issues/5396](url)