### PR TITLE
Help JET prove that nrows/ncols returns Int

### DIFF
--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -29,9 +29,7 @@ function Base.hash(a::MatRingElem, h::UInt)
    return b
 end
 
-number_of_rows(a::MatRing) = a.n
-number_of_columns(a::MatRing) = number_of_rows(a)
-vector_space_dim(a::MatRing{T}) where {T <: Union{FieldElem, Rational{BigInt}}} = a.n * a.n
+vector_space_dim(a::MatRing{T}) where {T <: Union{FieldElem, Rational{BigInt}}} = nrows(a)^2
 
 @doc raw"""
     degree(a::MatRing)

--- a/src/generic/MatRing.jl
+++ b/src/generic/MatRing.jl
@@ -35,6 +35,10 @@ is_domain_type(::Type{MatRingElem{T}}) where T <: NCRingElement = false
 #
 ###############################################################################
 
+number_of_rows(a::MatRing) = a.n
+
+number_of_columns(a::MatRing) = number_of_rows(a)
+
 number_of_rows(a::MatRingElem) = nrows(matrix(a))
 
 number_of_columns(a::MatRingElem) = ncols(matrix(a))

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -43,9 +43,12 @@ dense_matrix_type(::Type{T}) where T <: NCRingElement = MatSpaceElem{T}
 #
 ###############################################################################
 
-number_of_rows(a::Mat) = size(a.entries, 1)
+number_of_rows(a::MatSpaceElem) = size(a.entries, 1)
+number_of_columns(a::MatSpaceElem) = size(a.entries, 2)
 
-number_of_columns(a::Mat) = size(a.entries, 2)
+number_of_rows(a::MatSpaceView) = size(a.entries, 1)
+number_of_columns(a::MatSpaceView) = size(a.entries, 2)
+
 
 Base.@propagate_inbounds getindex(a::Mat, r::Int, c::Int) = a.entries[r, c]
 

--- a/src/julia/Matrix.jl
+++ b/src/julia/Matrix.jl
@@ -4,8 +4,8 @@
 #
 ###############################################################################
 
-number_of_rows(A::Matrix{T}) where {T} = size(A)[1]
-number_of_columns(A::Matrix{T}) where {T} = size(A)[2]
+number_of_rows(A::Matrix{T}) where {T} = size(A, 1)
+number_of_columns(A::Matrix{T}) where {T} = size(A, 2)
 
 ###############################################################################
 #


### PR DESCRIPTION
To do this, restrict some nrows/ncols method signatures which access
struct field from the abstract type Generic.Mat to the concrete
types Generic.MatSpaceElem and Generic.MatSpaceView; and from MatRing
to Generic.MatRing.

Also rewrite `vector_space_dim(::MatRing)` in terms of `nrows` instead
of attempting to access a struct field.
