### PR TITLE
Add `universal_poly_type` and `universal_poly_ring_type`

### DIFF
--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -10,6 +10,42 @@ end
 
 ###############################################################################
 #
+#   Data type and parent object methods
+#
+###############################################################################
+
+@doc raw"""
+    universal_poly_type(::Type{T}) where T<:RingElement
+    universal_poly_type(::T) where T<:RingElement
+    universal_poly_type(::Type{S}) where S<:Ring
+    universal_poly_type(::S) where S<:Ring
+
+The type of universal polynomials with coefficients of type `T` respectively `elem_type(S)`.
+Falls back to `Generic.UnivPoly{T}`.
+
+See also [`universal_poly_ring_type`](@ref), [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
+"""
+universal_poly_type(::Type{T}) where T<:RingElement = Generic.UnivPoly{T}
+universal_poly_type(::Type{S}) where S<:Ring = universal_poly_type(elem_type(S))
+universal_poly_type(x) = universal_poly_type(typeof(x)) # to stop this method from eternally recursing on itself, we better add ...
+universal_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be subtype of `RingElement`."))
+universal_poly_type(T::Type{Union{}}) = throw(MethodError(universal_poly_type, (T,)))
+
+@doc raw"""
+    mpoly_ring_type(::Type{T}) where T<:RingElement
+    mpoly_ring_type(::T) where T<:RingElement
+    mpoly_ring_type(::Type{S}) where S<:Ring
+    mpoly_ring_type(::S) where S<:Ring
+
+The type of universal polynomial rings with coefficients of type `T`
+respectively `elem_type(S)`. Implemented via [`universal_poly_type`](@ref).
+
+See also [`mpoly_type`](@ref) and [`mpoly_ring_type`](@ref).
+"""
+universal_poly_ring_type(x) = parent_type(universal_poly_type(x))
+
+###############################################################################
+#
 #   Evaluation
 #
 ###############################################################################

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -593,6 +593,8 @@ export truncate
 export typed_hcat
 export typed_hvcat
 export unit
+export universal_poly_ring_type
+export universal_poly_type
 export universal_polynomial_ring
 export upper_triangular_matrix
 export upscale

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -29,6 +29,9 @@
          @test elem_type(Generic.UniversalPolyRing{elem_type(R)}) == Generic.UnivPoly{elem_type(R)}
          @test parent_type(Generic.UnivPoly{elem_type(R)}) == Generic.UniversalPolyRing{elem_type(R)}
 
+         @test elem_type(S) == universal_poly_type(elem_type(R))
+         @test typeof(S) == universal_poly_ring_type(elem_type(R))
+
          @test coefficient_ring(S) === R
          @test coefficient_ring(S) === R
          @test coefficient_ring_type(S) === typeof(R)


### PR DESCRIPTION
To make the action polynomial code in Oscar compatible with the changes in #2274 it is necessary to introduce new functions `universal_poly_type` and `universal_poly_ring_type` similar to `mpoly_type` and `mpoly_ring_type`. Otherwise, `base_ring_type` for the action polynomials can't be implemented easily. After we make a new AbstractAlgebra release with this PR included, I'll adjust Oscar to use the new methods and then #2274 can be rebased and with the adapted  `universal_poly_type` and `universal_poly_ring_type` functions the tests should pass again.

I've chosen the name of the functions such that it can't be confused with univariate polynomials.