### PR TITLE
Optimize `copy(::Generic.MPoly)`

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -796,7 +796,7 @@ function Base.deepcopy_internal(a::MPoly{T}, dict::IdDict) where {T <: RingEleme
    return parent(a)(Rc, Re)
 end
 
-Base.copy(f::Generic.MPoly) = deepcopy(f)
+Base.copy(f::Generic.MPoly) = parent(f)(copy(f.coeffs), copy(f.exps))
 
 ###############################################################################
 #


### PR DESCRIPTION
Before, `copy` did the same as `deepcopy`. Now we only copy the coefficient and exponent vectors.

Before:

    julia> R,(x,y) = polynomial_ring(QQ, [:x, :y]);

    julia> f = y^2 + 1;

    julia> @b copy(y)
    377.016 ns (17 allocs: 1.078 KiB)

    julia> @b copy(f)
    561.188 ns (26 allocs: 1.656 KiB)

After:

    julia> R,(x,y) = polynomial_ring(QQ, [:x, :y]);

    julia> f = y^2 + 1;

    julia> @b copy(y)
    120.892 ns (5 allocs: 224 bytes)

    julia> @b copy(f)
    117.348 ns (5 allocs: 256 bytes)


However, the downside are potential aliasing issues... For `f.exp` I think there is no problem as it has type `Matrix{UInt64}`. But perhaps `f.coeffs` should still be deepcopied?

Should we decide to merge it, it might be best to treat this as "breaking" and mention it explicitly in the release notes, as someone somewhere might have code that relies on the current behavior.


Thoughts @joschmitt @thofma @fieker  ?