### PR TITLE
chore: bump version to 0.49.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractAlgebra"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.49.0-DEV"
+version = "0.49.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
to be merged after:
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2364
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2376
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2339 ?
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2286
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2356
- https://github.com/Nemocas/AbstractAlgebra.jl/pull/2403