### PR TITLE
Use `NCRingElement` instead of `Union{RingElement, NCRingElem}`

### DIFF
--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -10,15 +10,15 @@
 #
 ###############################################################################
 
-parent_type(::Type{FreeModuleElem{T}}) where T <: Union{RingElement, NCRingElem} = FreeModule{T}
+parent_type(::Type{FreeModuleElem{T}}) where T <: NCRingElement = FreeModule{T}
 
-base_ring_type(::Type{FreeModule{T}}) where T <: Union{RingElement, NCRingElem} = parent_type(T)
+base_ring_type(::Type{FreeModule{T}}) where T <: NCRingElement = parent_type(T)
 
-base_ring(M::FreeModule{T}) where T <: Union{RingElement, NCRingElem} = M.base_ring::parent_type(T)
+base_ring(M::FreeModule{T}) where T <: NCRingElement = M.base_ring::parent_type(T)
 
-elem_type(::Type{FreeModule{T}}) where T <: Union{RingElement, NCRingElem} = FreeModuleElem{T}
+elem_type(::Type{FreeModule{T}}) where T <: NCRingElement = FreeModuleElem{T}
 
-parent(m::FreeModuleElem{T}) where T <: Union{RingElement, NCRingElem} = m.parent
+parent(m::FreeModuleElem{T}) where T <: NCRingElement = m.parent
 
 function rels(M::FreeModule{T}) where T <: RingElement
    # there are no relations in a free module
@@ -28,11 +28,11 @@ end
 is_free(M::FreeModule) = true
 
 @doc raw"""
-    rank(M::FreeModule{T}) where T <: Union{RingElement, NCRingElem}
+    rank(M::FreeModule{T}) where T <: NCRingElement
 
 Return the rank of the given free module.
 """
-rank(M::FreeModule{T}) where T <: Union{RingElement, NCRingElem} = M.rank
+rank(M::FreeModule{T}) where T <: NCRingElement = M.rank
 
 @doc raw"""
     dim(M::FreeModule{T}) where T <: FieldElement
@@ -42,13 +42,13 @@ Return the dimension of the given vector space.
 dim(M::FreeModule{T}) where T <: FieldElement = M.rank
 vector_space_dim(M::FreeModule{T}) where T <: FieldElement = M.rank
 
-number_of_generators(M::FreeModule{T}) where T <: Union{RingElement, NCRingElem} = M.rank
+number_of_generators(M::FreeModule{T}) where T <: NCRingElement = M.rank
 
-function gens(N::FreeModule{T}) where T <: Union{RingElement, NCRingElem}
+function gens(N::FreeModule{T}) where T <: NCRingElement
    return [gen(N, i) for i = 1:ngens(N)]
 end
 
-function gen(N::FreeModule{T}, i::Int) where T <: Union{RingElement, NCRingElem}
+function gen(N::FreeModule{T}, i::Int) where T <: NCRingElement
    @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
    m = zero_matrix(R, 1, ngens(N))
@@ -66,7 +66,7 @@ Base.hash(a::FreeModuleElem, h::UInt) = hash(a.v, h)
 #
 ###############################################################################
 
-function show(io::IO, M::FreeModule{T}) where T <: Union{RingElement, NCRingElem}
+function show(io::IO, M::FreeModule{T}) where T <: NCRingElement
    @show_name(io, M)
    @show_special(io, M)
    print(io, "Free module of rank ")
@@ -103,7 +103,7 @@ end
 #
 ###############################################################################
 
-function (M::FreeModule{T})(a::Vector{T}) where T <: Union{RingElement, NCRingElem}
+function (M::FreeModule{T})(a::Vector{T}) where T <: NCRingElement
    length(a) != rank(M) && error("Number of elements does not equal rank")
    R = base_ring(M)
    v = matrix(R, 1, length(a), a)
@@ -111,7 +111,7 @@ function (M::FreeModule{T})(a::Vector{T}) where T <: Union{RingElement, NCRingEl
    return z
 end
 
-#function (M::FreeModule{T})(a::Vector{<: Integer}) where T <: Union{RingElement, NCRingElem}
+#function (M::FreeModule{T})(a::Vector{<: Integer}) where T <: NCRingElement
 #   length(a) != rank(M) && error("Number of elements does not equal rank")
 #   R = base_ring(M)
 #   v = matrix(R, 1, length(a), a)
@@ -119,7 +119,7 @@ end
 #   return z
 #end
 
-function (M::FreeModule{T})(a::Vector{S}) where {T <: Union{RingElement, NCRingElem}, S <: RingElement}
+function (M::FreeModule{T})(a::Vector{S}) where {T <: NCRingElement, S <: RingElement}
    length(a) != rank(M) && error("Number of elements does not equal rank")
    R = base_ring(M)
    v = matrix(R, 1, length(a), a)
@@ -127,12 +127,12 @@ function (M::FreeModule{T})(a::Vector{S}) where {T <: Union{RingElement, NCRingE
    return z
 end
 
-function (M::FreeModule{T})(a::Vector{Any}) where T <: Union{RingElement, NCRingElem}
+function (M::FreeModule{T})(a::Vector{Any}) where T <: NCRingElement
    length(a) != 0 && error("Incompatible element")
    return M(T[])
 end
 
-function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: Union{RingElement, NCRingElem}
+function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: NCRingElement
    ncols(a) != rank(M) && error("Number of elements does not equal rank")
    nrows(a) != 1 && error("Matrix should have single row")
    z = FreeModuleElem{T}(M, a)

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1344,11 +1344,11 @@ end
 #
 ###############################################################################
 
-@attributes mutable struct FreeModule{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModule{T}
+@attributes mutable struct FreeModule{T <: NCRingElement} <: AbstractAlgebra.FPModule{T}
    rank::Int
    base_ring::NCRing
 
-   function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true) where T <: Union{RingElement, NCRingElem}
+   function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true) where T <: NCRingElement
       return get_cached!(FreeModuleDict, (R, rank), cached) do
          new{T}(rank, R)
       end::FreeModule{T}
@@ -1357,11 +1357,11 @@ end
 
 const FreeModuleDict = CacheDictType{Tuple{NCRing, Int}, FreeModule}()
 
-struct FreeModuleElem{T <: Union{RingElement, NCRingElem}} <: AbstractAlgebra.FPModuleElem{T}
+struct FreeModuleElem{T <: NCRingElement} <: AbstractAlgebra.FPModuleElem{T}
    parent::FreeModule{T}
    v::MatElem{T}
 
-   function FreeModuleElem{T}(m::FreeModule{T}, v::MatElem{T}) where T <: Union{RingElement, NCRingElem}
+   function FreeModuleElem{T}(m::FreeModule{T}, v::MatElem{T}) where T <: NCRingElement
       new{T}(m, v)
    end
 end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -3322,7 +3322,7 @@ function (a::MPoly{T})(val::U, vals::U...) where {T <: RingElement, U <: Union{I
 end
 
 @doc raw"""
-    (a::MPoly{T})(vals::Union{NCRingElem, RingElement}...) where T <: RingElement
+    (a::MPoly{T})(vals::NCRingElement...) where T <: RingElement
 
 Evaluate the polynomial at the supplied values, which may be any ring elements,
 commutative or non-commutative. Evaluation always proceeds in the order of the
@@ -3332,7 +3332,7 @@ all of the supplied values in order is defined. Note that this evaluation is
 more general than those provided by the evaluate function. The values do not
 need to be in the same ring, just in compatible rings.
 """
-function (a::MPoly{T})(vals::Union{NCRingElem, RingElement}...) where T <: RingElement
+function (a::MPoly{T})(vals::NCRingElement...) where T <: RingElement
    length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    R = base_ring(a)
    # The best we can do here is to cache previously used powers of the values

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -141,7 +141,7 @@ function (N::QuotientModule{T})(v::Vector{T}) where T <: RingElement
    return QuotientModuleElem{T}(N, mat)
 end
 
-function (M::QuotientModule{T})(a::Vector{Any}) where T <: Union{RingElement, NCRingElem}
+function (M::QuotientModule{T})(a::Vector{Any}) where T <: NCRingElement
    length(a) != 0 && error("Incompatible element")
    return M(T[])
 end

--- a/src/generic/UnivPoly.jl
+++ b/src/generic/UnivPoly.jl
@@ -851,7 +851,7 @@ function (a::UnivPoly{T})(val::V, vals::V...) where {T <: RingElement, V <: Unio
    return evaluate(a, [val, vals...])
 end
 
-function (a::UnivPoly{T})(vals::Union{NCRingElem, RingElement}...) where {T <: RingElement}
+function (a::UnivPoly{T})(vals::NCRingElement...) where {T <: RingElement}
    A = [vals...]
    n = length(vals)
    num = nvars(parent(data(a)))


### PR DESCRIPTION
As far as I understand the type hierarchy this should be functionally equivalent.