### PR TITLE
Add `generators` as alias for `gens`

### DIFF
--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -33,6 +33,7 @@ const is_upper_triangular = istriu
 
 # predeclare some functions to allow defining aliases for some of our own functions
 function charpoly end
+function gens end
 function minpoly end
 function number_of_columns end
 function number_of_generators end
@@ -42,6 +43,7 @@ function number_of_relations end
 function relations end
 
 @alias characteristic_polynomial charpoly
+@alias generators gens
 @alias minimal_polynomial minpoly
 @alias ncols number_of_columns
 @alias ngens number_of_generators


### PR DESCRIPTION
Resolves the first part of https://github.com/oscar-system/Oscar.jl/issues/5987.

Should only be merged once the downstream tests work again, i.e. after https://github.com/oscar-system/Oscar.jl/pull/5982.