### PR TITLE
Fix a typo in the docstring of `universal_poly_ring_type`

### DIFF
--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -32,10 +32,10 @@ universal_poly_type(::Type{T}) where T = throw(ArgumentError("Type `$T` must be 
 universal_poly_type(T::Type{Union{}}) = throw(MethodError(universal_poly_type, (T,)))
 
 @doc raw"""
-    mpoly_ring_type(::Type{T}) where T<:RingElement
-    mpoly_ring_type(::T) where T<:RingElement
-    mpoly_ring_type(::Type{S}) where S<:Ring
-    mpoly_ring_type(::S) where S<:Ring
+    universal_poly_ring_type(::Type{T}) where T<:RingElement
+    universal_poly_ring_type(::T) where T<:RingElement
+    universal_poly_ring_type(::Type{S}) where S<:Ring
+    universal_poly_ring_type(::S) where S<:Ring
 
 The type of universal polynomial rings with coefficients of type `T`
 respectively `elem_type(S)`. Implemented via [`universal_poly_type`](@ref).


### PR DESCRIPTION
I somehow missed this in #2333.