### PR TITLE
Remove dubious group interface conformance test for `gens`

### DIFF
--- a/ext/TestExt/Groups-conformance-tests.jl
+++ b/ext/TestExt/Groups-conformance-tests.jl
@@ -66,10 +66,6 @@ function test_Group_interface(G::Group)
                   @test first(gens(G)) == gen(G, 1)
                   @test last(gens(G)) == gen(G, ngens(G))
               end
-          else
-              # TODO: throw something more specific
-              @test_throws ErrorException gens(G)
-              @test_throws ErrorException ngens(G)
           end
       end
 


### PR DESCRIPTION
The removed test contradicted the `has_gens` docstring, which states:

> Note that the result of this function when applied to a
> specific group instance can change over time, as side effect
> of a generating set becoming available for the group.

Indeed, calling `gens` on a group `G` for which `has_gens(G)` may have at least three different outcomes:
1. it may throw an exception (as the test assumed),
2. it may compute and return generators,
3. it may not terminate while trying to compute generators.

Both 2 and 3 occur with certain group implementations, so the removed test not just was incorrect but also could make it impossible to use the conformance tests for certain groups, as they would get stuck in an endless loop.