### PR TITLE
"Inplace" iterators over the coefficients, monomials, terms and exponent words of a free associative algebra element

### DIFF
--- a/src/FreeAssociativeAlgebra.jl
+++ b/src/FreeAssociativeAlgebra.jl
@@ -107,26 +107,33 @@ end
 #
 ###############################################################################
 
-function coefficients(a::FreeAssociativeAlgebraElem)
-   return Generic.MPolyCoeffs(a)
+function coefficients(a::FreeAssociativeAlgebraElem; inplace::Bool = false)
+   return Generic.MPolyCoeffs(a; inplace)
 end
 
-function terms(a::FreeAssociativeAlgebraElem)
-   return Generic.MPolyTerms(a)
+function terms(a::FreeAssociativeAlgebraElem; inplace::Bool = false)
+   return Generic.MPolyTerms(a; inplace)
 end
 
-function monomials(a::FreeAssociativeAlgebraElem)
-   return Generic.MPolyMonomials(a)
+function monomials(a::FreeAssociativeAlgebraElem; inplace::Bool = false)
+   return Generic.MPolyMonomials(a; inplace)
 end
 
 @doc raw"""
-    exponent_words(a::FreeAssociativeAlgebraElem{T}) where T <: RingElement
+    exponent_words(a::FreeAssociativeAlgebraElem{T}; inplace::Bool = false) where T <: RingElement
 
 Return an iterator for the exponent words of the given polynomial. To
 retrieve an array of the exponent words, use `collect(exponent_words(a))`.
+
+If `inplace` is `true`, the elements of the iterator may share their memory. This
+means that an element returned by the iterator may be overwritten 'in place' in
+the next iteration step. This may result in significantly fewer memory allocations.
+However, using the in-place version is only meaningful, if just one element of
+the iterator is needed at any time. For example, calling `collect` on this
+iterator will not give useful results.
 """
-function exponent_words(a::FreeAssociativeAlgebraElem{T}) where T <: RingElement
-   return Generic.FreeAssAlgExponentWords(a)
+function exponent_words(a::FreeAssociativeAlgebraElem{T}; inplace::Bool = false) where T <: RingElement
+   return Generic.FreeAssAlgExponentWords(a; inplace)
 end
 
 function is_unit(a::FreeAssociativeAlgebraElem{T}) where T

--- a/src/generic/FreeAssociativeAlgebra.jl
+++ b/src/generic/FreeAssociativeAlgebra.jl
@@ -171,16 +171,47 @@ function coeff(a::FreeAssociativeAlgebraElem, i::Int)
     return a.coeffs[i]
 end
 
+# Only for compatibility, we can't do anything in place here
+function coeff!(c::T, a::FreeAssociativeAlgebraElem{T}, i::Int) where T <: RingElement
+    return coeff(a, i)
+end
+
 function term(a::FreeAssociativeAlgebraElem{T}, i::Int) where T <: RingElement
     @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
     R = parent(a)
     return FreeAssociativeAlgebraElem{T}(R, [a.coeffs[i]], [a.exps[i]], 1)
 end
 
+function term!(
+    t::FreeAssociativeAlgebraElem{T},
+    a::FreeAssociativeAlgebraElem{T},
+    i::Int,
+) where T <: RingElement
+    fit!(t, 1)
+    t.coeffs[1] = deepcopy(a.coeffs[i])
+    t.exps[1] = copy(a.exps[i])
+    t.length = 1
+    return t
+end
+
 function monomial(a::FreeAssociativeAlgebraElem{T}, i::Int) where T <: RingElement
     @boundscheck 1 <= i <= length(a) || throw(ArgumentError("index out of range"))
     R = parent(a)
     return FreeAssociativeAlgebraElem{T}(R, T[one(base_ring(R))], [a.exps[i]], 1)
+end
+
+function monomial!(
+    m::FreeAssociativeAlgebraElem{T},
+    a::FreeAssociativeAlgebraElem{T},
+    i::Int,
+) where T <: RingElement
+    fit!(m, 1)
+    if !isassigned(m.coeffs, 1) || !is_one(m.coeffs[1])
+        m.coeffs[1] = one(base_ring(a))
+    end
+    m.exps[1] = copy(a.exps[i])
+    m.length = 1
+    return m
 end
 
 @doc raw"""
@@ -195,10 +226,24 @@ function exponent_word(a::FreeAssociativeAlgebraElem{T}, i::Int) where T <: Ring
     return a.exps[i]
 end
 
-function Base.iterate(a::FreeAssAlgExponentWords, state = 0)
-    state += 1
-    state <= length(a.poly) || return nothing
-    return exponent_word(a.poly, state), state
+function exponent_word!(
+    w::Vector{Int},
+    a::FreeAssociativeAlgebraElem{T},
+    i::Int,
+) where T <: RingElement
+    resize!(w, length(a.exps[i]))
+    copyto!(w, a.exps[i])
+    return w
+end
+
+function Base.iterate(a::FreeAssAlgExponentWords, state::Union{Nothing, Int} = nothing)
+    s = isnothing(state) ? 1 : state + 1
+    if length(a.poly) >= s
+      w = a.inplace ? exponent_word!(a.temp, a.poly, s) : exponent_word(a.poly, s)
+      return w, s
+    else
+      return nothing
+    end
 end
 
 function leading_coefficient(a::FreeAssociativeAlgebraElem{T}) where T
@@ -226,9 +271,7 @@ function total_degree(a::FreeAssociativeAlgebraElem{T}) where T
     return length(a) > 0 ? length(a.exps[1]) : -1
 end
 
-function Base.length(
-    x::FreeAssAlgExponentWords{T},
-) where {S <: RingElement, T <: FreeAssociativeAlgebraElem{S}}
+function Base.length(x::FreeAssAlgExponentWords)
     return length(x.poly)
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1222,8 +1222,18 @@ mutable struct FreeAssociativeAlgebraElem{T <: RingElement} <: AbstractAlgebra.F
 end
 
 # the iterators for coeffs, terms, etc. are shared with MPoly. Just this remains
-struct FreeAssAlgExponentWords{T <: AbstractAlgebra.NCRingElem}
+mutable struct FreeAssAlgExponentWords{T <: AbstractAlgebra.NCRingElem}
    poly::T
+   inplace::Bool
+   temp::Vector{Int} # only used if inplace == true
+
+   function FreeAssAlgExponentWords(f::AbstractAlgebra.NCRingElem; inplace::Bool = false)
+      I = new{typeof(f)}(f, inplace)
+      if inplace
+         I.temp = Int[]
+      end
+      return I
+   end
 end
 
 ###############################################################################

--- a/test/generic/FreeAssociativeAlgebra-test.jl
+++ b/test/generic/FreeAssociativeAlgebra-test.jl
@@ -210,6 +210,21 @@ end
    end
 end
 
+@testset "Generic.FreeAssociativeAlgebra.iterators" begin
+   R, (x, y) = free_associative_algebra(QQ, [:x, :y])
+   f = x * y * x + 2 * x + 3
+
+   @test (@inferred collect(coefficients(f))) == [QQ(1), QQ(2), QQ(3)]
+   @test (@inferred collect(terms(f))) == [x * y * x, 2 * x, 3]
+   @test (@inferred collect(monomials(f))) == [x * y * x, x, 1]
+   @test (@inferred collect(exponent_words(f))) == [Int[1, 2, 1], Int[1], Int[]]
+
+   @test (@inferred first(coefficients(f, inplace = true))) == QQ(1)
+   @test (@inferred first(terms(f, inplace = true))) == x * y * x
+   @test (@inferred first(monomials(f, inplace = true))) == x * y * x
+   @test (@inferred first(exponent_words(f, inplace = true))) == Int[1, 2, 1]
+end
+
 @testset "Generic.FreeAssociativeAlgebra.adhoc_binary" begin
    R, x = ZZ["y"]
 


### PR DESCRIPTION
Add missing coeff!/term!/monomial! support for FreeAssociativeAlgebraElem and add exponent_word! for reusable buffers.

This mirrors the changes for MPoly from https://github.com/Nemocas/AbstractAlgebra.jl/pull/2196.

Also fixes the following JET issue:
```
julia> using Revise, AbstractAlgebra, JET

julia> R, (x,y) = free_associative_algebra(QQ, [:x, :y])
(Free associative algebra on 2 indeterminates over rationals, AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{BigInt}}[x, y])

julia> @report_call hash(x)
[ Info: tracking Base
═════ 1 possible error found ═════
┌ hash(x::AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{BigInt}}) @ Base ./hashing.jl:28
│┌ hash(x::AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{BigInt}}, h::UInt64) @ AbstractAlgebra /home/lgoe/code/julia/AbstractAlgebra.jl/src/FreeAssociativeAlgebra.jl:154
││┌ iterate(z::Base.Iterators.Zip{Tuple{…}}) @ Base.Iterators ./iterators.jl:415
│││┌ _zip_iterate_all(is::Tuple{…}, ss::Tuple{…}) @ Base.Iterators ./iterators.jl:425
││││┌ _zip_iterate_some(is::Tuple{…}, ss::Tuple{…}, ds::Tuple{…}, f::Missing) @ Base.Iterators ./iterators.jl:433
│││││┌ iterate(x::AbstractAlgebra.Generic.MPolyCoeffs{AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{…}, Rational{…}}) @ AbstractAlgebra.Generic /home/lgoe/code/julia/AbstractAlgebra.jl/src/generic/MPoly.jl:849
││││││┌ iterate(x::AbstractAlgebra.Generic.MPolyCoeffs{…}, state::Nothing) @ AbstractAlgebra.Generic /home/lgoe/code/julia/AbstractAlgebra.jl/src/generic/MPoly.jl:851
│││││││ no matching method found `coeff!(::Rational{BigInt}, ::AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{BigInt}}, ::Int64)`: @_7 = coeff!((x::AbstractAlgebra.Generic.MPolyCoeffs{AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{…}}, Rational{BigInt}}).temp::Rational{BigInt}, (x::AbstractAlgebra.Generic.MPolyCoeffs{AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{…}}, Rational{BigInt}}).poly::AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{Rational{BigInt}}, s::Int64)
││││││└────────────────────
```