### PR TITLE
Remove unneeded `upgrade` for `MPoly` used for universal polynomials

### DIFF
--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -1195,19 +1195,6 @@ end
 #
 ###############################################################################
 
-function upgrade(S::UniversalPolyRing{T}, pp::MPoly{T}) where {T}
-   alloc = length(pp.coeffs)
-   n = nvars(S) - nvars(parent(pp))
-   ctx = MPolyBuildCtx(mpoly_ring(S))
-   v0 = zeros(Int, n)
-   for (c, v) in zip(coefficients(pp), exponent_vectors(pp))
-      push_term!(ctx, c, vcat(v, v0))
-   end
-   p = finish(ctx)
-   fit!(p, alloc)
-   return p
-end
-
 function upgrade(S::UniversalPolyRing{T}, pp::MPolyRingElem{T}) where {T}
    n = nvars(S) - nvars(parent(pp))
    ctx = MPolyBuildCtx(mpoly_ring(S))


### PR DESCRIPTION
Currently, there are two `upgrade` methods used in the code of the universal polynomial rings. One for the generic type `MPolyRingElem` and one specifically for the AbstractAlgebra implementation `MPoly`. The only difference is an additional call to `fit!` in the specific implementation for `MPoly`. But this doesn't do anything as the polynomial, on which this is called, already has a long enough coefficient vector.

So, I think we can safely remove this methods.