### PR TITLE
Fix bug in `*(::Ideal,::RingElement)`

### DIFF
--- a/src/Ideal.jl
+++ b/src/Ideal.jl
@@ -147,7 +147,7 @@ function *(p::T, I::Ideal{T}) where T <: RingElement
   return I*p
 end
 
-function *(I::Ideal{<:RingElement}, p::RingElement)
+function *(I::Ideal{T}, p::RingElement) where T <: RingElement
   R = base_ring(I)
   iszero(p*one(R)) && return ideal(R, T[])
   return ideal(R, [v*p for v in gens(I)])


### PR DESCRIPTION
Found by JET: T was not being defined.

Luckily this is brand new code, but it is unfortunate that it obviously doesn't get tested. I had tests in an earlier version, using Generic.Ideal, but had to reinstate the `*` etc. methods for `Generic.Ideal`. I'll see if I can bring it back, at least in limited fashion.