### PR TITLE
chore: Bump version to 0.47.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.47.5"
+version = "0.47.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
To be merged and released asap after https://github.com/Nemocas/AbstractAlgebra.jl/pull/2242 to unbreak the Nemo docs