### PR TITLE
Fix stack overflow in MPoly creation

### DIFF
--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1513,7 +1513,7 @@ end
 
 function (S::MPolyRing)(b::Vector, m::Vector{Vector{T}}) where {T}
    R = base_ring(S)
-   return S(map(R, b)::Vector{elem_type(R)}, m)
+   return S(map(R, b)::Vector{elem_type(R)}, convert(Vector{Vector{Int}}, m))
 end
 
 ###############################################################################

--- a/src/MPoly.jl
+++ b/src/MPoly.jl
@@ -1513,7 +1513,7 @@ end
 
 function (S::MPolyRing)(b::Vector, m::Vector{Vector{T}}) where {T}
    R = base_ring(S)
-   return S(map(R, b)::Vector{elem_type(R)}, convert(Vector{Vector{Int}}, m))
+   return S(map(R, b)::Vector{elem_type(R)}, m)
 end
 
 ###############################################################################

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4116,6 +4116,10 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{UInt}}) where {T <: Ri
    return z
 end
 
-function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{<:Integer}}) where {T <: RingElement}
+function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: RingElement}
+   return S(b, convert(Vector{Vector{UInt}}, m))
+end
+
+function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{BigInt}}) where {T <: RingElement}
    return S(b, convert(Vector{Vector{UInt}}, m))
 end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4075,7 +4075,7 @@ end
 # This is the main user interface for efficiently creating a polynomial. It accepts
 # an array of coefficients and an array of exponent vectors. Sorting, coalescing of
 # like terms and removal of zero terms is performed.
-function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: RingElement}
+function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{UInt}}) where {T <: RingElement}
    if length(b) > 0 && isassigned(b, 1)
        parent(b[1]) != base_ring(a) && error("Unable to coerce to polynomial")
    end
@@ -4091,22 +4091,22 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: Rin
    if ord == :lex
       for i = 1:length(m)
          for j = 1:N
-            Pe[j, i] = UInt(m[i][N - j + 1])
+            Pe[j, i] = m[i][N - j + 1]
          end
       end
    elseif ord == :deglex
       for i = 1:length(m)
          for j = 1:N - 1
-            Pe[j, i] = UInt(m[i][N - j])
+            Pe[j, i] = m[i][N - j]
          end
-         Pe[N, i] = UInt(sum(m[i]))
+         Pe[N, i] = sum(m[i])
       end
    else # degrevlex
       for i = 1:length(m)
          for j = 1:N - 1
-            Pe[j, i] = UInt(m[i][j])
+            Pe[j, i] = m[i][j]
          end
-         Pe[N, i] = UInt(sum(m[i]))
+         Pe[N, i] = sum(m[i])
       end
    end
 
@@ -4114,4 +4114,8 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: Rin
    z = sort_terms!(z)
    z = combine_like_terms!(z)
    return z
+end
+
+function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{<:Integer}}) where {T <: RingElement}
+   return S(b, convert(Vector{Vector{UInt}}, m))
 end

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -4116,10 +4116,6 @@ function (a::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{UInt}}) where {T <: Ri
    return z
 end
 
-function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{Int}}) where {T <: RingElement}
-   return S(b, convert(Vector{Vector{UInt}}, m))
-end
-
-function (S::MPolyRing{T})(b::Vector{T}, m::Vector{Vector{BigInt}}) where {T <: RingElement}
+function (S::MPolyRing{T})(b::Vector{T}, m::Vector{<:Vector{<:Integer}}) where {T <: RingElement}
    return S(b, convert(Vector{Vector{UInt}}, m))
 end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -46,10 +46,14 @@
       @test isa(S(V, W), MPolyRingElem)
 
       W1 = [[rand(0:100) for i in 1:num_vars] for j in 1:5]
+      W2 = [UInt.(w) for w in W1]
+      W3 = [map(ZZ, w) for w in W1]
 
       f1 = S(V, W1)
 
       @test isa(f1, MPolyRingElem)
+      @test S(V, W2) == f1
+      @test S(V, W3) == f1
 
       Va = [rand(-100:100) for i in 1:5]
       f1a = S(Va, W1)


### PR DESCRIPTION
Currently I have:

```julia
using AbstractAlgebra
R, _ = ZZ["y"]
S, _ = polynomial_ring(R, ["x1", "x2"])
S([R(1)], [map(UInt, [1, 2])])

#=
ERROR: StackOverflowError:
Stacktrace:
  [1] GenericMemory
    @ .\boot.jl:588 [inlined]
  [2] Array
    @ .\boot.jl:647 [inlined]
  [3] Array
    @ .\boot.jl:660 [inlined]
  [4] similar
    @ .\array.jl:377 [inlined]
  [5] similar
    @ .\abstractarray.jl:830 [inlined]
  [6] _similar_for
    @ .\array.jl:664 [inlined]
  [7] _collect
    @ .\array.jl:815 [inlined]
  [8] collect_similar
    @ .\array.jl:732 [inlined]
  [9] map
    @ .\abstractarray.jl:3372 [inlined]
 [10] (::AbstractAlgebra.Generic.MPolyRing{…})(b::Vector{…}, m::Vector{…}) (repeats 47513 times)
    @ AbstractAlgebra C:\Users\User\.julia\packages\AbstractAlgebra\eRqDm\src\MPoly.jl:1460    
Some type information was truncated. Use `show(err)` to see complete types.
=#
```

The generic method seems to re-enter itself without reaching a concrete implementation, for the latter only accepts `Int` exponents:
https://github.com/Nemocas/AbstractAlgebra.jl/blob/1929d13d90ebcbf098cf08961085e50e49950faa/src/generic/MPoly.jl#L4078

With the added `convert` the dispatch goes through. Note that `convert(Vector{Vector{Int}}, m)` is a no-op in the case `T == Int`, so there should be no slowdown in the already-working case.

Co-written with AI.