### PR TITLE
Make `promote` a no-op if inputs have same type

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1178,9 +1178,6 @@ end
 function Base.promote(x::MatrixElem{S},
                       y::MatrixElem{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
-   if S === T
-      return x, y
-   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, change_base_ring(base_ring(x), y)
@@ -1203,9 +1200,6 @@ end
 function Base.promote(x::MatrixElem{S},
                       y::Vector{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
-   if S === T
-      return x, y
-   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, map(base_ring(x), y)::Vector{S}  # Julia needs help here
@@ -1228,9 +1222,6 @@ end
 *(x::Vector, y::MatrixElem) = *(promote(x, y)...)
 
 function Base.promote(x::MatElem{S}, y::T) where {S <: NCRingElement, T <: NCRingElement}
-   if S === T
-      return x, y
-   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, base_ring(x)(y)

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1178,6 +1178,9 @@ end
 function Base.promote(x::MatrixElem{S},
                       y::MatrixElem{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
+   if S === T
+      return x, y
+   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, change_base_ring(base_ring(x), y)
@@ -1200,6 +1203,9 @@ end
 function Base.promote(x::MatrixElem{S},
                       y::Vector{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
+   if S === T
+      return x, y
+   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, map(base_ring(x), y)::Vector{S}  # Julia needs help here
@@ -1222,6 +1228,9 @@ end
 *(x::Vector, y::MatrixElem) = *(promote(x, y)...)
 
 function Base.promote(x::MatElem{S}, y::T) where {S <: NCRingElement, T <: NCRingElement}
+   if S === T
+      return x, y
+   end
    U = promote_rule_sym(S, T)
    if U === S
       return x, base_ring(x)(y)

--- a/src/NCRings.jl
+++ b/src/NCRings.jl
@@ -34,6 +34,9 @@ function promote_rule_sym(::Type{T}, ::Type{S}) where {T, S}
 end
 
 @inline function try_promote(x::S, y::T) where {S <: NCRingElem, T <: NCRingElem}
+   if S === T
+      return x, y
+   end
    U = promote_rule_sym(S, T)
    if S === U
       return true, x, parent(x)(y)


### PR DESCRIPTION
to satisfy the assumption noted in https://github.com/Nemocas/AbstractAlgebra.jl/blob/67299a75b26f3acbb1b298c43ff4895e87864149/src/NCRings.jl#L107, namely that "we assume that promotion returns identical operands if no proper promotion can be performed".

This should also change the silent stackoverflow from https://github.com/oscar-system/Oscar.jl/issues/5975 into a proper `NotImplementedError`. To verify that this does not break anything, I would like to wait with merging until https://github.com/oscar-system/Oscar.jl/pull/5982 and https://github.com/oscar-system/Oscar.jl/pull/5985 are merged.