### PR TITLE
Add `_upgrade` and `_add_gens` for mpolys

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1442,6 +1442,40 @@ end
 
 ###############################################################################
 #
+#  Universal polynomial ring methods
+#
+###############################################################################
+
+@doc raw"""
+    _upgrade(p::MPolyRingElem{T}, R::MPolyRing{T}) where {T}
+
+Return an element of `R` which is obtained from `p` by mapping the $i$-th variable
+of `parent(p)` to the $i$-th variable of `R`.
+For this to work, `R` needs to have at least as many variables as `parent(p)`.
+"""
+function _upgrade(p::MPolyRingElem{T}, R::MPolyRing{T}) where {T}
+   n = nvars(R) - nvars(parent(p))
+   n < 0 && error("Too few variables")
+   ctx = MPolyBuildCtx(R)
+   v0 = zeros(Int, n)
+   for (c, v) in zip(coefficients(p), exponent_vectors(p))
+      push_term!(ctx, c, vcat(v, v0))
+   end
+   return finish(ctx)
+end
+
+@doc raw"""
+    _add_gens(R::MPolyRing, varnames::Vector{Symbol})
+
+Return a new uncached multivariate polynomial ring which has the same properties
+as `R` but `varnames` as additional generators.
+"""
+function _add_gens(R::MPolyRing, varnames::Vector{Symbol})
+   return polynomial_ring_only(base_ring(R), vcat(symbols(R), varnames); internal_ordering=internal_ordering(R), cached=false)
+end
+
+###############################################################################
+#
 #  Factorization
 #
 ###############################################################################


### PR DESCRIPTION
This is a follow up of #2182 and it replaces #2192. As discussed in #2193 and #2192 respectively, I haven't exported the two new methods. For now they are very specialized just for the current usecase of the universal polynomial ring and what will be become the universal ring. In the future `im_func` from OSCAR could be moved to AbstractAlgebra to replace `_upgrade`. With `im_func` it would theoretically be possible to perform some computations in smaller rings. Currently, if we have the polynomials `f=x` and `g=z` in a universal polynomial ring, which was created with the only generator `x` and later extended by `y` and `z`, their sum would be computed by mapping `f` and `g` to a multivariate polynomial ring in `x`, `y` and `z`. But with `im_func` they could also be mapped to a multivariate polynomial ring in just `x` and `z`. With larger examples this could potentially decrease computation time.

The diff to #2182 shouldn't be breaking.