### PR TITLE
Add `@nospecialize` to conformance tests

### DIFF
--- a/ext/TestExt/Groups-conformance-tests.jl
+++ b/ext/TestExt/Groups-conformance-tests.jl
@@ -16,6 +16,8 @@
 ###############################################################################
 
 
+@nospecialize
+
 function test_Group_interface(G::Group)
   @testset "Group interface" begin
 #        @testset "Iteration protocol" begin
@@ -322,3 +324,5 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
       end
   end
 end
+
+@specialize

--- a/ext/TestExt/Mutating-ops.jl
+++ b/ext/TestExt/Mutating-ops.jl
@@ -1,6 +1,8 @@
 # The following functions should not expect that their input is a `NCRingElem` or similar.
 # They should be usable in more general types, that don't even have a `parent/elem` correspondence
 
+@nospecialize
+
 function test_mutating_op_like_zero(f::Function, f!::Function, A)
   a = deepcopy(A)
   a = f!(a)
@@ -145,3 +147,5 @@ function test_mutating_op_like_addmul(f::Function, f!_::Function, Z, A, B, T = A
      end
   end
 end
+
+@specialize

--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -14,6 +14,7 @@
 # - test_MatSpace_interface(R)
 # - test_MatRing_interface(R)
 
+@nospecialize
 
 function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 15)
 
@@ -838,3 +839,5 @@ function test_Field_interface_recursive(R::AbstractAlgebra.Field; reps = 15)
    test_Ring_interface_recursive(R, reps = reps)
    test_Field_interface(R, reps = reps)
 end
+
+@specialize


### PR DESCRIPTION
Reduces the overhead for the conformance tests in CI. These are big functions which Julia has to spend a lot of effort on for no benefit.