### PR TITLE
Remove `similar` and `zero` methods for `MatRingElem` which took a row and column count as argument, despite matrix ring elements being square

### DIFF
--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -94,14 +94,6 @@ end
 
 similar(x::MatRingElem, n::Int) = similar(x, base_ring(x), n)
 
-# TODO: deprecate these:
-function similar(x::MatRingElem{T}, R::NCRing, m::Int, n::Int) where T <: NCRingElement
-   m != n && error("Dimensions don't match in similar")
-   return similar(x, R, n)
-end
-
-similar(x::MatRingElem, m::Int, n::Int) = similar(x, base_ring(x), m, n)
-
 @doc raw"""
     zero(x::MatRingElem, R::NCRing, n::Int)
     zero(x::MatRingElem, R::NCRing)
@@ -113,10 +105,6 @@ with defaults based upon the given source matrix ring element `x`.
 """
 zero(x::MatRingElem, R::NCRing=base_ring(x), n::Int=degree(x)) = zero!(similar(x, R, n))
 zero(x::MatRingElem, n::Int) = zero!(similar(x, n))
-
-# TODO: deprecate these
-zero(x::MatRingElem, R::NCRing, r::Int, c::Int) = zero!(similar(x, R, r, c))
-zero(x::MatRingElem, r::Int, c::Int) = zero!(similar(x, r, c))
 
 iszero(a::MatRingElem{T}) where T <: NCRingElement = iszero(matrix(a))
 

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -123,14 +123,6 @@ end
 
 similar(A::MatRingElem, n::Int) = similar(A, base_ring(A), n)
 
-# TODO: deprecate these:
-function similar(A::MatRingElem{T}, R::NCRing, m::Int, n::Int) where T <: NCRingElement
-   m != n && error("Dimensions don't match in similar")
-   return similar(A, R, n)
-end
-
-similar(A::MatRingElem, m::Int, n::Int) = similar(A, base_ring(A), m, n)
-
 @doc raw"""
     zero(A::MatRingElem, R::NCRing, n::Int)
     zero(A::MatRingElem, R::NCRing)
@@ -142,10 +134,6 @@ with defaults based upon the given source matrix ring element `A`.
 """
 zero(A::MatRingElem, R::NCRing=base_ring(A), n::Int=degree(A)) = zero!(similar(A, R, n))
 zero(A::MatRingElem, n::Int) = zero!(similar(A, n))
-
-# TODO: deprecate these
-zero(A::MatRingElem, R::NCRing, r::Int, c::Int) = zero!(similar(A, R, r, c))
-zero(A::MatRingElem, r::Int, c::Int) = zero!(similar(A, r, c))
 
 iszero(A::MatRingElem{T}) where T <: NCRingElement = iszero(matrix(A))
 

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -505,6 +505,18 @@ function fflu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingE
   return r, d, p, S(L), S(U)
 end
 
+function lu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+  S = parent(A)
+  r, p, L, U = lu(matrix(A), P)
+  return r, p, S(L), S(U)
+end
+
+function fflu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+  S = parent(A)
+  r, d, p, L, U = fflu(matrix(A), P)
+  return r, d, p, S(L), S(U)
+end
+
 ###############################################################################
 #
 #   Random generation

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1869,7 +1869,7 @@ $p$ of $A$ belonging to $P$, a lower triangular matrix $L$ and an upper
 triangular matrix $U$ such that $p(A) = LU$, where $p(A)$ stands for the
 matrix whose rows are the given permutation $p$ of the rows of $A$.
 """
-function lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+function lu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
@@ -1896,6 +1896,12 @@ function lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldEle
       end
    end
    return rank, p, L, U
+end
+
+function lu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+  S = parent(A)
+  r, p, L, U = lu(matrix(A))
+  return r, p, S(L), S(U)
 end
 
 function fflu!(P::Perm, A::MatrixElem{T}) where {T <: RingElement}
@@ -2025,7 +2031,7 @@ $\pm \mathrm{det}(S)$ where $S$ is an appropriate submatrix of $A$ ($S = A$ if
 $A$ is square and nonsingular) and the sign is decided by the parity of the
 permutation.
 """
-function fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+function fflu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
@@ -2065,6 +2071,12 @@ function fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingEl
    end
 
    return rank, d, p, L, U
+end
+
+function fflu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+  S = parent(A)
+  rank, d, p, L, U = fflu(matrix(A))
+  return rank, d, p, S(L), S(U)
 end
 
 ###############################################################################

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -185,8 +185,8 @@ end
    @test isempty(M) == false
    @test isassigned(M, 1, 1) == true
 
-   @test iszero(zero(M, 3, 3))
-   @test iszero(zero(M, QQ, 3, 3))
+   @test iszero(zero(M, 3))
+   @test iszero(zero(M, QQ, 3))
    @test iszero(zero(M, QQ))
 
    M = zero!(M)
@@ -1380,11 +1380,6 @@ end
       @test !test_zero || iszero(n)
       @test parent(n) == matrix_ring(R, r)
       @test size(n) == (r, r)
-      nn = sim_zero(m, r, r)
-      @test !test_zero || iszero(nn)
-      @test parent(nn) == matrix_ring(R, r)
-      @test size(nn) == (r, r)
-      @test_throws ErrorException sim_zero(m, r, r+1)
       for S = [QQ, ZZ, GF(2), GF(5)]
          n = sim_zero(m, S)
          @test !test_zero || iszero(n)
@@ -1395,11 +1390,6 @@ end
          @test !test_zero || iszero(n)
          @test parent(n) == matrix_ring(S, r)
          @test size(n) == (r, r)
-         n = sim_zero(m, S, r, r)
-         @test !test_zero || iszero(n)
-         @test parent(n) == matrix_ring(S, r)
-         @test size(n) == (r, r)
-         @test_throws ErrorException sim_zero(m, S, r, r+2)
       end
    end
 end

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -185,8 +185,8 @@ end
    @test isempty(M) == false
    @test isassigned(M, 1, 1) == true
 
-   @test iszero(zero(M, 3, 3))
-   @test iszero(zero(M, QQ, 3, 3))
+   @test iszero(zero(M, 3))
+   @test iszero(zero(M, QQ, 3))
    @test iszero(zero(M, QQ))
 
    M = zero!(M)
@@ -1385,11 +1385,6 @@ end
       @test !test_zero || iszero(n)
       @test parent(n) == matrix_ring(R, r)
       @test size(n) == (r, r)
-      nn = sim_zero(m, r, r)
-      @test !test_zero || iszero(nn)
-      @test parent(nn) == matrix_ring(R, r)
-      @test size(nn) == (r, r)
-      @test_throws ErrorException sim_zero(m, r, r+1)
       for S = [QQ, ZZ, GF(2), GF(5)]
          n = sim_zero(m, S)
          @test !test_zero || iszero(n)
@@ -1400,11 +1395,6 @@ end
          @test !test_zero || iszero(n)
          @test parent(n) == matrix_ring(S, r)
          @test size(n) == (r, r)
-         n = sim_zero(m, S, r, r)
-         @test !test_zero || iszero(n)
-         @test parent(n) == matrix_ring(S, r)
-         @test size(n) == (r, r)
-         @test_throws ErrorException sim_zero(m, S, r, r+2)
       end
    end
 end


### PR DESCRIPTION
Argh, forgot about these, and now 0.48.0 is out. Ah well, perhaps better this way, so that we can get CI tests for this (once everything has updated to 0.48.0).