### PR TITLE
Simplify `evaluate` for mpolys

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -964,8 +964,7 @@ function evaluate(a::MPolyRingElem{T}, vals::Vector{U}) where {T <: RingElement,
    # must be done in a certain order.
    # But addition is associative.
    S = parent(one(R)*one(parent(vals[1])))
-   r = elem_type(S)[zero(S)]
-   i = UInt(1)
+   r = zero(S)
    cvzip = zip(coefficients(a), exponent_vectors(a))
    for (c, v) in cvzip
       t = one(S)
@@ -979,19 +978,9 @@ function evaluate(a::MPolyRingElem{T}, vals::Vector{U}) where {T <: RingElement,
          end
          t = mul!(t, pe)
       end
-      push!(r, c*t)
-      j = i = i + 1
-      while iseven(j) && length(r) > 1
-          top = pop!(r)
-          r[end] = add!(r[end], top)
-          j >>= 1
-      end
+      r = add!(r, c*t)
    end
-   while length(r) > 1
-      top = pop!(r)
-      r[end] = add!(r[end], top)
-   end
-   return r[1]
+   return r
 end
 
 @doc raw"""


### PR DESCRIPTION
This fixes #2371. I'm not entirely sure if I made some stupid mistake here but previously the code was way more complex.
Note that this still has some weird effects because the parent ring is mostly determined by the first value:

```
julia> R,(x,y,z)=QQ[:x,:y,:z]
(Multivariate polynomial ring in 3 variables over rationals, AbstractAlgebra.Generic.MPoly{Rational{BigInt}}[x, y, z])

julia> evaluate(R(), RingElement[0,x,0])
0//1

julia> typeof(ans)
Rational{BigInt}

julia> evaluate(R(), RingElement[x,0,0])
0

julia> typeof(ans)
AbstractAlgebra.Generic.MPoly{Rational{BigInt}}

```

How do we want the code to behave in these types of situations.

Note that I haven't added any tests yet.