### PR TITLE
Pass through version to the script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     # Run the update script
     - name: Run python script
-      uses: oscar-system/changelog-script@master
+      uses: oscar-system/changelog-script@v1
       with:
         conffile: "dev/releases/config.toml"
         changelogfile: "CHANGELOG.md"


### PR DESCRIPTION
This should be the only change required to fix the minor issues we had with the changelog action.

The issue where PR #2235 was repeated was because it was merged on the same day as 0.47.6 (but earlier in the day). This is corrected by the changelog script using the full timestamp, not just the date, of the last tag ( https://github.com/oscar-system/changelog-script/commit/fb0ac581759a93901aa54472d5b0328a661d7fe2 ).

[skip ci]

------------

The action run manually against this branch ( https://github.com/Nemocas/AbstractAlgebra.jl/actions/runs/20923301978/job/60114319698 ) confirms that the version string goes through.


