### PR TITLE
Fix `roots(::PolyRingElem)` if coeffs are not in a field

### DIFF
--- a/src/generic/Misc/Poly.jl
+++ b/src/generic/Misc/Poly.jl
@@ -59,7 +59,8 @@ function roots(f::PolyRingElem)
     rts = Vector{elem_type(base_ring(f))}()
     for (p, e) in lf
         if degree(p) == 1
-            push!(rts, -divexact(constant_coefficient(p), leading_coefficient(p)))
+            fl, q = divides(constant_coefficient(p), leading_coefficient(p))
+            fl && push!(rts, -q)
         end
     end
     return rts


### PR DESCRIPTION
For example, this now works but previously gave an error:

    julia> Zx,x = ZZ[:x];  roots(2x + 1)
    ZZRingElem[]

No test as we can't factor here... Can be verified in Nemo, though.