### PR TITLE
chore: Bump version to 0.48.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.48.4"
+version = "0.48.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Still waiting for:
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2365

The changelog update in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2372 needs to be merged right before this one.