### PR TITLE
Reduce reps for conformance tests

### DIFF
--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -15,7 +15,7 @@
 # - test_MatRing_interface(R)
 
 
-function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
+function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 15)
 
    T = elem_type(R)
 
@@ -219,7 +219,7 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 50)
 end
 
 
-function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
+function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 15)
 
    T = elem_type(R)
 
@@ -284,7 +284,7 @@ function test_Ring_interface(R::AbstractAlgebra.Ring; reps = 50)
    return nothing
 end
 
-function test_Field_interface(R::AbstractAlgebra.Field; reps = 50)
+function test_Field_interface(R::AbstractAlgebra.Field; reps = 15)
 
    T = elem_type(R)
 
@@ -312,7 +312,7 @@ function test_Field_interface(R::AbstractAlgebra.Field; reps = 50)
    return nothing
 end
 
-function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 20)
+function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 15)
 
    T = elem_type(R)
 
@@ -404,7 +404,7 @@ function test_EuclideanRing_interface(R::AbstractAlgebra.Ring; reps = 20)
 end
 
 
-function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
+function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 10)
 
    T = elem_type(Rx)
 
@@ -511,7 +511,7 @@ function test_Poly_interface(Rx::AbstractAlgebra.PolyRing; reps = 30)
 end
 
 
-function test_MPoly_interface(Rxy::AbstractAlgebra.MPolyRing; reps = 30)
+function test_MPoly_interface(Rxy::AbstractAlgebra.MPolyRing; reps = 10)
 
    # for simplicity, these tests for now assume exactly two generators
    @assert ngens(Rxy) == 2
@@ -650,7 +650,7 @@ function test_MPoly_interface(Rxy::AbstractAlgebra.MPolyRing; reps = 30)
 end
 
 
-function test_MatSpace_interface(S::MatSpace; reps = 20)
+function test_MatSpace_interface(S::MatSpace; reps = 10)
 
    ST = elem_type(S)
    R = base_ring(S)
@@ -766,7 +766,7 @@ function test_MatSpace_interface(S::MatSpace; reps = 20)
    return nothing
 end
 
-function test_MatRing_interface(S::MatRing; reps = 20)
+function test_MatRing_interface(S::MatRing; reps = 15)
 
    ST = elem_type(S)
    R = base_ring(S)
@@ -818,7 +818,7 @@ function test_MatRing_interface(S::MatRing; reps = 20)
    return nothing
 end
 
-function test_Ring_interface_recursive(R::AbstractAlgebra.Ring; reps = 50)
+function test_Ring_interface_recursive(R::AbstractAlgebra.Ring; reps = 15)
    test_Ring_interface(R; reps = reps)
    Rx, _ = polynomial_ring(R, :x)
    test_Poly_interface(Rx, reps = 2 + fld(reps, 2))
@@ -834,7 +834,7 @@ function test_Ring_interface_recursive(R::AbstractAlgebra.Ring; reps = 50)
    end
 end
 
-function test_Field_interface_recursive(R::AbstractAlgebra.Field; reps = 50)
+function test_Field_interface_recursive(R::AbstractAlgebra.Field; reps = 15)
    test_Ring_interface_recursive(R, reps = reps)
    test_Field_interface(R, reps = reps)
 end


### PR DESCRIPTION
This might help us to get Nemo to pass in Nanosoldier again. It seems conformance tests for a ring there can take *minutes*. [In this log](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2026-01/26/Nemo.primary.log) we see e.g.:
```
QQFieldElem.conformance_tests | 65244  65244  1m47.3s
...
FqPolyRepFieldElem.conformance_tests | 65187  65187  2m02.4s
...
AbsSimpleNumFieldElem.conformance_tests | 65537  65537  2m29.7s
```
No idea why exactly it is *that* slow -- on my laptop it takes. Nanosoldier gave up about 43 minutes. 


Anyway, on my laptop, I see this *before* this PR:
```
QQFieldElem.conformance_tests | 65485  65485  16.2s
...
FqPolyRepFieldElem.conformance_tests | 65356  65356  16.5s
...
AbsSimpleNumFieldElem.conformance_tests | 65234  65234  18.5s
```
And this *after*:
```
QQFieldElem.conformance_tests | 21659  21659  15.0s
...
FqPolyRepFieldElem.conformance_tests | 21728  21728  16.8s
...
AbsSimpleNumFieldElem.conformance_tests | 21725  21725  17.9s
```

So I am not sure it will actually help at all ... ☹️ 