### PR TITLE
add simplfication/ canonicalization to FunctionFields

### DIFF
--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1088,6 +1088,11 @@ mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
    parent::FunctionField{T}
 
    function FunctionFieldElem{T}(R::FunctionField{T}, num::Poly{S}, den::S) where {T <: FieldElement, S <: PolyRingElem{T}}
+      if !iszero(num) #normalize the denominator
+         c = inv(content(den))
+         num *= c
+         den *= c
+      end
       return new{T}(num, den, R)
    end
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1089,9 +1089,11 @@ mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
 
    function FunctionFieldElem{T}(R::FunctionField{T}, num::Poly{S}, den::S) where {T <: FieldElement, S <: PolyRingElem{T}}
       if !iszero(num) #normalize the denominator
-         c = inv(content(den))
-         num *= c
-         den *= c
+         c = content(den)
+         if !is_one(c)
+            num = divexact(num, c)
+            den = divexact(den, c)
+         end
       end
       return new{T}(num, den, R)
    end


### PR DESCRIPTION
fixes Tobias' is_irreducible problem:

```julia-repl
julia> Qt, t = rational_function_field(QQ, :t)
julia> Qtx, x = Qt[:x]
julia> f = x^4 + 4*(t^12-t)*x
julia> K = splitting_field(f)
julia> R, s = K[:s]
julia> r = roots(K, f)[1] #the root might vary
(1//72*b^4 + (-1//2*t^12 + 1//2*t)*b)//(t^12 - t)

julia> g = s^2 - r^3 - t^12 + t
s^2 + 3*t^12 - 3*t

julia> is_irreducible(g) #this kills time and memory without the fix
```

I do not really know how to test this...it does not change the mathematics, but the performance - in particular in functions not available in AA...