### PR TITLE
Update `canonical_unit` docs to match current reality

### DIFF
--- a/docs/src/ring_interface.md
+++ b/docs/src/ring_interface.md
@@ -317,8 +317,9 @@ denominator, this would be $-1$.
 
 For non-zero elements of a field, `canonical_unit` simply returns the element itself.
 In general, `canonical_unit` of an invertible element should be that element.
-Finally, if $a = ub$ we should have the identity
-`canonical_unit(a) = canonical_unit(u)*canonical_unit(b)`.
+Finally, if $a = bc$, then `canonical_unit(a)*a = canonical_unit(b)*canonical_unit(c)*a`
+holds. Thus if $a$ is not a zero-divisor, then we even have
+`canonical_unit(a) = canonical_unit(b)*canonical_unit(c)`.
 
 For some rings, it is completely impractical to implement this function, in which case
 it may return $1$ in the given ring. The function must however always exist, and always


### PR DESCRIPTION
However, what we really should do is turn that text into a docstring for `canonical_unit`.

Also the text is misleading (see issue #1254), and it doesn't explain very well what `canonical_unit` does, IMHO -- and it should clarify that the "canonical_unit" is not canonical itself, but rather is used to produce a canonical value (if possible at all), namely `x/canonical_unit(x)` is "canonical" (or not -- given that the text proceeds to explain that it is allowed to implement `canonical_unit(x::MyRingType) = one(x)`. So I guess we really should have a function that tests when `canonical_unit` does something useful? Like `has_actually_useful_canonical_unit(x)` or so