### PR TITLE
Add `^(I::Ideal, k::Integer)` fallback method

### DIFF
--- a/src/Ideal.jl
+++ b/src/Ideal.jl
@@ -123,6 +123,25 @@ function Base.:*(I::T, J::T) where {T <: Ideal{<:RingElement}}
   return ideal(base_ring(I), [x*y for x in gens(I) for y in gens(J)])
 end
 
+function Base.:^(I::Ideal, k::Integer)
+  k >= 0 || error("exponent must be non-negative")
+  k == 1 && return I
+
+  # exponentiate by square-and-multiply
+  R = base_ring(I)
+  J = ideal(R, one(R))
+  while k > 0
+    while iseven(k)
+      I *= I
+      k >>= 1
+    end
+    J *= I
+    k -= 1
+  end
+
+  return J
+end
+
 ###############################################################################
 #
 #   Ad hoc binary operations

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -25,6 +25,10 @@ function is_exact_type(a::Type{T}) where {S <: RingElement, T <: PolyRingElem{S}
    return is_exact_type(S)
 end
 
+# ideal interface
+ideal_type(::Type{T}) where T <: PolyRing = Generic.Ideal{elem_type(T)}
+ideal(R::PolyRing{<:FieldElement}, V::Vector) = Generic.Ideal(R, V)
+
 @doc raw"""
     var(a::PolyRing)
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -28,6 +28,10 @@ is_domain_type(::Type{T}) where T <: Integer = true
 
 base_ring(::Vector{T}) where T <: Integer = T
 
+# ideal interface
+ideal_type(::Type{Integers{T}}) where T <: Integer = Generic.Ideal{T}
+ideal(R::Integers, V::Vector) = Generic.Ideal(R, V)
+
 ###############################################################################
 #
 #   Basic manipulation

--- a/test/generic/Ideal-test.jl
+++ b/test/generic/Ideal-test.jl
@@ -684,3 +684,52 @@ end
       @test is_subset(K, J)
    end
 end
+
+@testset "Generic.Ideal.power" begin
+   # QQ[x]
+   R, x = polynomial_ring(QQ, "x")
+
+   for i = 1:30
+      n = rand(0:5)
+      V = elem_type(R)[rand(R, 0:5, -10:10) for i in 1:n]
+
+      I = Generic.Ideal(R, V)
+      J = Generic.Ideal(R, one(R))
+
+      for k in 0:5
+        @test I^k == J
+        J *= I
+      end
+   end
+
+   # Fp[x]
+   Fp = GF(31)
+   R, x = polynomial_ring(Fp, "x")
+
+   for i = 1:30
+      n = rand(0:10)
+      V = elem_type(R)[rand(R, 0:5) for i in 1:n]
+
+      I = Generic.Ideal(R, V)
+      J = Generic.Ideal(R, one(R))
+
+      for k in 0:5
+        @test I^k == J
+        J *= I
+      end
+   end
+
+   # integer
+   for i = 1:30
+      n = rand(0:10)
+      V = elem_type(ZZ)[rand(ZZ, -10:10) for i in 1:n]
+
+      I = Generic.Ideal(ZZ, V)
+      J = Generic.Ideal(ZZ, one(ZZ))
+
+      for k in 0:5
+        @test I^k == J
+        J *= I
+      end
+   end
+end


### PR DESCRIPTION
Also implement `ideal`, `ideal_type` for integers and univariate polynomial rings over fields, so that we can have some tests for the new `^` method.


I wrote this well over a month ago but then forgot to submit it after my previous "ideal" PRs got merged :-(

(It would be nice to have because we can then remove more code in OSCAR and possible Hecke, but since it should be non-breaking, it could also come later)