### PR TITLE
Fix `@attributes Foo` if `AbstractAlgebra` is not imported

### DIFF
--- a/src/Attributes.jl
+++ b/src/Attributes.jl
@@ -91,13 +91,13 @@ macro attributes(expr)
       #    @attributes [Module[.Submodule].]Type{T}
       return esc(quote
          # do nothing if the type already has storage for attributes
-         if !AbstractAlgebra.is_attribute_storing_type($expr)
-           isstructtype($expr) && AbstractAlgebra.ismutabletype($expr) || error("attributes can only be attached to mutable structs")
+         if !$(@__MODULE__).is_attribute_storing_type($expr)
+           Base.isstructtype($expr) && $(@__MODULE__).ismutabletype($expr) || error("attributes can only be attached to mutable structs")
            let attr = Base.WeakKeyDict{$expr, Dict{Symbol, Any}}()
-             AbstractAlgebra._get_attributes(G::$expr) = Base.get(attr, G, nothing)
-             AbstractAlgebra._get_attributes!(G::$expr) = Base.get!(() -> Dict{Symbol, Any}(), attr, G)
-             AbstractAlgebra._get_attributes(::Type{$expr}) = attr
-             AbstractAlgebra.is_attribute_storing_type(::Type{$expr}) = true
+             $(@__MODULE__)._get_attributes(G::$expr) = Base.get(attr, G, nothing)
+             $(@__MODULE__)._get_attributes!(G::$expr) = Base.get!(() -> Dict{Symbol, Any}(), attr, G)
+             $(@__MODULE__)._get_attributes(::Type{$expr}) = attr
+             $(@__MODULE__).is_attribute_storing_type(::Type{$expr}) = true
            end
          end
       end)

--- a/test/Attributes-test.jl
+++ b/test/Attributes-test.jl
@@ -1,10 +1,12 @@
 using REPL # needed due to https://github.com/JuliaLang/julia/issues/53349
 
 module Tmp
-    using AbstractAlgebra
+    # Import under a different module name to verify the macro does
+    # not try to access AbstractAlgebra "by name"
+    import AbstractAlgebra as AA
 
     # test @attributes applied to a struct definition, using internal storage
-    @attributes mutable struct Foo
+    AA.@attributes mutable struct Foo
         x::Int
         Foo() = new(0)
     end
@@ -14,7 +16,7 @@ module Tmp
         x::Int
         Bar() = new(0)
     end
-    @attributes Bar
+    AA.@attributes Bar
 
     mutable struct Quux
         x::Int
@@ -25,7 +27,7 @@ module Tmp
     end
 
     # applying @attributes to a singleton type definition is supported but does nothing
-    @attributes struct AnotherSingleton
+    AA.@attributes struct AnotherSingleton
     end
 
     struct NotSupported
@@ -38,10 +40,10 @@ module Tmp
         x::Int
         FooBar{T}() where T = new(0)
     end
-    @attributes Tmp.FooBar{Bar}
+    AA.@attributes Tmp.FooBar{Bar}
 
 
-    @attributes mutable struct Container{T}
+    AA.@attributes mutable struct Container{T}
         x::T
         Container(x::T) where T = new{T}(x)
     end


### PR DESCRIPTION
Without this, the modified tests would report an error:
> ERROR: LoadError: UndefVarError: `AbstractAlgebra` not defined in `Main.Tmp`