### PR TITLE
Move 'duplicate' `constant_coefficient` method to Generic.MPoly

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -320,14 +320,6 @@ function constant_coefficient(p::MPolyRingElem{T}) where T <: RingElement
    return zero(base_ring(p))
 end
 
-function constant_coefficient(p::MPolyRingElem)
-   len = length(p)
-   if !iszero(p) && iszero(exponent_vector(p, len))
-      return coeff(p, len)
-   end
-   return zero(base_ring(p))
-end
-
 @doc raw"""
     leading_monomial(p::MPolyRingElem)
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -660,6 +660,14 @@ function coeff!(c::T, x::MPoly{T}, i::Int) where T <: RingElement
   return x.coeffs[i]
 end
 
+function constant_coefficient(p::MPoly{T}) where T <: RingElement
+   len = length(p)
+   if !iszero(p) && iszero(exponent_vector(p, len))
+      return coeff(p, len)
+   end
+   return zero(base_ring(p))
+end
+
 function trailing_coefficient(p::MPoly{T}) where T <: RingElement
    @req !iszero(p) "Zero polynomial does not have a leading monomial"
    return coeff(p, length(p))


### PR DESCRIPTION
... as discussed during triage, cf. https://github.com/Nemocas/AbstractAlgebra.jl/pull/2286