### PR TITLE
Remove `getindex(::SimpleNumField, ::Int)`, rely on generic `getindex(::Set,::Int)` instead (hence `L[0]` won't return `one(L)` anymore) 

### DIFF
--- a/src/NumFields.jl
+++ b/src/NumFields.jl
@@ -5,16 +5,6 @@ function gen(L::SimpleNumField{T}, i::Int) where {T}
    return gen(L)
 end
 
-function Base.getindex(L::SimpleNumField{T}, i::Int) where {T}
-   if i == 0
-      return one(L)
-   elseif i == 1
-      return gen(L)
-   else
-      error("index has to be 0 or 1")
-   end
-end
-
 number_of_generators(L::SimpleNumField{T}) where {T} = 1
 
 characteristic(F::NumField) = 0


### PR DESCRIPTION
The generic `getindex(::Set,::Int)` suffices.

This means dropping the feature that `L[0]` returns `one(L)`. Arguably that's not great loss, it is trivial to rewrite code to use `one(L)`.

