### PR TITLE
Minimal changes to allow some non-comm. modules

### DIFF
--- a/src/ModuleHomomorphism.jl
+++ b/src/ModuleHomomorphism.jl
@@ -221,6 +221,10 @@ function module_homomorphism(M1::Module, M2::Module, m::MatElem)
    Generic.ModuleHomomorphism(M1, M2, m)
 end
 
+function zero_map(M::FPModule, N::FPModule)
+   return module_homomorphism(M, N, zero_matrix(base_ring(M), ngens(M), ngens(N)))
+end
+
 @doc raw"""
     ModuleIsomorphism(M1::FPModule{T}, M2::FPModule{T}, M::MatElem{T},
                       minv::MatElem{T}) where T <: RingElement

--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -293,7 +293,7 @@ end
 function hom_direct_sum(A::DirectSumModule{T}, B::DirectSumModule{T}, M::Matrix{<:Map{<:AbstractAlgebra.FPModule{T}, <:AbstractAlgebra.FPModule{T}}}) where {T}
   pro = canonical_projections(A)
   im = canonical_injections(B)
-  s = hom(A, B, [zero(B) for i = 1:dim(A)])
+  s = hom(A, B, [zero(B) for i = 1:ngens(A)])
   for i=1:length(pro)
     for j=1:length(im)
       s += pro[i]*M[i,j]*im[j]

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -24,7 +24,7 @@ elem_type(::Type{FreeModule{T}}) where T <: NCRingElement = FreeModuleElem{T}
 
 parent(m::FreeModuleElem{T}) where T <: NCRingElement = m.parent
 
-function rels(M::FreeModule{T}) where T <: RingElement
+function rels(M::FreeModule{T}) where T <: NCRingElement
    # there are no relations in a free module
    return Vector{dense_matrix_type(T)}(undef, 0)
 end
@@ -73,7 +73,11 @@ Base.hash(a::FreeModuleElem, h::UInt) = hash(a.v, h)
 function show(io::IO, M::FreeModule{T}) where T <: NCRingElement
    @show_name(io, M)
    @show_special(io, M)
-   print(io, "Free module of rank ")
+   if M.is_row
+     print(io, "Free module of rank ")
+   else
+     print(io, "Free column-module of rank ")
+   end
    print(io, rank(M))
    print(io, " over ")
    print(terse(pretty(io)), Lowercase(), base_ring(M))
@@ -91,13 +95,24 @@ end
 function show(io::IO, a::FreeModuleElem)
    print(io, "(")
    M = parent(a)
-   for i = 1:rank(M) - 1
-      print(IOContext(io, :compact => true), _matrix(a)[1, i])
-      print(io, ", ")
+   if M.is_row
+     for i = 1:rank(M) - 1
+        print(IOContext(io, :compact => true), _matrix(a)[1, i])
+        print(io, ", ")
+     end
+     if rank(M) > 0
+        print(IOContext(io, :compact => true), _matrix(a)[1, rank(M)])
+     end
+   else
+     for i = 1:rank(M) - 1
+        print(IOContext(io, :compact => true), _matrix(a)[i, 1])
+        print(io, ", ")
+     end
+     if rank(M) > 0
+        print(IOContext(io, :compact => true), _matrix(a)[rank(M), 1])
+     end
    end
-   if rank(M) > 0
-      print(IOContext(io, :compact => true), _matrix(a)[1, rank(M)])
-   end
+
    print(io, ")")
 end
 
@@ -110,7 +125,11 @@ end
 function (M::FreeModule{T})(a::Vector{T}) where T <: NCRingElement
    length(a) != rank(M) && error("Number of elements does not equal rank")
    R = base_ring(M)
-   v = matrix(R, 1, length(a), a)
+   if M.is_row
+     v = matrix(R, 1, length(a), a)
+   else
+     v = matrix(R, length(a), 1, a)
+   end
    z = FreeModuleElem{T}(M, v)
    return z
 end
@@ -126,7 +145,11 @@ end
 function (M::FreeModule{T})(a::Vector{S}) where {T <: NCRingElement, S <: RingElement}
    length(a) != rank(M) && error("Number of elements does not equal rank")
    R = base_ring(M)
-   v = matrix(R, 1, length(a), a)
+   if M.is_row
+     v = matrix(R, 1, length(a), a)
+   else
+     v = matrix(R, length(a), 1, a)
+   end
    z = FreeModuleElem{T}(M, v)
    return z
 end
@@ -137,8 +160,13 @@ function (M::FreeModule{T})(a::Vector{Any}) where T <: NCRingElement
 end
 
 function (M::FreeModule{T})(a::AbstractAlgebra.MatElem{T}) where T <: NCRingElement
-   ncols(a) != rank(M) && error("Number of elements does not equal rank")
-   nrows(a) != 1 && error("Matrix should have single row")
+  if M.is_row
+     ncols(a) != rank(M) && error("Number of elements does not equal rank")
+     nrows(a) != 1 && error("Matrix should have single row")
+   else
+     nrows(a) != rank(M) && error("Number of elements does not equal rank")
+     ncols(a) != 1 && error("Matrix should have single column")
+   end
    z = FreeModuleElem{T}(M, a)
    return z
 end
@@ -166,8 +194,8 @@ end
 #
 ###############################################################################
 
-function FreeModule(R::NCRing, rank::Int; cached::Bool = true)
+function FreeModule(R::NCRing, rank::Int; cached::Bool = true, is_row::Bool = true)
    T = elem_type(R)
-   return FreeModule{T}(R, rank, cached)
+   return FreeModule{T}(R, rank, cached; is_row)
 end
 

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -55,8 +55,13 @@ end
 function gen(N::FreeModule{T}, i::Int) where T <: NCRingElement
    @boundscheck 1 <= i <= ngens(N) || throw(ArgumentError("generator index out of range"))
    R = base_ring(N)
-   m = zero_matrix(R, 1, ngens(N))
-   add_one!(m, 1, i)
+   if N.is_row
+     m = zero_matrix(R, 1, ngens(N))
+     add_one!(m, 1, i)
+   else
+     m = zero_matrix(R, ngens(N), 1)
+     add_one!(m, i, 1)
+   end
    return N(m)
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1411,17 +1411,30 @@ mutable struct ModuleHomomorphism{T <: NCRingElement} <: AbstractAlgebra.Map{Abs
    image_fn::Function
    is_left::Bool  # x -> is_left ? #xA : Ax so is_left is the "normal" case
    solve_ctx::Any # really: SolveCtx
+   map::Map # to change the ring. The morphism is
+   #1st apply map (coefficient wise, map_entries(map, x.v))
+   #2nd apply matrix
 
    function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}) where T <: RingElement
       z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(x.v*m), true)
    end
-   function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where T <: NCRingElement
+
+   function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true, map::Union{Nothing, Map} = nothing) where T <: NCRingElement
 
       if is_left
          z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(x.v*m), is_left)
+         if !isa(map, Nothing)
+           z.map = map
+           z.image_fn = x::AbstractAlgebra.FPModuleElem{T} -> C(map_entries(map, x.v)*m)
+         end
       else
          z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(m*x.v), is_left)
+         if !isa(map, Nothing)
+           z.map = map
+           z.image_fn = x::AbstractAlgebra.FPModuleElem{T} -> C(m*map_entries(map, x.v))
+         end
       end
+      return z
    end
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1354,15 +1354,16 @@ end
 @attributes mutable struct FreeModule{T <: NCRingElement} <: AbstractAlgebra.FPModule{T}
    rank::Int
    base_ring::NCRing
+   is_row::Bool
 
-   function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true) where T <: NCRingElement
-      return get_cached!(FreeModuleDict, (R, rank), cached) do
-         new{T}(rank, R)
+   function FreeModule{T}(R::NCRing, rank::Int, cached::Bool = true; is_row::Bool = true) where T <: NCRingElement
+      return get_cached!(FreeModuleDict, (R, rank, is_row), cached) do
+         new{T}(rank, R, is_row)
       end::FreeModule{T}
    end
 end
 
-const FreeModuleDict = CacheDictType{Tuple{NCRing, Int}, FreeModule}()
+const FreeModuleDict = CacheDictType{Tuple{NCRing, Int, Bool}, FreeModule}()
 
 struct FreeModuleElem{T <: NCRingElement} <: AbstractAlgebra.FPModuleElem{T}
    parent::FreeModule{T}
@@ -1402,16 +1403,25 @@ end
 #
 ###############################################################################
 
-mutable struct ModuleHomomorphism{T <: RingElement} <: AbstractAlgebra.Map{AbstractAlgebra.FPModule{T}, AbstractAlgebra.FPModule{T}, AbstractAlgebra.FPModuleHomomorphism, ModuleHomomorphism}
+mutable struct ModuleHomomorphism{T <: NCRingElement} <: AbstractAlgebra.Map{AbstractAlgebra.FPModule{T}, AbstractAlgebra.FPModule{T}, AbstractAlgebra.FPModuleHomomorphism, ModuleHomomorphism}
 
    domain::AbstractAlgebra.FPModule{T}
    codomain::AbstractAlgebra.FPModule{T}
    matrix::AbstractAlgebra.MatElem{T}
    image_fn::Function
+   is_left::Bool #xA vs Ax
    solve_ctx::Any # really: SolveCtx
 
    function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}) where T <: RingElement
-      z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(x.v*m))
+      z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(x.v*m), true)
+   end
+   function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where T <: NCRingElement
+
+      if is_left
+         z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(x.v*m), is_left)
+      else
+         z = new(D, C, m, x::AbstractAlgebra.FPModuleElem{T} -> C(m*x.v), is_left)
+      end
    end
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1409,7 +1409,7 @@ mutable struct ModuleHomomorphism{T <: NCRingElement} <: AbstractAlgebra.Map{Abs
    codomain::AbstractAlgebra.FPModule{T}
    matrix::AbstractAlgebra.MatElem{T}
    image_fn::Function
-   is_left::Bool #xA vs Ax
+   is_left::Bool  # x -> is_left ? #xA : Ax so is_left is the "normal" case
    solve_ctx::Any # really: SolveCtx
 
    function ModuleHomomorphism{T}(D::AbstractAlgebra.FPModule{T}, C::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}) where T <: RingElement

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -268,6 +268,7 @@ function +(b::MatElem{T}, c::InjProjMat{T}) where {T <: NCRingElement}
 end
 +(c::InjProjMat{T}, b::MatElem{T}) where {T <: NCRingElement} = b+c
 +(c::InjProjMat{T}, b::InjProjMat{T}) where {T <: NCRingElement} = matrix(b) + c
+-(c::InjProjMat{T}, b::MatElem{T}) where {T <: NCRingElement} = matrix(c) - b
 
 function add_one!(a::MatElem, i::Int, j::Int)
   a[i, j] += 1

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -59,7 +59,7 @@ function AbstractAlgebra.compose(f::Map(ModuleHomomorphism), g::Map(ModuleHomomo
    end
 
    if f.is_left
-     return ModuleHomomorphism(domain(f), codomain(g), m1*g.matrix; is_left = true, mp)
+     return ModuleHomomorphism(domain(f), codomain(g), m1*g.matrix; is_left = true, map = mp)
    else
      return ModuleHomomorphism(domain(f), codomain(g), g.matrix*m1; is_left = false)
    end

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -41,6 +41,17 @@ Base.:*(a::T, b::ModuleIsomorphism{T}) where {T <: RingElement} = hom(domain(b),
 Base.:+(a::ModuleHomomorphism, b::ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) + matrix(b))
 Base.:-(a::ModuleHomomorphism, b::ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) - matrix(b))
 
+function AbstractAlgebra.compose(f::Map(ModuleHomomorphism), g::Map(ModuleHomomorphism))
+   check_composable(f, g)
+   @assert f.is_left == g.is_left
+   if f.is_left
+     return ModuleHomomorphism(domain(f), codomain(g), f.matrix*g.matrix; is_left = true)
+   else
+     return ModuleHomomorphism(domain(f), codomain(g), g.matrix*f.matrix; is_left = false)
+   end
+end
+
+
 ###############################################################################
 #
 #   Comparison
@@ -148,10 +159,24 @@ end
 ###############################################################################
 
 function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T},
-     M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}) where
+     M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where
+                                                               T <: NCRingElement
+   if is_left
+     (nrows(m) == ngens(M1) && ncols(m) == ngens(M2)) ||
+                                                      error("dimension mismatch")
+   else
+     (nrows(m) == ngens(M2) && ncols(m) == ngens(M1)) ||
+                                                      error("dimension mismatch")
+   end
+   return ModuleHomomorphism{T}(M1, M2, m; is_left)
+end
+
+function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T},
+     M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where
                                                                T <: RingElement
    (nrows(m) == ngens(M1) && ncols(m) == ngens(M2)) ||
                                                     error("dimension mismatch")
+   @assert is_left
    return ModuleHomomorphism{T}(M1, M2, m)
 end
 
@@ -204,6 +229,6 @@ function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::Vector{<:M
   return ModuleHomomorphism(V, W, reduce(vcat, [x.v for x = v]))
 end
 
-function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::MatElem; check::Bool = true)
-  return ModuleHomomorphism(V, W, v)
+function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::MatElem; check::Bool = true, is_left::Bool = true)
+  return ModuleHomomorphism(V, W, v; is_left)
 end

--- a/src/generic/ModuleHomomorphism.jl
+++ b/src/generic/ModuleHomomorphism.jl
@@ -44,10 +44,24 @@ Base.:-(a::ModuleHomomorphism, b::ModuleHomomorphism) = hom(domain(a), codomain(
 function AbstractAlgebra.compose(f::Map(ModuleHomomorphism), g::Map(ModuleHomomorphism))
    check_composable(f, g)
    @assert f.is_left == g.is_left
+   m1 = f.matrix
+   local mp::Union{Nothing, Map} = nothing
+   if isdefined(g, :map) 
+     m1 = map_entries(g.map, m1)
+     mp = g.map
+   end
+   if isdefined(f, :map)
+     if isa(mp, Nothing)
+       mp = f.map
+     else
+       mp = f.map*mp
+     end
+   end
+
    if f.is_left
-     return ModuleHomomorphism(domain(f), codomain(g), f.matrix*g.matrix; is_left = true)
+     return ModuleHomomorphism(domain(f), codomain(g), m1*g.matrix; is_left = true, mp)
    else
-     return ModuleHomomorphism(domain(f), codomain(g), g.matrix*f.matrix; is_left = false)
+     return ModuleHomomorphism(domain(f), codomain(g), g.matrix*m1; is_left = false)
    end
 end
 
@@ -142,7 +156,7 @@ end
 #
 ###############################################################################
 
-function (f::ModuleHomomorphism{T})(a::AbstractAlgebra.FPModuleElem{T}) where T <: RingElement
+function (f::ModuleHomomorphism{T})(a::AbstractAlgebra.FPModuleElem{T}) where T <: NCRingElement
    parent(a) !== domain(f) && error("Incompatible module element")
    return image_fn(f)(a)
 end
@@ -159,7 +173,7 @@ end
 ###############################################################################
 
 function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T},
-     M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where
+  M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true, map::Union{Nothing, Map} = nothing) where
                                                                T <: NCRingElement
    if is_left
      (nrows(m) == ngens(M1) && ncols(m) == ngens(M2)) ||
@@ -168,11 +182,11 @@ function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T},
      (nrows(m) == ngens(M2) && ncols(m) == ngens(M1)) ||
                                                       error("dimension mismatch")
    end
-   return ModuleHomomorphism{T}(M1, M2, m; is_left)
+   return ModuleHomomorphism{T}(M1, M2, m; is_left, map)
 end
 
 function ModuleHomomorphism(M1::AbstractAlgebra.FPModule{T},
-     M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true) where
+  M2::AbstractAlgebra.FPModule{T}, m::AbstractAlgebra.MatElem{T}; is_left::Bool = true, map::Union{Nothing, Map} = nothing) where
                                                                T <: RingElement
    (nrows(m) == ngens(M1) && ncols(m) == ngens(M2)) ||
                                                     error("dimension mismatch")
@@ -229,6 +243,6 @@ function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::Vector{<:M
   return ModuleHomomorphism(V, W, reduce(vcat, [x.v for x = v]))
 end
 
-function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::MatElem; check::Bool = true, is_left::Bool = true)
-  return ModuleHomomorphism(V, W, v; is_left)
+function hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::MatElem; check::Bool = true, is_left::Bool = true, map::Union{Nothing, Map} = nothing)
+  return ModuleHomomorphism(V, W, v; is_left, map)
 end


### PR DESCRIPTION
To support free resolutions of ZG in Oscar, some modules in the non-commutative setting are required. This PR allows
 - Generic.FreeModule (both as row and col module - both are needed)
 - homs between free modules via matrices, both right and left compose
 - minor tweaks (relations of non-comm free modules, ...)

This is NOT meant to fully support lin. alg. in this case. Feel free to add functionality. This is meant to be minimal invasive to support exactly what is needed in Oscar.

btw: free_module(ZG, n) already exists (in Hecke) but does s.th. differently. In particular it does not really preserve the free structure - but it allows more cool mathematics. Thus to use the new stuff: Generic.FreeModule..