### PR TITLE
Fix `is_power` for e.g. `ZZPolyRing`

### DIFF
--- a/src/generic/Misc/Poly.jl
+++ b/src/generic/Misc/Poly.jl
@@ -9,10 +9,10 @@ function is_power(a::PolyRingElem, n::Int)
     # probably a equal-degree-factorisation would be good + some more gcd's
     # implement some Newton-type algo?
     degree(a) % n == 0 || return false, a
-    fl, x = is_power(leading_coefficient(a), n)
-    fl || return false, a
     f = factor(a)
     all(i % n == 0 for (_, i) in f) || return false, a
+    fl, x = is_power(constant_coefficient(f.unit), n)
+    fl || return false, a
     return true, x*prod(p^div(k, n) for (p, k) = f)
 end
 


### PR DESCRIPTION
Without this, we get in Nemo:

    julia> ZZx, x = ZZ[:x];  is_power(2^2 * x^2, 2)
    (true, 4*x)

With it, the correct result is produced:

    julia> ZZx, x = ZZ[:x];  is_power(2^2 * x^2, 2)
    (true, 2*x)


Motivated by #2051 which also contains some tests for this, which requires implementing factorization for some rings in AA... I did not want to go to these lengths, so i run the above and a couple other tests in Nemo... That is:

```
ZZx, x = ZZ[:x]
#QQx, x = QQ[:x]

@test is_power(x, 2) == (false, x)
@test is_power(x, 3) == (false, x)
@test is_power(x^2, 2) == (true, x)
@test is_power(3 * x^2, 2) == (false, 3 * x^2)
@test is_power(2^2 * x^2, 2) == (true, 2 * x)
@test is_power(2^3 * x^3, 3) == (true, 2 * x)
@test is_power(3^4 * x^4, 2) == (true, 9 * x^2)
@test is_power(-3^4 * x^4, 2) == (false, -81 * x^4)
@test is_power(-3^3 * x^3, 3) == (true, -3 * x)
@test is_power(3^2 * (x + 1)^2 * x^2, 2) == (true, 3 * (x + 1) * x)
@test is_power(-3^2 * (x + 1)^2 * x^2, 2) == (false, -3^2 * (x + 1)^2 * x^2)
```
Once with the ring over ZZ and once with the one over QQ.