### PR TITLE
Change behavior of `base_ring` for Laurent polynomials

### DIFF
--- a/src/LaurentMPoly.jl
+++ b/src/LaurentMPoly.jl
@@ -10,13 +10,13 @@
 #
 ###############################################################################
 
-characteristic(R::LaurentMPolyRing) = characteristic(base_ring(R))
-is_known(::typeof(characteristic), R::LaurentMPolyRing) = is_known(characteristic, base_ring(R))
+characteristic(R::LaurentMPolyRing) = characteristic(coefficient_ring(R))
+is_known(::typeof(characteristic), R::LaurentMPolyRing) = is_known(characteristic, coefficient_ring(R))
 
-is_finite(R::LaurentMPolyRing) = is_trivial(base_ring(R)) || (nvars(R) == 0 && is_finite(base_ring(R)))
+is_finite(R::LaurentMPolyRing) = is_trivial(coefficient_ring(R)) || (nvars(R) == 0 && is_finite(coefficient_ring(R)))
 is_known(::typeof(is_finite), R::LaurentMPolyRing) =
-  is_known(is_trivial, base_ring(R)) &&
-    (is_trivial(base_ring(R)) || nvars(R) > 0 || is_known(is_finite, base_ring(R)))
+  is_known(is_trivial, coefficient_ring(R)) &&
+    (is_trivial(coefficient_ring(R)) || nvars(R) > 0 || is_known(is_finite, coefficient_ring(R)))
 
 ###############################################################################
 #
@@ -62,7 +62,7 @@ function show(io::IO, mime::MIME"text/plain", p::LaurentMPolyRing)
     println(io)
   end
   io = pretty(io)
-  print(io, Indent(), "over ", Lowercase(), base_ring(p))
+  print(io, Indent(), "over ", Lowercase(), coefficient_ring(p))
   print(io, Dedent())
 end
 
@@ -74,7 +74,7 @@ function show(io::IO, p::LaurentMPolyRing)
   else
     io = pretty(io)
     print(io, "Multivariate Laurent polynomial ring in ", ItemQuantity(nvars(p), "variable"))
-    print(terse(io), " over ", Lowercase(), base_ring(p))
+    print(terse(io), " over ", Lowercase(), coefficient_ring(p))
   end
 end
 
@@ -113,7 +113,7 @@ function RandomExtensions.make(S::LaurentMPolyRing,
                                term_range::AbstractUnitRange{Int},
                                exp_bound::AbstractUnitRange{Int},
                                vs...)
-   R = base_ring(S)
+   R = coefficient_ring(S)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, term_range, exp_bound, vs[1])
    else
@@ -129,7 +129,7 @@ function rand(rng::AbstractRNG,
    S, term_range, exp_bound, v = sp[][1:end]
    f = zero(S)
    g = gens(S)
-   R = base_ring(S)
+   R = coefficient_ring(S)
    for i = 1:rand(rng, term_range)
       term = one(S)
       for j = 1:length(g)

--- a/src/LaurentPoly.jl
+++ b/src/LaurentPoly.jl
@@ -10,8 +10,8 @@
 #
 ###############################################################################
 
-characteristic(R::LaurentPolyRing) = characteristic(base_ring(R))
-is_known(::typeof(characteristic), R::LaurentPolyRing) = is_known(characteristic, base_ring(R))
+characteristic(R::LaurentPolyRing) = characteristic(coefficient_ring(R))
+is_known(::typeof(characteristic), R::LaurentPolyRing) = is_known(characteristic, coefficient_ring(R))
 
 is_finite(R::LaurentPolyRing) = is_trivial(R)
 is_known(::typeof(is_finite), R::LaurentPolyRing) = is_known(is_trivial, R)

--- a/src/algorithms/LaurentPoly.jl
+++ b/src/algorithms/LaurentPoly.jl
@@ -103,12 +103,12 @@ end
 
 function leading_coefficient(p::LaurentPolyRingElem)
    dr = degrees_range(p)
-   isempty(dr) ? zero(base_ring(p)) : coeff(p, last(dr))
+   isempty(dr) ? zero(coefficient_ring(p)) : coeff(p, last(dr))
 end
 
 function trailing_coefficient(p::LaurentPolyRingElem)
    dr = degrees_range(p)
-   isempty(dr) ? zero(base_ring(p)) : coeff(p, first(dr))
+   isempty(dr) ? zero(coefficient_ring(p)) : coeff(p, first(dr))
 end
 
 gens(R::LaurentPolyRing) = [gen(R)]
@@ -218,7 +218,7 @@ function show(io::IO, mime::MIME"text/plain", p::LaurentPolyRing)
   print(io, "Univariate Laurent polynomial ring in ", var(p))
   println(io)
   io = pretty(io)
-  print(io, Indent(), "over ", Lowercase(), base_ring(p))
+  print(io, Indent(), "over ", Lowercase(), coefficient_ring(p))
   print(io, Dedent())
 end
 
@@ -230,7 +230,7 @@ function show(io::IO, p::LaurentPolyRing)
   else
     io = pretty(io)
     print(io, "Univariate Laurent polynomial ring in ", var(p), " over ")
-    print(terse(io), Lowercase(), base_ring(p))
+    print(terse(io), Lowercase(), coefficient_ring(p))
   end
 end
 

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -17,16 +17,16 @@ elem_type(::Type{LaurentMPolyWrapRing{T, PR}}) where {T, PR} =
 
 parent(p::LaurentMPolyWrap) = p.parent
 
-base_ring_type(::Type{<:LaurentMPolyWrapRing{T}}) where {T} = parent_type(T)
-base_ring(R::LaurentMPolyWrapRing) = base_ring(R.mpolyring)::base_ring_type(R)
+base_ring_type(::Type{<:LaurentMPolyWrapRing{T}}) where {T} = mpoly_ring_type(T)
+base_ring(R::LaurentMPolyWrapRing) = R.mpolyring::base_ring_type(R)
 
 coefficient_ring_type(::Type{LaurentMPolyWrapRing{T, PR}}) where {T, PR} = coefficient_ring_type(PR)
-coefficient_ring(R::LaurentMPolyWrapRing) = coefficient_ring(R.mpolyring)
+coefficient_ring(R::LaurentMPolyWrapRing) = coefficient_ring(base_ring(R))
 
-symbols(R::LaurentMPolyWrapRing) = symbols(R.mpolyring)
+symbols(R::LaurentMPolyWrapRing) = symbols(base_ring(R))
 
-number_of_variables(R::LaurentMPolyWrapRing) = number_of_variables(R.mpolyring)
-number_of_generators(R::LaurentMPolyWrapRing) = number_of_variables(R.mpolyring)
+number_of_variables(R::LaurentMPolyWrapRing) = number_of_variables(base_ring(R))
+number_of_generators(R::LaurentMPolyWrapRing) = number_of_variables(base_ring(R))
 
 ###############################################################################
 #
@@ -51,15 +51,15 @@ function length(a::LaurentMPolyWrap)
 end
 
 function zero(R::LaurentMPolyWrapRing)
-    return LaurentMPolyWrap(R, zero(R.mpolyring))
+    return LaurentMPolyWrap(R, zero(base_ring(R)))
 end
 
 function one(R::LaurentMPolyWrapRing)
-    return LaurentMPolyWrap(R, one(R.mpolyring))
+    return LaurentMPolyWrap(R, one(base_ring(R)))
 end
 
 function gen(R::LaurentMPolyWrapRing, i::Int)
-    return LaurentMPolyWrap(R, gen(R.mpolyring, i))
+    return LaurentMPolyWrap(R, gen(base_ring(R), i))
 end
 
 function iszero(a::LaurentMPolyWrap)
@@ -585,11 +585,11 @@ function (a::LaurentMPolyWrapRing{T})() where T <: RingElement
 end
 
 function (a::LaurentMPolyWrapRing{T})(b::RingElement) where T <: RingElement
-   return LaurentMPolyWrap(a, a.mpolyring(b))
+   return LaurentMPolyWrap(a, base_ring(a)(b))
 end
 
 function (a::LaurentMPolyWrapRing{T})(b::MPolyRingElem{T}) where T <: RingElement
-   parent(b) == a.mpolyring || error("Unable to coerce polynomial")
+   parent(b) == base_ring(a) || error("Unable to coerce polynomial")
    return LaurentMPolyWrap(a, b)
 end
 
@@ -608,7 +608,7 @@ function (a::LaurentMPolyWrapRing{T})(b::Vector{T}, e::Vector{Vector{Int}}) wher
         length(e[i]) == n || error("Exponent vector $i has length $(length(m[i])) (expected $(n))")
         min_broadcast!(m, m, e[i])
     end
-    return LaurentMPolyWrap(a, a.mpolyring(b, map(x -> x - m, e)), m)
+    return LaurentMPolyWrap(a, base_ring(a)(b, map(x -> x - m, e)), m)
 end
 
 ###############################################################################
@@ -630,7 +630,7 @@ end
 ################################################################################
 
 function AbstractAlgebra._map(g::T, p::LaurentMPolyWrap, R::LaurentMPolyWrapRing) where T
-   return LaurentMPolyWrap(R, AbstractAlgebra._map(g, p.mpoly, R.mpolyring),
+   return LaurentMPolyWrap(R, AbstractAlgebra._map(g, p.mpoly, base_ring(R)),
                               p.mindegs)
 end
 

--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -17,15 +17,15 @@ elem_type(::Type{LaurentPolyWrapRing{T, PR}}) where {T, PR} =
 
 parent(p::LaurentPolyWrap) = p.parent
 
-base_ring_type(::Type{<:LaurentPolyWrapRing{T}}) where {T} = parent_type(T)
-base_ring(R::LaurentPolyWrapRing) = base_ring(R.polyring)::base_ring_type(R)
+base_ring_type(::Type{<:LaurentPolyWrapRing{T}}) where {T} = poly_ring_type(T)
+base_ring(R::LaurentPolyWrapRing) = R.polyring::base_ring_type(R)
 
 coefficient_ring_type(::Type{LaurentPolyWrapRing{T, PR}}) where {T, PR} = coefficient_ring_type(PR)
-coefficient_ring(R::LaurentPolyWrapRing) = coefficient_ring(R.polyring)
+coefficient_ring(R::LaurentPolyWrapRing) = coefficient_ring(base_ring(R))
 
-var(R::LaurentPolyWrapRing) = var(R.polyring)
+var(R::LaurentPolyWrapRing) = var(base_ring(R))
 
-symbols(R::LaurentPolyWrapRing) = symbols(R.polyring)
+symbols(R::LaurentPolyWrapRing) = symbols(base_ring(R))
 
 number_of_variables(R::LaurentPolyWrapRing) = 1
 number_of_generators(R::LaurentPolyWrapRing) = number_of_variables(R)
@@ -59,7 +59,7 @@ The result is undefined when `p` is null.
 lead_degree(p::LaurentPolyWrap) = p.mindeg + degree(p.poly)
 
 coeff(p::LaurentPolyWrap, i::Int) =
-   i < p.mindeg ? zero(base_ring(p)) : coeff(p.poly, i - p.mindeg)
+   i < p.mindeg ? zero(coefficient_ring(p)) : coeff(p.poly, i - p.mindeg)
 
 function _enable_deg!(p::LaurentPolyWrap, i::Int)
    diff = p.mindeg - i
@@ -81,10 +81,10 @@ iszero(p::LaurentPolyWrap) = iszero(p.poly)
 
 isone(p::LaurentPolyWrap) = is_monomial(p, 0)
 
-zero(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, zero(R.polyring))
-one(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, one(R.polyring))
+zero(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, zero(base_ring(R)))
+one(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, one(base_ring(R)))
 
-gen(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, gen(R.polyring))
+gen(R::LaurentPolyWrapRing) = LaurentPolyWrap(R, gen(base_ring(R)))
 
 is_gen(p::LaurentPolyWrap) = is_monomial(p, 1)
 
@@ -413,7 +413,7 @@ end
 RandomExtensions.maketype(S::LaurentPolyWrapRing, _, _) = elem_type(S)
 
 function RandomExtensions.make(S::LaurentPolyWrapRing, v1, vs...)
-   R = S.polyring
+   R = base_ring(S)
    if length(vs) == 1 && vs[1] isa Integer && elem_type(R) == Random.gentype(v1)
       Make(S, v1, vs[1]) # forward to default Make constructor
    else
@@ -474,7 +474,7 @@ end
 
 function AbstractAlgebra._map(g::T, p::LaurentPolyWrap, Rx::LaurentPolyWrapRing) where T
    return LaurentPolyWrap(Rx,
-                        AbstractAlgebra._map(g, p.poly, Rx.polyring), p.mindeg)
+                        AbstractAlgebra._map(g, p.poly, base_ring(Rx)), p.mindeg)
 end
 
 function change_base_ring(R::Ring, p::LaurentPolyWrap; cached::Bool = true,
@@ -496,14 +496,14 @@ end
 #
 ###############################################################################
 
-(R::LaurentPolyWrapRing)(b::RingElement) = LaurentPolyWrap(R, R.polyring(b))
+(R::LaurentPolyWrapRing)(b::RingElement) = LaurentPolyWrap(R, base_ring(R)(b))
 
-(R::LaurentPolyWrapRing)(b::RingElement, d::Int) = LaurentPolyWrap(R, R.polyring(b), d)
+(R::LaurentPolyWrapRing)(b::RingElement, d::Int) = LaurentPolyWrap(R, base_ring(R)(b), d)
 
-(R::LaurentPolyWrapRing)() = LaurentPolyWrap(R, R.polyring())
+(R::LaurentPolyWrapRing)() = LaurentPolyWrap(R, base_ring(R)())
 
 function (R::LaurentPolyWrapRing)(p::LaurentPolyWrap)
-   parent(p) == R ? p : LaurentPolyWrap(R, R.polyring(p.poly), p.mindeg)
+   parent(p) == R ? p : LaurentPolyWrap(R, base_ring(R)(p.poly), p.mindeg)
 end
 
 ###############################################################################

--- a/test/generic/LaurentMPoly-test.jl
+++ b/test/generic/LaurentMPoly-test.jl
@@ -12,10 +12,8 @@ end
     @test L != laurent_polynomial_ring(GF(5), 2, 'x', cached = false)[1]
     @test L == laurent_polynomial_ring(GF(5), 2, :x, cached = true)[1]
 
-    @test base_ring(L) == GF(5)
     @test coefficient_ring(L) == GF(5)
     @test coefficient_ring_type(L) === typeof(GF(5))
-    @test base_ring(x) == GF(5)
     @test coefficient_ring(x) == GF(5)
     @test coefficient_ring_type(x) === typeof(GF(5))
 

--- a/test/generic/LaurentPoly-test.jl
+++ b/test/generic/LaurentPoly-test.jl
@@ -35,9 +35,8 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
 
          @test parent(y) == L
 
-         @test base_ring(L) == R
-         @test base_ring(L) == base_ring(P)
          @test coefficient_ring(L) == R
+         @test coefficient_ring(L) == coefficient_ring(P)
          @test coefficient_ring_type(L) === typeof(R)
 
          @test var(L) == :y
@@ -122,7 +121,7 @@ using AbstractAlgebra.Generic: Integers, LaurentPolyWrapRing, LaurentPolyWrap,
          @test is_unit(y^e)
       end
 
-      if base_ring(L) isa AbstractAlgebra.Field
+      if coefficient_ring(L) isa AbstractAlgebra.Field
          for e = -5:5
             @test is_unit(2*y^e)
             @test is_unit(3*y^(2e))


### PR DESCRIPTION
Similar to #2182, this changes the behavior of `base_ring` for Laurent polynomials to return the underlying polynomial ring instead of the coefficient ring.