### PR TITLE
Add script for running JET with options

### DIFF
--- a/dev/jet.jl
+++ b/dev/jet.jl
@@ -1,6 +1,7 @@
 using Revise
 using JET
 
+# can be dropped once https://github.com/aviatesk/JET.jl/pull/798 is available
 struct AnyFrameMethod <: ReportMatcher
     m::Union{Function,Method,Symbol}
 end
@@ -18,4 +19,6 @@ function JET.match_report(matcher::AnyFrameMethod, @nospecialize(report::JET.Inf
 end
 
 using AbstractAlgebra
-report_package(AbstractAlgebra; ignored_modules=[AnyFrameMethod(:show_spec_linfo)])
+report_package(AbstractAlgebra; ignored_modules=[
+    AnyFrameMethod(:show_spec_linfo), # fixed in https://github.com/JuliaLang/julia/pull/60645
+])


### PR DESCRIPTION
E.g. to ignore warnings from inside Julia's stdlib. Of course we can try to fix them there (in this case, @lgoettgens already did so, but the relevant fix is not yet in a Julia release).

See also <https://github.com/oscar-system/GAP.jl/pull/1312/>

I've also tried to [upstream `AnyFrameMethod`](https://github.com/aviatesk/JET.jl/pull/798), that will allow reducing the script's size.