### PR TITLE
Remove bad `transpose(::MatRingElem)` method

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1516,8 +1516,6 @@ function transpose(x::MatElem)
   return transpose!(z, x)
 end
 
-transpose(x::MatRingElem) = transpose(matrix(x))
-
 @doc raw"""
     transpose!(x::MatElem)
     transpose!(x::MatRingElem)


### PR DESCRIPTION
It had the wrong return type. Note that a correct one is defined in src/generic/MatRing.jl for Generic.MatRingElem