### PR TITLE
Drop `is_unit` tests from `test_NCRing_interface` to comply with interface definitions

### DIFF
--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -74,8 +74,6 @@ function test_NCRing_interface(R::AbstractAlgebra.NCRing; reps = 15)
          @test isone(one(R))
          @test iszero(R(0))
          @test isone(R(1))
-         @test isone(R(0)) || !is_unit(R(0))
-         @test is_unit(R(1))
          for i in 1:reps
             a = generate_element(R)::T
             @test hash(a) isa UInt


### PR DESCRIPTION
This PR removes all calls to `is_unit` from `test_NCRing_interface`.

The documentation says that implementation of `is_unit` is optional, but at the moment it is not. For our new cohomology rings in Oscar it is in fact not trivial to implement this function (I think), so we would like to be able to not write a mathematically incorrect stub in order to make the tests pass. 
