### PR TITLE
Add basic functionality for univariate Ore operators

### DIFF
--- a/src/AbstractAlgebra.jl
+++ b/src/AbstractAlgebra.jl
@@ -296,6 +296,7 @@ include("UniversalLaurentPoly.jl")
 include("UniversalRing.jl")
 include("UnivPoly.jl")
 include("FreeAssociativeAlgebra.jl")
+include("OreAlgebras.jl")
 include("LaurentMPoly.jl")
 include("MatrixNormalForms.jl")
 

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -110,7 +110,7 @@ abstract type MatRing{T<:NCRingElement} <: NCRing end
 
 abstract type FreeAssociativeAlgebra{T<:RingElement} <: NCRing end
 
-abstract type OreAlgebra{T<:RingElement} <: NCPolyRing{T} end
+abstract type OrePolyRing{T<:RingElement} <: NCPolyRing{T} end
 
 # Abstract types for number fields, parmeterised by the element type of
 # the base field.
@@ -159,7 +159,7 @@ abstract type MatRingElem{T<:NCRingElement} <: NCRingElem end
 
 abstract type FreeAssociativeAlgebraElem{T<:RingElement} <: NCRingElem end
 
-abstract type OreOperator{T<:RingElem} <: NCPolyRingElem{T} end
+abstract type OrePolyRingElem{T<:RingElem} <: NCPolyRingElem{T} end
 
 abstract type NumFieldElem{T<:RingElement} <: FieldElem end
 

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -110,7 +110,7 @@ abstract type MatRing{T<:NCRingElement} <: NCRing end
 
 abstract type FreeAssociativeAlgebra{T<:RingElement} <: NCRing end
 
-abstract type OrePolyRing{T<:RingElement} <: NCPolyRing{T} end
+abstract type OrePolyRing{T<:RingElement,S<:SkewDerivation} <: NCPolyRing{T} end
 
 # Abstract types for number fields, parmeterised by the element type of
 # the base field.
@@ -159,7 +159,7 @@ abstract type MatRingElem{T<:NCRingElement} <: NCRingElem end
 
 abstract type FreeAssociativeAlgebraElem{T<:RingElement} <: NCRingElem end
 
-abstract type OrePolyRingElem{T<:RingElem} <: NCPolyRingElem{T} end
+abstract type OrePolyRingElem{T<:RingElem,S<:SkewDerivation} <: NCPolyRingElem{T} end
 
 abstract type NumFieldElem{T<:RingElement} <: FieldElem end
 

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -76,6 +76,8 @@ abstract type IdentityMap <: SetMap end
 
 abstract type FPModuleHomomorphism <: FunctionalMap end
 
+abstract type SkewDerivation{D,S} <: Map{D,D,Map,SkewDerivation} where {S<:Map{D,D}} end
+
 # rings, fields etc, parameterised by an element type
 # these are the type classes of different kinds of
 # mathematical rings/fields/etc, which have a base ring,
@@ -107,6 +109,8 @@ abstract type TotFracRing{T<:RingElement} <: Ring end
 abstract type MatRing{T<:NCRingElement} <: NCRing end
 
 abstract type FreeAssociativeAlgebra{T<:RingElement} <: NCRing end
+
+abstract type OreAlgebra{T<:RingElement} <: NCPolyRing{T} end
 
 # Abstract types for number fields, parmeterised by the element type of
 # the base field.
@@ -154,6 +158,8 @@ abstract type MatElem{T} <: ModuleElem{T} end
 abstract type MatRingElem{T<:NCRingElement} <: NCRingElem end
 
 abstract type FreeAssociativeAlgebraElem{T<:RingElement} <: NCRingElem end
+
+abstract type OreOperator{T<:RingElem} <: NCPolyRingElem{T} end
 
 abstract type NumFieldElem{T<:RingElement} <: FieldElem end
 

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -96,6 +96,7 @@ include("generic/PolyRingHom.jl")
 
 include("generic/OreAlgebras.jl")
 include("generic/PolySkewDerivation.jl")
+include("generic/PolyFracFieldHom.jl")
 
 ###############################################################################
 #

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -94,6 +94,9 @@ include("generic/FreeAssociativeAlgebraGroebner.jl")
 
 include("generic/PolyRingHom.jl")
 
+include("generic/OreOperator.jl")
+include("generic/PolySkewDerivation.jl")
+
 ###############################################################################
 #
 #   Temporary miscellaneous files being moved from Hecke.jl

--- a/src/Generic.jl
+++ b/src/Generic.jl
@@ -94,7 +94,7 @@ include("generic/FreeAssociativeAlgebraGroebner.jl")
 
 include("generic/PolyRingHom.jl")
 
-include("generic/OreOperator.jl")
+include("generic/OreAlgebras.jl")
 include("generic/PolySkewDerivation.jl")
 
 ###############################################################################

--- a/src/OreAlgebras.jl
+++ b/src/OreAlgebras.jl
@@ -1,0 +1,65 @@
+###############################################################################
+#
+#   OreAlgebras.jl: skew-commutative polynomial ring R<D;σ,δ>
+#
+###############################################################################
+
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
+
+#coefficient_ring_type(T::Type{<:OreAlgebra}) = base_ring_type(T)
+#coefficient_ring(R::OreAlgebra{T}) where T <: RingElement = base_ring(R)
+
+#is_domain_type(::Type{OreOperator{T}}) where {T <: RingElement} = is_domain_type(T)
+#is_exact_type(::Type{OreOperator{T}}) where {T <: RingElement} = is_exact_type(T)
+
+number_of_variables(a::OreAlgebra) = 1
+
+###############################################################################
+#
+#   String I/O
+#
+###############################################################################
+
+function expressify(a::OreOperator{T}, D=parent(a)|>var; context=nothing) where T
+  sum = Expr(:call,:+)
+  for i in order(a):-1:0
+    c = coeff(a,i)
+    if !iszero(c)
+      xi = i < 1 ? 1 : i==1 ? D : Expr(:call,:^,D,i)
+      if isone(c)
+        push!(sum.args, Expr(:call,:*,xi))
+      else
+        push!(sum.args, Expr(:call,:*,expressify(c; context = context), xi))
+      end
+    end
+  end
+
+  return sum
+end
+@enable_all_show_via_expressify OreOperator
+
+function show(io::IO, R::OreAlgebra)
+  @show_name(io, R)
+  @show_special(io, R)
+
+  if is_terse(io)
+    print(io, "Univariate Ore extension")
+  else
+    io = pretty(io)
+    println(io, "Univariate Ore extension in ", gen(R))
+    print(io,Indent(),"over ",Lowercase(),base_ring(R))
+  end
+end
+
+
+###############################################################################
+#
+#   SkewDerivations
+#
+###############################################################################
+
+function sigma_endomorphism(::SkewDerivation{D,S}) where {D,S} end

--- a/src/OreAlgebras.jl
+++ b/src/OreAlgebras.jl
@@ -24,7 +24,7 @@ number_of_variables(a::OrePolyRing) = 1
 #
 ###############################################################################
 
-function expressify(a::OrePolyRingElem{T}, D=parent(a)|>var; context=nothing) where T
+function expressify(a::OrePolyRingElem, D=parent(a)|>var; context=nothing)
   sum = Expr(:call,:+)
   for i in order(a):-1:0
     c = coeff(a,i)

--- a/src/OreAlgebras.jl
+++ b/src/OreAlgebras.jl
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-#   OreAlgebras.jl: skew-commutative polynomial ring R<D;σ,δ>
+#   OrePolyRings.jl: skew-commutative polynomial ring R<D;σ,δ>
 #
 ###############################################################################
 
@@ -10,13 +10,13 @@
 #
 ###############################################################################
 
-#coefficient_ring_type(T::Type{<:OreAlgebra}) = base_ring_type(T)
-#coefficient_ring(R::OreAlgebra{T}) where T <: RingElement = base_ring(R)
+#coefficient_ring_type(T::Type{<:OrePolyRing}) = base_ring_type(T)
+#coefficient_ring(R::OrePolyRing{T}) where T <: RingElement = base_ring(R)
 
-#is_domain_type(::Type{OreOperator{T}}) where {T <: RingElement} = is_domain_type(T)
-#is_exact_type(::Type{OreOperator{T}}) where {T <: RingElement} = is_exact_type(T)
+#is_domain_type(::Type{OrePolyRingElem{T}}) where {T <: RingElement} = is_domain_type(T)
+#is_exact_type(::Type{OrePolyRingElem{T}}) where {T <: RingElement} = is_exact_type(T)
 
-number_of_variables(a::OreAlgebra) = 1
+number_of_variables(a::OrePolyRing) = 1
 
 ###############################################################################
 #
@@ -24,7 +24,7 @@ number_of_variables(a::OreAlgebra) = 1
 #
 ###############################################################################
 
-function expressify(a::OreOperator{T}, D=parent(a)|>var; context=nothing) where T
+function expressify(a::OrePolyRingElem{T}, D=parent(a)|>var; context=nothing) where T
   sum = Expr(:call,:+)
   for i in order(a):-1:0
     c = coeff(a,i)
@@ -40,9 +40,9 @@ function expressify(a::OreOperator{T}, D=parent(a)|>var; context=nothing) where 
 
   return sum
 end
-@enable_all_show_via_expressify OreOperator
+@enable_all_show_via_expressify OrePolyRingElem
 
-function show(io::IO, R::OreAlgebra)
+function show(io::IO, R::OrePolyRing)
   @show_name(io, R)
   @show_special(io, R)
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -629,6 +629,6 @@ export ore_extension
 export trivial_derivation
 export derivation
 export sigma_endomorphism
-export OreAlgebra
-export OreOperator
+export OrePolyRing
+export OrePolyRingElem
 export SkewDerivation

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -629,3 +629,6 @@ export ore_extension
 export trivial_derivation
 export derivation
 export sigma_endomorphism
+export OreAlgebra
+export OreOperator
+export SkewDerivation

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -624,3 +624,8 @@ export zero!
 export zero_matrix
 export zeros
 export zz
+
+export ore_extension
+export trivial_derivation
+export derivation
+export sigma_endomorphism

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1621,8 +1621,8 @@ mutable struct PolyFracFieldAnyMap{
   domain::D
   morphism::V
 
-  function PolyFracFieldAnyMap{D,C,V}(d::D,ϕ::V) where {D,C,V}
-    return new{D,C,V}(d,ϕ)
+  function PolyFracFieldAnyMap{D,C,V}(d::D,phi::V) where {D,C,V}
+    return new{D,C,V}(d,phi)
   end
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1606,3 +1606,45 @@ end
 function PolyRingAnyMap(d::D, c::C, cm::U, ig::V) where {D, C, U, V}
   return PolyRingAnyMap{D, C, U, V}(d, c, cm, ig)
 end
+
+################################################################################
+#
+#   Univariate Ore algebra, its element type skew derivations
+#
+################################################################################
+abstract type AbstractOreAlgebra <: NCRing end
+abstract type SkewDerivation{D,S} <: Map{D,D,Map,SkewDerivation} where {S<:Map{D,D}} end
+
+@attributes mutable struct OreAlgebra{T<:RingElem} <: AbstractOreAlgebra
+  base_ring::Ring
+  D::Symbol
+  δ::Map(SkewDerivation)
+
+  function OreAlgebra{T}(R::Ring, D::Symbol, δ; cached=true) where T<:RingElem
+    return get_cached!(OreID, (R,D,δ), cached) do
+      new{T}(R,D,δ)
+    end
+  end
+end
+
+const OreID = CacheDictType{Tuple{Ring,Symbol,Map(SkewDerivation)},NCRing}()
+
+mutable struct OreOperator{T<:RingElem} <: NCPolyRingElem{T}
+  parent::OreAlgebra{T}
+  coeffs::Vector{T}
+  length::Int
+end
+
+mutable struct PolySkewDerivation{D,S} <: SkewDerivation{D,S}
+  domain::D
+  σ::S
+  intermediate_cache::Vector{<:NCRingElem}
+
+  function PolySkewDerivation{D,S}(dom::D,σ::S,coeff::T) where {D,S,T<:NCRingElem}
+    return new{D,S}(dom,σ,[coeff])
+  end
+end
+
+function sigma_endomorphism(::SkewDerivation{D,S}) where {D,S} end
+
+Univariateish = Union{PolyRing,FracField{<:PolyRingElem},RationalFunctionField}

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1609,6 +1609,30 @@ end
 
 ################################################################################
 #
+#   R-algebra morphisms of R(x)
+#
+################################################################################
+
+mutable struct PolyFracFieldAnyMap{
+    D <: Union{FracField{<:PolyRingElem},RationalFunctionField{<:RingElement,<:PolyRingElem}},
+    C <: NCRing,
+    V <: Map{<:PolyRing,C}} <: Map{D,C,Map,PolyFracFieldAnyMap}
+
+  domain::D
+  morphism::V
+
+  function PolyFracFieldAnyMap{D,C,V}(d::D,ϕ::V) where {D,C,V}
+    return new{D,C,V}(d,ϕ)
+  end
+end
+
+function PolyFracFieldAnyMap(d::D,i::V) where {D,C,V<:Map{<:PolyRing,C}}
+  return PolyFracFieldAnyMap{D,C,V}(d,i)
+end
+
+
+################################################################################
+#
 #   Univariate Ore algebra, its element type skew derivations
 #
 ################################################################################

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1636,21 +1636,21 @@ end
 #   Univariate Ore algebra, its element type skew derivations
 #
 ################################################################################
-@attributes mutable struct OrePolyRing{T<:RingElem} <: AbstractAlgebra.OrePolyRing{T}
+@attributes mutable struct OrePolyRing{T<:RingElem,S<:SkewDerivation} <: AbstractAlgebra.OrePolyRing{T,S}
   base_ring::Ring
   D::Symbol
-  δ::Map(SkewDerivation)
+  d::S
 
-  function OrePolyRing{T}(R::Ring, D::Symbol, δ; cached=true) where T<:RingElem
-    return get_cached!(OreID, (R,D,δ), cached) do
-      new{T}(R,D,δ)
+  function OrePolyRing{T,S}(R::Ring, D::Symbol, d::S; cached=true) where {T<:RingElem,S<:Map(SkewDerivation)}
+    return get_cached!(OreID, (R,D,d), cached) do
+      new{T,S}(R,D,d)
     end
   end
 end
 
 const OreID = CacheDictType{Tuple{Ring,Symbol,Map(SkewDerivation)},NCRing}()
 
-mutable struct OrePolyRingElem{T<:RingElem} <: AbstractAlgebra.OrePolyRingElem{T}
+mutable struct OrePolyRingElem{T<:RingElem,S<:SkewDerivation} <: AbstractAlgebra.OrePolyRingElem{T,S}
   parent::OrePolyRing{T}
   coeffs::Vector{T}
   length::Int
@@ -1658,11 +1658,31 @@ end
 
 mutable struct PolySkewDerivation{D,S} <: SkewDerivation{D,S}
   domain::D
-  σ::S
+  s::S
   intermediate_cache::Vector{<:NCRingElem}
 
   function PolySkewDerivation{D,S}(dom::D,σ::S,coeff::T) where {D,S,T<:NCRingElem}
     return new{D,S}(dom,σ,[coeff])
+  end
+end
+
+mutable struct MPolySkewDerivation{D,S} <: SkewDerivation{D,S}
+  domain::D
+  s::S
+  g
+  coeff
+
+  function MPolySkewDerivation{D,S}(dom::D,s::S,g,coeff) where {D,S}
+    return new{D,S}(dom,s,g,coeff)
+  end
+end
+
+mutable struct TrivialSkewDerivation{D,S} <: SkewDerivation{D,S}
+  domain::D
+  s::S
+
+  function TrivialSkewDerivation{D,S}(dom::D,s::S) where {D,S}
+    return new{D,S}(dom,s)
   end
 end
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1636,10 +1636,7 @@ end
 #   Univariate Ore algebra, its element type skew derivations
 #
 ################################################################################
-abstract type AbstractOreAlgebra <: NCRing end
-abstract type SkewDerivation{D,S} <: Map{D,D,Map,SkewDerivation} where {S<:Map{D,D}} end
-
-@attributes mutable struct OreAlgebra{T<:RingElem} <: AbstractOreAlgebra
+@attributes mutable struct OreAlgebra{T<:RingElem} <: AbstractAlgebra.OreAlgebra{T}
   base_ring::Ring
   D::Symbol
   δ::Map(SkewDerivation)
@@ -1653,7 +1650,7 @@ end
 
 const OreID = CacheDictType{Tuple{Ring,Symbol,Map(SkewDerivation)},NCRing}()
 
-mutable struct OreOperator{T<:RingElem} <: NCPolyRingElem{T}
+mutable struct OreOperator{T<:RingElem} <: AbstractAlgebra.OreOperator{T}
   parent::OreAlgebra{T}
   coeffs::Vector{T}
   length::Int
@@ -1668,7 +1665,5 @@ mutable struct PolySkewDerivation{D,S} <: SkewDerivation{D,S}
     return new{D,S}(dom,σ,[coeff])
   end
 end
-
-function sigma_endomorphism(::SkewDerivation{D,S}) where {D,S} end
 
 Univariateish = Union{PolyRing,FracField{<:PolyRingElem},RationalFunctionField}

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1636,12 +1636,12 @@ end
 #   Univariate Ore algebra, its element type skew derivations
 #
 ################################################################################
-@attributes mutable struct OreAlgebra{T<:RingElem} <: AbstractAlgebra.OreAlgebra{T}
+@attributes mutable struct OrePolyRing{T<:RingElem} <: AbstractAlgebra.OrePolyRing{T}
   base_ring::Ring
   D::Symbol
   δ::Map(SkewDerivation)
 
-  function OreAlgebra{T}(R::Ring, D::Symbol, δ; cached=true) where T<:RingElem
+  function OrePolyRing{T}(R::Ring, D::Symbol, δ; cached=true) where T<:RingElem
     return get_cached!(OreID, (R,D,δ), cached) do
       new{T}(R,D,δ)
     end
@@ -1650,8 +1650,8 @@ end
 
 const OreID = CacheDictType{Tuple{Ring,Symbol,Map(SkewDerivation)},NCRing}()
 
-mutable struct OreOperator{T<:RingElem} <: AbstractAlgebra.OreOperator{T}
-  parent::OreAlgebra{T}
+mutable struct OrePolyRingElem{T<:RingElem} <: AbstractAlgebra.OrePolyRingElem{T}
+  parent::OrePolyRing{T}
   coeffs::Vector{T}
   length::Int
 end

--- a/src/generic/OreAlgebras.jl
+++ b/src/generic/OreAlgebras.jl
@@ -8,12 +8,12 @@
 #
 ###############################################################################
 
-function ore_extension(R::DT, D::Symbol, δ) where {DT<:Ring}
+function ore_extension(R::DT, D::Symbol, δ::S) where {DT<:Ring,S<:Map(SkewDerivation)}
   σ = sigma_endomorphism(δ)
   OO = ore_extension_only(R,D,δ)
   return OO,gen(OO)
 end
-ore_extension_only(R::T, D::Symbol, δ) where T<:Ring = OrePolyRing{elem_type(R)}(R, D, δ)
+ore_extension_only(R::T, D::Symbol, δ::S) where {T<:Ring,S<:Map(SkewDerivation)} = OrePolyRing{elem_type(R),S}(R, D, δ)
 
 ###############################################################################
 #
@@ -21,16 +21,16 @@ ore_extension_only(R::T, D::Symbol, δ) where T<:Ring = OrePolyRing{elem_type(R)
 #
 ###############################################################################
 
-elem_type(::Type{OrePolyRing{T}}) where T = OrePolyRingElem{T}
-base_ring_type(::Type{OrePolyRing{T}}) where T = parent_type(T)
+elem_type(::Type{OrePolyRing{T,S}}) where {T,S} = OrePolyRingElem{T,S}
+base_ring_type(::Type{OrePolyRing{T,S}}) where {T,S} = parent_type(T)
 base_ring(R::OrePolyRing) = R.base_ring
 
 var(R::OrePolyRing) = R.D
 symbols(R::OrePolyRing) = [var(R)]
 
-function gen(R::OrePolyRing{T}) where T
+function gen(R::OrePolyRing{T,S}) where {T,S}
   C = base_ring(R)
-  return OrePolyRingElem{T}(R,[zero(C),one(C)],2)
+  return OrePolyRingElem{T,S}(R,[zero(C),one(C)],2)
 end
 
 AbstractAlgebra.ngens(R::OrePolyRing) = 1
@@ -42,15 +42,15 @@ gens(R::OrePolyRing) = [gen(R)]
 #
 ###############################################################################
 
-function zero(R::OrePolyRing{T}) where T
-  return OrePolyRingElem{T}(R,T[],0)
+function zero(R::OrePolyRing{T,S}) where {T,S}
+  return OrePolyRingElem{T,S}(R,T[],0)
 end
 
-function one(R::OrePolyRing{T}) where T
-  return OrePolyRingElem{T}(R,T[one(base_ring(R))],1)
+function one(R::OrePolyRing{T,S}) where {T,S}
+  return OrePolyRingElem{T,S}(R,T[one(base_ring(R))],1)
 end
 
-derivation(R::OrePolyRing) = R.δ
+derivation(R::OrePolyRing) = R.d
 sigma_endomorphism(R::OrePolyRing) = sigma_endomorphism(derivation(R))
 
 ###############################################################################
@@ -63,18 +63,18 @@ sigma_endomorphism(R::OrePolyRing) = sigma_endomorphism(derivation(R))
 #
 ###############################################################################
 
-parent_type(::Type{OrePolyRingElem{T}}) where T = OrePolyRing{T}
-parent(a::OrePolyRingElem{T}) where T = a.parent
+parent_type(::Type{OrePolyRingElem{T,S}}) where {T,S} = OrePolyRing{T,S}
+parent(a::OrePolyRingElem{T,S}) where {T,S} = a.parent
 
-promote_rule(::Type{OrePolyRingElem{T}},::Type{OrePolyRingElem{T}}) where T<:RingElement = OrePolyRingElem{T}
-function promote_rule(::Type{OrePolyRingElem{T}},::Type{U}) where {T<:RingElement,U<:RingElement}
-  promote_rule(T, U) == T ? OrePolyRingElem{T} : Union{}
+promote_rule(::Type{OrePolyRingElem{T,S}},::Type{OrePolyRingElem{T,S}}) where {T<:RingElement,S} = OrePolyRingElem{T,S}
+function promote_rule(::Type{OrePolyRingElem{T,S}},::Type{U}) where {T<:RingElement,U<:RingElement,S}
+  promote_rule(T, U) == T ? OrePolyRingElem{T,S} : Union{}
 end
 
-function deepcopy_internal(a::OrePolyRingElem{T}, dict::IdDict) where T
+function deepcopy_internal(a::OrePolyRingElem{T,S}, dict::IdDict) where {T,S}
   C = [deepcopy_internal(c,dict) for c in coefficients(a)]
 
-  return OrePolyRingElem{T}(parent(a), C, length(C))
+  return OrePolyRingElem{T,S}(parent(a), C, length(C))
 end
 
 ###############################################################################
@@ -83,36 +83,36 @@ end
 #
 ###############################################################################
 
-function (R::OrePolyRing{T})() where T
+function (R::OrePolyRing)()
   return zero(R)
 end
 
-function (R::OrePolyRing{T})(c::T) where T
+function (R::OrePolyRing{T,S})(c::T) where {T,S}
   iszero(c) && return zero(R)
-  return OrePolyRingElem{T}(R,[c],1)
+  return OrePolyRingElem{T,S}(R,[c],1)
 end
 
-function (R::OrePolyRing{T})(c::Union{Integer,Rational,AbstractFloat}) where T
+function (R::OrePolyRing)(c::Union{Integer,Rational,AbstractFloat})
   C = base_ring(R)
   return R(C(c))
 end
 
-function (R::OrePolyRing{T})(a::OrePolyRingElem{T}) where T
+function (R::OrePolyRing{T,S})(a::OrePolyRingElem{T,S}) where {T,S}
  parent(a) != R && error("Unable to coerce polynomial")
  return a
 end
 
-function (R::OrePolyRing{T})(c::Vector{T}) where T<:RingElem
-  return OrePolyRingElem{T}(R,c,length(c))
+function (R::OrePolyRing{T,S})(c::Vector{T}) where {T<:RingElem,S}
+  return OrePolyRingElem{T,S}(R,c,length(c))
 end
 
-function (R::OrePolyRing{T})(c::Vector{U}) where {T<:RingElem,U<:RingElem}
-  return OrePolyRingElem{T}(R,c,length(c))
+function (R::OrePolyRing{T,S})(c::Vector{U}) where {T<:RingElem,U<:RingElem,S}
+  return OrePolyRingElem{T,S}(R,c,length(c))
 end
 
-function (R::OrePolyRing{T})(c::Vector{U}) where {T<:RingElem,U<:Integer}
+function (R::OrePolyRing{T,S})(c::Vector{U}) where {T<:RingElem,U<:Integer,S}
   C = base_ring(R)
-  return OrePolyRingElem{T}(R,C.(c),length(c))
+  return OrePolyRingElem{T,S}(R,C.(c),length(c))
 end
 
 ###############################################################################
@@ -121,34 +121,32 @@ end
 #
 ###############################################################################
 
-iszero(a::OrePolyRingElem{T}) where T = a.length == 0
-function isone(a::OrePolyRingElem{T}) where T
+iszero(a::OrePolyRingElem) = a.length == 0
+function isone(a::OrePolyRingElem)
   return length(a) == 1 && first(coefficients(a)) |> isone
 end
 
-function canonical_unit(a::OrePolyRingElem{T}) where T
-  return one(parent(a))
-end
+canonical_unit(a::OrePolyRingElem) = one(parent(a))
 
-function is_unit(a::OrePolyRingElem{T}) where T
+function is_unit(a::OrePolyRingElem)
   iszero(a) && return false
   isone(a) && return true
   order(a) == 0 && leading_coefficient(a)|>is_unit && return true
 end
 
-order(a::OrePolyRingElem{T}) where T = iszero(a) ? -1 : length(a)-1
-length(a::OrePolyRingElem{T}) where T = a.length
+order(a::OrePolyRingElem) = iszero(a) ? -1 : length(a)-1
+length(a::OrePolyRingElem) = a.length
 
-function set_length!(a::OrePolyRingElem{T},n::Int) where T
+function set_length!(a::OrePolyRingElem,n::Int)
   resize!(a.coeffs, n)
   a.length = n
 
   return a
 end
 
-coefficients(a::OrePolyRingElem{T}) where T = a.coeffs[1:length(a)]
+coefficients(a::OrePolyRingElem) = a.coeffs[1:length(a)]
 
-function coeff(a::OrePolyRingElem{T},i) where T
+function coeff(a::OrePolyRingElem, i::Int)
   if 0 <= i && i <= order(a)
     return a.coeffs[i+1]
   else
@@ -156,8 +154,8 @@ function coeff(a::OrePolyRingElem{T},i) where T
   end
 end
 
-setcoeff!(a::OrePolyRingElem{T}, n::Int, c::Integer) where T = setcoeff!(a,n,base_ring(a)(c))
-function setcoeff!(a::OrePolyRingElem{T}, n::Int, c::T) where T
+setcoeff!(a::OrePolyRingElem, n::Int, c::Integer) = setcoeff!(a,n,base_ring(a)(c))
+function setcoeff!(a::OrePolyRingElem{T,S}, n::Int, c::T) where {T,S}
   i = n+1
   if i > length(a.coeffs)
     resize!(a.coeffs,i)
@@ -168,14 +166,14 @@ function setcoeff!(a::OrePolyRingElem{T}, n::Int, c::T) where T
   return a
 end
 
-function normalise(a::OrePolyRingElem{T}, n::Int) where T
+function normalise(a::OrePolyRingElem, n::Int)
   n = min(n,length(a.coeffs))
   i = findlast(!iszero, a.coeffs[1:n])
   isnothing(i) && return 0
   return i
 end
 
-function fit!(a::OrePolyRingElem{T}, n::Int) where T
+function fit!(a::OrePolyRingElem, n::Int)
   if n > length(a)
     old_n = length(a)+1
     resize!(a.coeffs, n)
@@ -185,15 +183,15 @@ function fit!(a::OrePolyRingElem{T}, n::Int) where T
   return
 end
 
-function leading_coefficient(a::OrePolyRingElem{T}) where T
+function leading_coefficient(a::OrePolyRingElem)
   iszero(a) && return base_ring(a)()
   return coefficients(a) |> last
 end
-function leading_term(a::OrePolyRingElem{T}) where T
+function leading_term(a::OrePolyRingElem)
   iszero(a) && return parent(a)()
   return leading_coefficient(a)*leading_monomial(a)
 end
-function leading_monomial(a::OrePolyRingElem{T}) where T
+function leading_monomial(a::OrePolyRingElem)
   iszero(a) && return parent(a)()
   A = parent(a)
   C = base_ring(a)
@@ -208,14 +206,14 @@ end
 #
 ###############################################################################
 
-function -(a::OrePolyRingElem{T}) where T
+function -(a::OrePolyRingElem)
   R = parent(a)
   c = -a.coeffs
 
-  return OrePolyRingElem{T}(R,c,length(c))
+  return R(c)
 end
 
-function +(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T<:RingElem
+function +(a::OrePolyRingElem{T,S},b::OrePolyRingElem{T,S}) where {T<:RingElem,S}
   check_parent(a,b)
   
   z = parent(a)()
@@ -261,7 +259,7 @@ end
 -(a::OrePolyRingElem,c::Integer) = a + -c
 -(c::Integer,a::OrePolyRingElem) = a -  c
 
-function -(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
+function -(a::OrePolyRingElem{T,S},b::OrePolyRingElem{T,S}) where {T,S}
   return a + -b
 end
 
@@ -277,20 +275,28 @@ function *(a::OrePolyRingElem{T},b::T) where T<:RingElem
   return a*parent(a)(b)
 end
 
-function *(a::T,b::OrePolyRingElem{T}) where T<:RingElem
+function *(a::T,b::OrePolyRingElem{T,S}) where {T<:RingElem,S}
   R = parent(b)
   res = a.*coefficients(b)
-  return OrePolyRingElem{T}(R,res,length(b))
+  return OrePolyRingElem{T,S}(R,res,length(b))
 end
 
-function *(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
+function _mult_step(k::D,q::Vector{T},d::S) where {D,T,S<:SkewDerivation{D}}
+  s = sigma_endomorphism(d)
+  return [d.(q); zero(k)] .+ [zero(k); s.(q)]
+end
+function _mult_step(k::D,q::Vector{T},d::S) where {D,T,S<:TrivialSkewDerivation{D}}
+  s = sigma_endomorphism(d)
+  return [zero(k); s.(q)]
+end
+
+function *(a::OrePolyRingElem{T,S},b::OrePolyRingElem{T,S}) where {T,S}
   check_parent(a,b)
   (iszero(a) || iszero(b)) && return zero(a)
 
   R = parent(a)
   k = base_ring(R)
-  δ = derivation(R)
-  σ = sigma_endomorphism(R)
+  d = derivation(R)
 
   res = zeros(parent(a)|>base_ring,length(b))
   q = coefficients(b)
@@ -298,7 +304,7 @@ function *(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
   for p in coefficients(a)
     res += p.*q
     push!(res,zero(k))
-    q = [δ.(q); zero(k)] .+ [zero(k); σ.(q)]
+    q = _mult_step(k,q,d)
   end
 
   i = findlast(!iszero,res)
@@ -306,10 +312,10 @@ function *(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
     return zero(R)
   end
 
-  return OrePolyRingElem{T}(R,res[1:i],i)
+  return OrePolyRingElem{T,S}(R,res[1:i],i)
 end
 
-function ==(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
+function ==(a::OrePolyRingElem{T,S},b::OrePolyRingElem{T,S}) where {T,S}
   fl = check_parent(a,b,false)
   !fl && return false
   if a.length != b.length
@@ -318,7 +324,7 @@ function ==(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
   return all(splat(==),zip(a.coeffs,b.coeffs))
 end
 
-function ==(a::OrePolyRingElem{T}, c::T) where T
+function ==(a::OrePolyRingElem{T,S}, c::T) where {T,S}
   if iszero(c)
     return a.length == 0
   elseif a.length == 1
@@ -327,9 +333,9 @@ function ==(a::OrePolyRingElem{T}, c::T) where T
     return false
   end
 end
-==(c::T,a::OrePolyRingElem{T}) where T = a == c
+==(c::T,a::OrePolyRingElem{T,S}) where {T,S} = a == c
 
-function ^(a::OrePolyRingElem{T},i::Int) where T
+function ^(a::OrePolyRingElem{T,S},i::Int) where {T,S}
   if i < 0
     throw(DomainError(i, "exponent must be >= 0"))
   elseif i == 0
@@ -341,7 +347,7 @@ function ^(a::OrePolyRingElem{T},i::Int) where T
   end
 end
 
-function divexact_right(a::OrePolyRingElem{T},b::OrePolyRingElem{T}; check=true) where T
+function divexact_right(a::OrePolyRingElem{T,S},b::OrePolyRingElem{T,S}; check=true) where {T,S}
   iszero(b) && throw(DivideError())
   q,r = rdivrem(a,b)
 
@@ -356,14 +362,14 @@ end
 #
 ###############################################################################
 
-function zero!(a::OrePolyRingElem{T}) where T
+function zero!(a::OrePolyRingElem)
   a.coeffs = elem_type(base_ring(a))[]
   a.length = 0
 
   return a
 end
 
-function one!(a::OrePolyRingElem{T}) where T
+function one!(a::OrePolyRingElem)
   a.coeffs = [one(base_ring(a))]
   a.length = 1
 

--- a/src/generic/OreAlgebras.jl
+++ b/src/generic/OreAlgebras.jl
@@ -1,0 +1,307 @@
+function ore_extension(R::DT, D::Symbol, δ) where {DT<:Ring}
+  σ = sigma_endomorphism(δ)
+  OO = ore_extension_only(R,D,δ)
+  return OO,gen(OO)
+end
+ore_extension_only(R::T, D::Symbol, δ) where T<:Ring = OreAlgebra{elem_type(R)}(R, D, δ)
+
+function (R::OreAlgebra{T})() where T
+  return zero(R)
+end
+
+function (R::OreAlgebra{T})(c::T) where T
+  iszero(c) && return zero(R)
+  return OreOperator{T}(R,[c],1)
+end
+
+function (R::OreAlgebra{T})(c::Union{Integer,Rational,AbstractFloat}) where T
+  C = base_ring(R)
+  return R(C(c))
+end
+
+function (R::OreAlgebra{T})(a::OreOperator{T}) where T
+ parent(a) != R && error("Unable to coerce polynomial")
+ return a
+end
+
+function (R::OreAlgebra{T})(c::Vector{T}) where T<:RingElem
+  return OreOperator{T}(R,c,length(c))
+end
+
+function (R::OreAlgebra{T})(c::Vector{U}) where {T<:RingElem,U<:RingElem}
+  return OreOperator{T}(R,c,length(c))
+end
+
+function (R::OreAlgebra{T})(c::Vector{U}) where {T<:RingElem,U<:Integer}
+  C = base_ring(R)
+  return OreOperator{T}(R,C.(c),length(c))
+end
+
+###############################################################################
+#
+#   OreAlgebra
+#
+###############################################################################
+
+elem_type(::Type{OreAlgebra{T}}) where T = OreOperator{T}
+base_ring_type(::Type{OreAlgebra{T}}) where T = parent_type(T)
+
+base_ring(R::OreAlgebra) = R.base_ring
+
+var(R::OreAlgebra) = R.D
+symbols(R::OreAlgebra) = [var(R)]
+
+function gen(R::OreAlgebra{T}) where T
+  C = base_ring(R)
+  return OreOperator{T}(R,[zero(C),one(C)],2)
+end
+
+ngens(R::OreAlgebra) = 1
+gens(R::OreAlgebra) = [gen(R)]
+
+function zero(R::OreAlgebra{T}) where T
+  return OreOperator{T}(R,T[],0)
+end
+
+function one(R::OreAlgebra{T}) where T
+  return OreOperator{T}(R,T[one(base_ring(R))],1)
+end
+
+derivation(R::OreAlgebra) = R.δ
+sigma_endomorphism(R::OreAlgebra) = sigma_endomorphism(derivation(R))
+
+###############################################################################
+#
+#   OreOperator
+#
+###############################################################################
+
+parent_type(::Type{OreOperator{T}}) where T = OreAlgebra{T}
+parent(a::OreOperator{T}) where T = a.parent
+
+is_domain_type(::Type{OreOperator{T}}) where T = false
+is_exact_type(::Type{OreOperator{T}}) where T = is_exact_type(T)
+
+promote_rule(::Type{OreOperator{T}},::Type{OreOperator{T}}) where T<:RingElement = OreOperator{T}
+function promote_rule(::Type{OreOperator{T}},::Type{U}) where {T<:RingElement,U<:RingElement}
+  promote_rule(T, U) == T ? OreOperator{T} : Union{}
+end
+
+function deepcopy_internal(a::OreOperator{T}, dict::IdDict) where T
+  C = [deepcopy_internal(c,dict) for c in coefficients(a)]
+
+  return OreOperator{T}(parent(a), C, length(C))
+end
+
+coefficients(a::OreOperator{T}) where T = a.coeffs[1:length(a)]
+length(a::OreOperator{T}) where T = a.length
+
+iszero(a::OreOperator{T}) where T = a.length == 0
+function isone(a::OreOperator{T}) where T
+  return length(a) == 1 && first(coefficients(a)) |> isone
+end
+
+function canonical_unit(a::OreOperator{T}) where T
+  return one(parent(a))
+end
+
+function coeff(a::OreOperator{T},i) where T
+  if 0 <= i && i <= order(a)
+    return a.coeffs[i+1]
+  else
+    return zero(base_ring(a))
+  end
+end
+
+setcoeff!(a::OreOperator{T}, n::Int, c::Integer) where T = setcoeff!(a,n,base_ring(a)(c))
+function setcoeff!(a::OreOperator{T}, n::Int, c::T) where T
+  i = n+1
+  if i > length(a.coeffs)
+    resize!(a.coeffs,i)
+    a.coeffs[a.length+1:i] .= zero(base_ring(a))
+  end
+  a.coeffs[i] = c
+  a.length = normalise(a,length(a.coeffs))
+  return a
+end
+
+function leading_coefficient(a::OreOperator{T}) where T
+  iszero(a) && return base_ring(a)()
+  return coefficients(a) |> last
+end
+function leading_term(a::OreOperator{T}) where T
+  iszero(a) && return parent(a)()
+  A = parent(a)
+  C = base_ring(a)
+  c = leading_coefficient(a)
+  k = order(a)
+
+  return A([fill(zero(C),k); c])
+end
+function leading_monomial(a::OreOperator{T}) where T
+  iszero(a) && return parent(a)()
+  A = parent(a)
+  C = base_ring(a)
+  k = order(a)
+
+  return A(T[(zero(C) for _ in 1:k)..., one(C)])
+end
+
+order(a::OreOperator{T}) where T = iszero(a) ? -1 : length(a)-1
+
+function +(a::OreOperator{T},b::OreOperator{T}) where T<:RingElem
+  check_parent(a,b)
+
+  la = length(a)
+  lb = length(b)
+  l = min(la,lb)
+  L = max(la,lb)
+
+  new_c = Vector{T}(undef,L)
+
+  new_c[1:l] .= coefficients(a)[1:l] + coefficients(b)[1:l]
+  c = la > lb ? coefficients(a) : coefficients(b)
+  new_c[(l+1):L] = c[(l+1):L]
+
+  if all(iszero,new_c)
+    return zero(parent(a))
+  else
+    i = findlast(!iszero,new_c)
+    return OreOperator{T}(parent(a), new_c, i)
+  end
+end
+
+function -(a::OreOperator{T}) where T
+  R = parent(a)
+  c = -a.coeffs
+
+  return OreOperator{T}(R,c,length(c))
+end
+
+function -(a::OreOperator{T},b::OreOperator{T}) where T
+  return a + -b
+end
+
+function *(a::OreOperator{T},b::T) where T<:RingElem
+  return a*parent(a)(b)
+end
+
+function *(a::T,b::OreOperator{T}) where T<:RingElem
+  R = parent(b)
+  res = a.*coefficients(b)
+  return OreOperator{T}(R,res,length(b))
+end
+
+function *(a::OreOperator{T},b::OreOperator{T}) where T
+  check_parent(a,b)
+  (iszero(a) || iszero(b)) && return zero(a)
+
+  R = parent(a)
+  k = base_ring(R)
+  δ = derivation(R)
+  σ = sigma_endomorphism(R)
+
+  res = zeros(parent(a)|>base_ring,length(b))
+  q = coefficients(b)
+  l = length(q)
+  for p in coefficients(a)
+    res += p.*q
+    push!(res,zero(R|>base_ring))
+    q = [δ.(q); zero(k)] .+ [zero(k); σ.(q)]
+  end
+
+  i = findlast(!iszero,res)
+  if isnothing(i)
+    return zero(R)
+  end
+
+  return OreOperator{T}(R,res[1:i],i)
+end
+
+function ^(a::OreOperator{T},i::Int) where T
+  if i < 0
+    throw(DomainError(i, "exponent must be >= 0"))
+  elseif i == 0
+    return one(parent(a))
+  elseif i == 1
+    return a
+  else
+    return reduce(*,Iterators.repeated(a,i-1);init=a)
+  end
+end
+
+
+function divexact_right(a::OreOperator{T},b::OreOperator{T}; check=true) where T
+  iszero(b) && throw(DivideError())
+  q,r = rdivrem(a,b)
+
+  !check && return q
+  @req iszero(r) "not an exact division"
+  return q
+end
+
+function ==(a::OreOperator{T},b::OreOperator{T}) where T
+  fl = check_parent(a,b,false)
+  !fl && return false
+  if a.length != b.length
+    return false
+  end
+  return all(splat(==),zip(a.coeffs,b.coeffs))
+end
+
+function ==(a::OreOperator{T}, c::T) where T
+  if iszero(c)
+    return a.length == 0
+  elseif a.length == 1
+    return leading_coefficient(a) == c
+  else
+    return false
+  end
+end
+==(c::T,a::OreOperator{T}) where T = a == c
+
+function is_unit(a::OreOperator{T}) where T
+  iszero(a) && return false
+  isone(a) && return true
+  order(a) == 0 && leading_coefficient(a)|>is_unit && return true
+end
+
+function zero!(a::OreOperator{T}) where T
+  a.coeffs = elem_type(base_ring(a))[]
+  a.length = 0
+
+  return a
+end
+
+function one!(a::OreOperator{T}) where T
+  a.coeffs = [one(base_ring(a))]
+  a.length = 1
+
+  return a
+end
+
+function set_length!(a::OreOperator{T},n::Int) where T
+  resize!(a.coeffs, n)
+  a.length = n
+
+  return a
+end
+
+function normalise(a::OreOperator{T}, n::Int) where T
+  n = min(n,length(a.coeffs))
+  i = findlast(!iszero, a.coeffs[1:n])
+  isnothing(i) && return 0
+  return i
+end
+
+function fit!(a::OreOperator{T}, n::Int) where T
+  if n > length(a)
+    old_n = length(a)+1
+    resize!(a.coeffs, n)
+    a.coeffs[old_n:n] .= base_ring(a)|>zero
+  end
+
+  return
+end
+
+

--- a/src/generic/OreAlgebras.jl
+++ b/src/generic/OreAlgebras.jl
@@ -1,111 +1,154 @@
+###############################################################################
+#
+#   OrePolyRing
+#
+###############################################################################
+#
+#   Constructors
+#
+###############################################################################
+
 function ore_extension(R::DT, D::Symbol, δ) where {DT<:Ring}
   σ = sigma_endomorphism(δ)
   OO = ore_extension_only(R,D,δ)
   return OO,gen(OO)
 end
-ore_extension_only(R::T, D::Symbol, δ) where T<:Ring = OreAlgebra{elem_type(R)}(R, D, δ)
+ore_extension_only(R::T, D::Symbol, δ) where T<:Ring = OrePolyRing{elem_type(R)}(R, D, δ)
 
-function (R::OreAlgebra{T})() where T
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
+
+elem_type(::Type{OrePolyRing{T}}) where T = OrePolyRingElem{T}
+base_ring_type(::Type{OrePolyRing{T}}) where T = parent_type(T)
+base_ring(R::OrePolyRing) = R.base_ring
+
+var(R::OrePolyRing) = R.D
+symbols(R::OrePolyRing) = [var(R)]
+
+function gen(R::OrePolyRing{T}) where T
+  C = base_ring(R)
+  return OrePolyRingElem{T}(R,[zero(C),one(C)],2)
+end
+
+AbstractAlgebra.ngens(R::OrePolyRing) = 1
+gens(R::OrePolyRing) = [gen(R)]
+
+###############################################################################
+#
+#   Basic manipulation of rings
+#
+###############################################################################
+
+function zero(R::OrePolyRing{T}) where T
+  return OrePolyRingElem{T}(R,T[],0)
+end
+
+function one(R::OrePolyRing{T}) where T
+  return OrePolyRingElem{T}(R,T[one(base_ring(R))],1)
+end
+
+derivation(R::OrePolyRing) = R.δ
+sigma_endomorphism(R::OrePolyRing) = sigma_endomorphism(derivation(R))
+
+###############################################################################
+#
+#   OrePolyRingElem
+#
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
+
+parent_type(::Type{OrePolyRingElem{T}}) where T = OrePolyRing{T}
+parent(a::OrePolyRingElem{T}) where T = a.parent
+
+promote_rule(::Type{OrePolyRingElem{T}},::Type{OrePolyRingElem{T}}) where T<:RingElement = OrePolyRingElem{T}
+function promote_rule(::Type{OrePolyRingElem{T}},::Type{U}) where {T<:RingElement,U<:RingElement}
+  promote_rule(T, U) == T ? OrePolyRingElem{T} : Union{}
+end
+
+function deepcopy_internal(a::OrePolyRingElem{T}, dict::IdDict) where T
+  C = [deepcopy_internal(c,dict) for c in coefficients(a)]
+
+  return OrePolyRingElem{T}(parent(a), C, length(C))
+end
+
+###############################################################################
+#
+#   Constructors
+#
+###############################################################################
+
+function (R::OrePolyRing{T})() where T
   return zero(R)
 end
 
-function (R::OreAlgebra{T})(c::T) where T
+function (R::OrePolyRing{T})(c::T) where T
   iszero(c) && return zero(R)
-  return OreOperator{T}(R,[c],1)
+  return OrePolyRingElem{T}(R,[c],1)
 end
 
-function (R::OreAlgebra{T})(c::Union{Integer,Rational,AbstractFloat}) where T
+function (R::OrePolyRing{T})(c::Union{Integer,Rational,AbstractFloat}) where T
   C = base_ring(R)
   return R(C(c))
 end
 
-function (R::OreAlgebra{T})(a::OreOperator{T}) where T
+function (R::OrePolyRing{T})(a::OrePolyRingElem{T}) where T
  parent(a) != R && error("Unable to coerce polynomial")
  return a
 end
 
-function (R::OreAlgebra{T})(c::Vector{T}) where T<:RingElem
-  return OreOperator{T}(R,c,length(c))
+function (R::OrePolyRing{T})(c::Vector{T}) where T<:RingElem
+  return OrePolyRingElem{T}(R,c,length(c))
 end
 
-function (R::OreAlgebra{T})(c::Vector{U}) where {T<:RingElem,U<:RingElem}
-  return OreOperator{T}(R,c,length(c))
+function (R::OrePolyRing{T})(c::Vector{U}) where {T<:RingElem,U<:RingElem}
+  return OrePolyRingElem{T}(R,c,length(c))
 end
 
-function (R::OreAlgebra{T})(c::Vector{U}) where {T<:RingElem,U<:Integer}
+function (R::OrePolyRing{T})(c::Vector{U}) where {T<:RingElem,U<:Integer}
   C = base_ring(R)
-  return OreOperator{T}(R,C.(c),length(c))
+  return OrePolyRingElem{T}(R,C.(c),length(c))
 end
 
 ###############################################################################
 #
-#   OreAlgebra
+#   Basic manipulation of elements
 #
 ###############################################################################
 
-elem_type(::Type{OreAlgebra{T}}) where T = OreOperator{T}
-base_ring_type(::Type{OreAlgebra{T}}) where T = parent_type(T)
-
-base_ring(R::OreAlgebra) = R.base_ring
-
-var(R::OreAlgebra) = R.D
-symbols(R::OreAlgebra) = [var(R)]
-
-function gen(R::OreAlgebra{T}) where T
-  C = base_ring(R)
-  return OreOperator{T}(R,[zero(C),one(C)],2)
-end
-
-ngens(R::OreAlgebra) = 1
-gens(R::OreAlgebra) = [gen(R)]
-
-function zero(R::OreAlgebra{T}) where T
-  return OreOperator{T}(R,T[],0)
-end
-
-function one(R::OreAlgebra{T}) where T
-  return OreOperator{T}(R,T[one(base_ring(R))],1)
-end
-
-derivation(R::OreAlgebra) = R.δ
-sigma_endomorphism(R::OreAlgebra) = sigma_endomorphism(derivation(R))
-
-###############################################################################
-#
-#   OreOperator
-#
-###############################################################################
-
-parent_type(::Type{OreOperator{T}}) where T = OreAlgebra{T}
-parent(a::OreOperator{T}) where T = a.parent
-
-is_domain_type(::Type{OreOperator{T}}) where T = false
-is_exact_type(::Type{OreOperator{T}}) where T = is_exact_type(T)
-
-promote_rule(::Type{OreOperator{T}},::Type{OreOperator{T}}) where T<:RingElement = OreOperator{T}
-function promote_rule(::Type{OreOperator{T}},::Type{U}) where {T<:RingElement,U<:RingElement}
-  promote_rule(T, U) == T ? OreOperator{T} : Union{}
-end
-
-function deepcopy_internal(a::OreOperator{T}, dict::IdDict) where T
-  C = [deepcopy_internal(c,dict) for c in coefficients(a)]
-
-  return OreOperator{T}(parent(a), C, length(C))
-end
-
-coefficients(a::OreOperator{T}) where T = a.coeffs[1:length(a)]
-length(a::OreOperator{T}) where T = a.length
-
-iszero(a::OreOperator{T}) where T = a.length == 0
-function isone(a::OreOperator{T}) where T
+iszero(a::OrePolyRingElem{T}) where T = a.length == 0
+function isone(a::OrePolyRingElem{T}) where T
   return length(a) == 1 && first(coefficients(a)) |> isone
 end
 
-function canonical_unit(a::OreOperator{T}) where T
+function canonical_unit(a::OrePolyRingElem{T}) where T
   return one(parent(a))
 end
 
-function coeff(a::OreOperator{T},i) where T
+function is_unit(a::OrePolyRingElem{T}) where T
+  iszero(a) && return false
+  isone(a) && return true
+  order(a) == 0 && leading_coefficient(a)|>is_unit && return true
+end
+
+order(a::OrePolyRingElem{T}) where T = iszero(a) ? -1 : length(a)-1
+length(a::OrePolyRingElem{T}) where T = a.length
+
+function set_length!(a::OrePolyRingElem{T},n::Int) where T
+  resize!(a.coeffs, n)
+  a.length = n
+
+  return a
+end
+
+coefficients(a::OrePolyRingElem{T}) where T = a.coeffs[1:length(a)]
+
+function coeff(a::OrePolyRingElem{T},i) where T
   if 0 <= i && i <= order(a)
     return a.coeffs[i+1]
   else
@@ -113,8 +156,8 @@ function coeff(a::OreOperator{T},i) where T
   end
 end
 
-setcoeff!(a::OreOperator{T}, n::Int, c::Integer) where T = setcoeff!(a,n,base_ring(a)(c))
-function setcoeff!(a::OreOperator{T}, n::Int, c::T) where T
+setcoeff!(a::OrePolyRingElem{T}, n::Int, c::Integer) where T = setcoeff!(a,n,base_ring(a)(c))
+function setcoeff!(a::OrePolyRingElem{T}, n::Int, c::T) where T
   i = n+1
   if i > length(a.coeffs)
     resize!(a.coeffs,i)
@@ -125,74 +168,122 @@ function setcoeff!(a::OreOperator{T}, n::Int, c::T) where T
   return a
 end
 
-function leading_coefficient(a::OreOperator{T}) where T
+function normalise(a::OrePolyRingElem{T}, n::Int) where T
+  n = min(n,length(a.coeffs))
+  i = findlast(!iszero, a.coeffs[1:n])
+  isnothing(i) && return 0
+  return i
+end
+
+function fit!(a::OrePolyRingElem{T}, n::Int) where T
+  if n > length(a)
+    old_n = length(a)+1
+    resize!(a.coeffs, n)
+    a.coeffs[old_n:n] .= base_ring(a)|>zero
+  end
+
+  return
+end
+
+function leading_coefficient(a::OrePolyRingElem{T}) where T
   iszero(a) && return base_ring(a)()
   return coefficients(a) |> last
 end
-function leading_term(a::OreOperator{T}) where T
+function leading_term(a::OrePolyRingElem{T}) where T
   iszero(a) && return parent(a)()
-  A = parent(a)
-  C = base_ring(a)
-  c = leading_coefficient(a)
-  k = order(a)
-
-  return A([fill(zero(C),k); c])
+  return leading_coefficient(a)*leading_monomial(a)
 end
-function leading_monomial(a::OreOperator{T}) where T
+function leading_monomial(a::OrePolyRingElem{T}) where T
   iszero(a) && return parent(a)()
   A = parent(a)
   C = base_ring(a)
   k = order(a)
 
-  return A(T[(zero(C) for _ in 1:k)..., one(C)])
+  return A([zeros(C,k); one(C)])
 end
 
-order(a::OreOperator{T}) where T = iszero(a) ? -1 : length(a)-1
+###############################################################################
+#
+#   Operations
+#
+###############################################################################
 
-function +(a::OreOperator{T},b::OreOperator{T}) where T<:RingElem
-  check_parent(a,b)
-
-  la = length(a)
-  lb = length(b)
-  l = min(la,lb)
-  L = max(la,lb)
-
-  new_c = Vector{T}(undef,L)
-
-  new_c[1:l] .= coefficients(a)[1:l] + coefficients(b)[1:l]
-  c = la > lb ? coefficients(a) : coefficients(b)
-  new_c[(l+1):L] = c[(l+1):L]
-
-  if all(iszero,new_c)
-    return zero(parent(a))
-  else
-    i = findlast(!iszero,new_c)
-    return OreOperator{T}(parent(a), new_c, i)
-  end
-end
-
-function -(a::OreOperator{T}) where T
+function -(a::OrePolyRingElem{T}) where T
   R = parent(a)
   c = -a.coeffs
 
-  return OreOperator{T}(R,c,length(c))
+  return OrePolyRingElem{T}(R,c,length(c))
 end
 
-function -(a::OreOperator{T},b::OreOperator{T}) where T
+function +(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T<:RingElem
+  check_parent(a,b)
+  
+  z = parent(a)()
+
+  L = max(length(a),length(b))
+  fit!(z,L)
+
+  if L == length(b)
+    add!(z,b,a)
+  else
+    add!(z,a,b)
+  end
+
+  n = normalise(z,L)
+
+  if iszero(n) 
+    return zero(parent(a))
+  else
+    return set_length!(z,n)
+  end
+end
+
+function add!(z::OrePolyRingElem{T},a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
+  # For this function we assume that la > lb, and that this fits into z
+  la = length(a)
+  lb = length(b)
+
+  z.coeffs[1:lb] .= coefficients(a)[1:lb] + coefficients(b)
+  z.coeffs[(lb+1):la] .= coefficients(a)[(lb+1):la]
+  z.length = la
+
+  return z
+end
+
+function +(a::OrePolyRingElem,c::Integer)
+  C = coefficients(a)
+  C[1] += c
+
+  return parent(a)(C)
+end
++(c::Integer,a::OrePolyRingElem) = a + c
+
+-(a::OrePolyRingElem,c::Integer) = a + -c
+-(c::Integer,a::OrePolyRingElem) = a -  c
+
+function -(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
   return a + -b
 end
 
-function *(a::OreOperator{T},b::T) where T<:RingElem
+function *(a::OrePolyRingElem,c::Integer)
+  C = coefficients(a)
+  return parent(a)(c*C)
+end
+*(c::Integer,a::OrePolyRingElem) = a * c
+
+# This is a non-commutative ring after all, so we do need two different `*` methods
+
+function *(a::OrePolyRingElem{T},b::T) where T<:RingElem
   return a*parent(a)(b)
 end
 
-function *(a::T,b::OreOperator{T}) where T<:RingElem
+function *(a::T,b::OrePolyRingElem{T}) where T<:RingElem
   R = parent(b)
   res = a.*coefficients(b)
-  return OreOperator{T}(R,res,length(b))
+  return OrePolyRingElem{T}(R,res,length(b))
 end
 
-function *(a::OreOperator{T},b::OreOperator{T}) where T
+function *(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
   check_parent(a,b)
   (iszero(a) || iszero(b)) && return zero(a)
 
@@ -206,7 +297,7 @@ function *(a::OreOperator{T},b::OreOperator{T}) where T
   l = length(q)
   for p in coefficients(a)
     res += p.*q
-    push!(res,zero(R|>base_ring))
+    push!(res,zero(k))
     q = [δ.(q); zero(k)] .+ [zero(k); σ.(q)]
   end
 
@@ -215,10 +306,30 @@ function *(a::OreOperator{T},b::OreOperator{T}) where T
     return zero(R)
   end
 
-  return OreOperator{T}(R,res[1:i],i)
+  return OrePolyRingElem{T}(R,res[1:i],i)
 end
 
-function ^(a::OreOperator{T},i::Int) where T
+function ==(a::OrePolyRingElem{T},b::OrePolyRingElem{T}) where T
+  fl = check_parent(a,b,false)
+  !fl && return false
+  if a.length != b.length
+    return false
+  end
+  return all(splat(==),zip(a.coeffs,b.coeffs))
+end
+
+function ==(a::OrePolyRingElem{T}, c::T) where T
+  if iszero(c)
+    return a.length == 0
+  elseif a.length == 1
+    return leading_coefficient(a) == c
+  else
+    return false
+  end
+end
+==(c::T,a::OrePolyRingElem{T}) where T = a == c
+
+function ^(a::OrePolyRingElem{T},i::Int) where T
   if i < 0
     throw(DomainError(i, "exponent must be >= 0"))
   elseif i == 0
@@ -230,8 +341,7 @@ function ^(a::OreOperator{T},i::Int) where T
   end
 end
 
-
-function divexact_right(a::OreOperator{T},b::OreOperator{T}; check=true) where T
+function divexact_right(a::OrePolyRingElem{T},b::OrePolyRingElem{T}; check=true) where T
   iszero(b) && throw(DivideError())
   q,r = rdivrem(a,b)
 
@@ -240,68 +350,23 @@ function divexact_right(a::OreOperator{T},b::OreOperator{T}; check=true) where T
   return q
 end
 
-function ==(a::OreOperator{T},b::OreOperator{T}) where T
-  fl = check_parent(a,b,false)
-  !fl && return false
-  if a.length != b.length
-    return false
-  end
-  return all(splat(==),zip(a.coeffs,b.coeffs))
-end
+###############################################################################
+#
+#   Unsafe operations
+#
+###############################################################################
 
-function ==(a::OreOperator{T}, c::T) where T
-  if iszero(c)
-    return a.length == 0
-  elseif a.length == 1
-    return leading_coefficient(a) == c
-  else
-    return false
-  end
-end
-==(c::T,a::OreOperator{T}) where T = a == c
-
-function is_unit(a::OreOperator{T}) where T
-  iszero(a) && return false
-  isone(a) && return true
-  order(a) == 0 && leading_coefficient(a)|>is_unit && return true
-end
-
-function zero!(a::OreOperator{T}) where T
+function zero!(a::OrePolyRingElem{T}) where T
   a.coeffs = elem_type(base_ring(a))[]
   a.length = 0
 
   return a
 end
 
-function one!(a::OreOperator{T}) where T
+function one!(a::OrePolyRingElem{T}) where T
   a.coeffs = [one(base_ring(a))]
   a.length = 1
 
   return a
 end
-
-function set_length!(a::OreOperator{T},n::Int) where T
-  resize!(a.coeffs, n)
-  a.length = n
-
-  return a
-end
-
-function normalise(a::OreOperator{T}, n::Int) where T
-  n = min(n,length(a.coeffs))
-  i = findlast(!iszero, a.coeffs[1:n])
-  isnothing(i) && return 0
-  return i
-end
-
-function fit!(a::OreOperator{T}, n::Int) where T
-  if n > length(a)
-    old_n = length(a)+1
-    resize!(a.coeffs, n)
-    a.coeffs[old_n:n] .= base_ring(a)|>zero
-  end
-
-  return
-end
-
 

--- a/src/generic/PolyFracFieldHom.jl
+++ b/src/generic/PolyFracFieldHom.jl
@@ -1,0 +1,58 @@
+################################################################################
+#
+#  Field access
+#
+################################################################################
+domain(f::PolyFracFieldAnyMap{D,C,V}) where {D,C,V} = f.domain
+codomain(f::PolyFracFieldAnyMap{D,C,V}) where {D,C,V} = f.morphism.codomain
+underlying_morphism(f) = f.morphism
+
+################################################################################
+#
+#  String I/O
+#
+################################################################################
+function Base.show(io::IO, f::PolyFracFieldAnyMap)
+  io = pretty(io)
+  if is_terse(io)
+    print(io, "Ring homomorphism")
+  else
+    print(io, "Hom: ")
+    print(terse(io), Lowercase(), domain(f), " -> ")
+    print(terse(io), Lowercase(), codomain(f))
+  end
+end
+
+function AbstractAlgebra.show_map_data(io::IO, f::PolyFracFieldAnyMap)
+  println(io)
+  println(io, "defined by", Indent())
+  R = domain(f)
+  g = gen(R)
+  print(io, g, " -> ", f(g))
+  print(io, Dedent())
+end
+
+################################################################################
+#
+#  Constructor
+#
+################################################################################
+function hom(R::D, S::NCRing, image) where {D<:FracField{<:PolyRingElem}}
+  r = base_ring(R)
+  return PolyFracFieldAnyMap(R,hom(r,S,image))
+end
+
+function hom(R::D, S::NCRing, image) where {D<:RationalFunctionField{<:RingElement,<:PolyRingElem}}
+  r = R() |> numerator |> parent
+  return PolyFracFieldAnyMap(R,hom(r,S,image))
+end
+
+################################################################################
+#
+#  Evaluation functions
+#
+################################################################################
+function (f::PolyFracFieldAnyMap{D,C,V})(a) where {D,C,V<:Map{<:PolyRing,C}}
+  ϕ = underlying_morphism(f)
+  return ϕ.(numerator(a))/ϕ.(denominator(a))
+end

--- a/src/generic/PolySkewDerivation.jl
+++ b/src/generic/PolySkewDerivation.jl
@@ -1,0 +1,113 @@
+
+function trivial_derivation(R::D,σ::S) where {D<:Univariateish,S}
+  return PolySkewDerivation{D,S}(R,σ,zero(R))
+end
+
+function derivation(R::D,σ::S,c::T) where {D<:Univariateish,S<:Map{D,D},T}
+  @req elem_type(R) == T "incompatible coefficient type"
+  return PolySkewDerivation{D,S}(R,σ,c)
+end
+derivation(R::D) where {D<:Univariateish} = derivation(R,identity_map(R),one(R))
+derivation(R::D,σ::S) where {D<:Univariateish,S<:Map{D,D}} = derivation(R,σ,one(R))
+
+function show(io::IO, d::PolySkewDerivation)
+  io = pretty(io)
+  if is_terse(io)
+    print(io, "Skew-derivation")
+  else
+    print(io, "σ-Der: ")
+    print(terse(io), Lowercase(), domain(d), " -> ")
+    print(terse(io), Lowercase(), codomain(d))
+  end
+end
+
+function show(io::IO, d::PolySkewDerivation{D,<:Map(IdentityMap)}) where D
+  io = pretty(io)
+  if is_terse(io)
+    print(io, "Derivation")
+  else
+    print(io, "Der: ")
+    print(terse(io), Lowercase(), domain(d), " -> ")
+    print(terse(io), Lowercase(), codomain(d))
+  end
+end
+
+function show_map_data(io::IO, d::PolySkewDerivation)
+  println(io)
+  if coefficient(d) |> iszero
+    print(io, "which is identically zero ")
+    println(io, "and with commutation rule", Indent())
+  elseif !(coefficient(d) |> isone)
+    println(io, "with coefficient ", coefficient(d))
+    println(io, "and commutation rule", Indent())
+  else
+    println(io, "with commutation rule", Indent())
+  end
+  print(io, sigma_endomorphism(d))
+  show_map_data(io,sigma_endomorphism(d))
+end
+
+function show_map_data(io::IO, d::PolySkewDerivation{D,<:Map(IdentityMap)}) where D
+  if !(coefficient(d) |> isone)
+    println(io)
+    print(io, "with coefficient ", coefficient(d))
+  end
+end
+
+domain(d::PolySkewDerivation) = d.domain
+codomain(d::PolySkewDerivation) = d.domain
+coefficient(d::PolySkewDerivation) = first(d.intermediate_cache)
+
+sigma_endomorphism(δ::PolySkewDerivation{D,S}) where {D,S} = δ.σ
+
+function (d::PolySkewDerivation{D,S})(a) where {D,S<:Map(IdentityMap)}
+  c = coefficient(d)
+  iszero(c) && return domain(d)()
+  return c*derivative(a)
+end
+
+function (d::PolySkewDerivation{D,S})(a::T) where {D,S<:Map{D,D,<:Map,<:Any},T<:PolyRingElem}
+  c = coefficient(d)
+  iszero(c) && return domain(d)()
+
+  x = parent(a) |> gen
+  σ = sigma_endomorphism(d)
+  for i in (length(d.intermediate_cache)+1):degree(a)
+    res = last(d.intermediate_cache)*x + σ(x^(i-1))*c
+    push!(d.intermediate_cache, res)
+  end
+
+  return sum(σ.(Iterators.drop(coefficients(a),1)) .* d.intermediate_cache; init=parent(a)())
+end
+
+#import AbstractAlgebra: Generic.RationalFunctionFieldElem
+
+function (d::PolySkewDerivation{D,S})(a::T) where {
+  D<:FracField{<:PolyRingElem},
+  S<:Map{D,D,<:Map,<:Any},
+  T<:FracElem{<:PolyRingElem}}
+  
+  c = coefficient(d)
+  iszero(c) && return domain(d)()
+
+  R = codomain(d)
+  σ = sigma_endomorphism(d)
+  p = numerator(a)
+  q = denominator(a)
+  return R((d(p) - σ(q)*d(p))//(σ(q)*q))::elem_type(R)
+end
+
+function (d::PolySkewDerivation{D,S})(a::T) where {
+  D<:RationalFunctionField{<:RingElement,<:PolyRingElem},
+  S<:Map{D,D,<:Map,<:Any},
+  T<:RationalFunctionFieldElem{<:RingElement,<:PolyRingElem}}
+
+  c = coefficient(d)
+  iszero(c) && return domain(d)()
+
+  R = codomain(d)
+  σ = sigma_endomorphism(d)
+  p = numerator(a)
+  q = denominator(a)
+  return R((d(p) - σ(q)*d(p))//(σ(q)*q))::elem_type(codomain(d))
+end

--- a/src/generic/PolySkewDerivation.jl
+++ b/src/generic/PolySkewDerivation.jl
@@ -1,6 +1,25 @@
 
 function trivial_derivation(R::D,σ::S) where {D<:Univariateish,S}
-  return PolySkewDerivation{D,S}(R,σ,zero(R))
+  return TrivialSkewDerivation{D,S}(R,σ)
+end
+
+function show(io::IO, d::TrivialSkewDerivation)
+  io = pretty(io)
+  if is_terse(io)
+    print(io, "Trivial skew-derivation")
+  else
+    print(io, "Trivial σ-Der: ")
+    print(terse(io), Lowercase(), domain(d), " -> ")
+    print(terse(io), Lowercase(), codomain(d))
+  end
+end
+
+function show_map_data(io::IO, d::TrivialSkewDerivation)
+  println(io)
+  print(io, "which is identically zero ")
+  println(io, "and with commutation rule", Indent())
+  print(io, sigma_endomorphism(d))
+  show_map_data(io,sigma_endomorphism(d))
 end
 
 function derivation(R::D,σ::S,c::T) where {D<:Univariateish,S<:Map{D,D},T}
@@ -9,6 +28,10 @@ function derivation(R::D,σ::S,c::T) where {D<:Univariateish,S<:Map{D,D},T}
 end
 derivation(R::D) where {D<:Univariateish} = derivation(R,identity_map(R),one(R))
 derivation(R::D,σ::S) where {D<:Univariateish,S<:Map{D,D}} = derivation(R,σ,one(R))
+
+function derivation(R::D,s::S,x::MPolyRingElem{C},c::MPolyRingElem) where {C,D<:MPolyRing{C},S<:Map{D,D}}
+  return MPolySkewDerivation{D,S}(R,s,x,c)
+end
 
 function show(io::IO, d::PolySkewDerivation)
   io = pretty(io)
@@ -53,12 +76,16 @@ function show_map_data(io::IO, d::PolySkewDerivation{D,<:Map(IdentityMap)}) wher
     print(io, "with coefficient ", coefficient(d))
   end
 end
-
 domain(d::PolySkewDerivation) = d.domain
 codomain(d::PolySkewDerivation) = d.domain
 coefficient(d::PolySkewDerivation) = first(d.intermediate_cache)
 
-sigma_endomorphism(δ::PolySkewDerivation{D,S}) where {D,S} = δ.σ
+sigma_endomorphism(d::PolySkewDerivation{D,S}) where {D,S} = d.s
+
+domain(d::TrivialSkewDerivation) = d.domain
+codomain(d::TrivialSkewDerivation) = d.domain
+
+sigma_endomorphism(d::TrivialSkewDerivation) = d.s
 
 function (d::PolySkewDerivation{D,S})(a) where {D,S<:Map(IdentityMap)}
   c = coefficient(d)

--- a/src/generic/PolySkewDerivation.jl
+++ b/src/generic/PolySkewDerivation.jl
@@ -72,15 +72,14 @@ function (d::PolySkewDerivation{D,S})(a::T) where {D,S<:Map{D,D,<:Map,<:Any},T<:
 
   x = parent(a) |> gen
   σ = sigma_endomorphism(d)
-  for i in (length(d.intermediate_cache)+1):degree(a)
+  cached_degree = length(d.intermediate_cache+1)
+  for i in cached_degree:degree(a)
     res = last(d.intermediate_cache)*x + σ(x^(i-1))*c
     push!(d.intermediate_cache, res)
   end
 
   return sum(σ.(Iterators.drop(coefficients(a),1)) .* d.intermediate_cache; init=parent(a)())
 end
-
-#import AbstractAlgebra: Generic.RationalFunctionFieldElem
 
 function (d::PolySkewDerivation{D,S})(a::T) where {
   D<:FracField{<:PolyRingElem},

--- a/src/generic/PolySkewDerivation.jl
+++ b/src/generic/PolySkewDerivation.jl
@@ -72,7 +72,7 @@ function (d::PolySkewDerivation{D,S})(a::T) where {D,S<:Map{D,D,<:Map,<:Any},T<:
 
   x = parent(a) |> gen
   σ = sigma_endomorphism(d)
-  cached_degree = length(d.intermediate_cache+1)
+  cached_degree = length(d.intermediate_cache)+1
   for i in cached_degree:degree(a)
     res = last(d.intermediate_cache)*x + σ(x^(i-1))*c
     push!(d.intermediate_cache, res)

--- a/src/generic/exports.jl
+++ b/src/generic/exports.jl
@@ -133,3 +133,8 @@ export unit
 export upscale
 export weights
 export zero
+
+export ore_extension
+export trivial_derivation
+export derivation
+export sigma_endomorphism

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -3,7 +3,7 @@ include("generic/NCPoly-test.jl")
 include("generic/FreeAssociativeAlgebra-test.jl")
 include("generic/FreeAssociativeAlgebraGroebner-test.jl")
 
-#include("generic/OreOperator-test.jl")
+include("generic/OrePolyRing-test.jl")
 
 @testset "NCRings.oftype" begin
    F = GF(3)

--- a/test/NCRings-test.jl
+++ b/test/NCRings-test.jl
@@ -3,6 +3,8 @@ include("generic/NCPoly-test.jl")
 include("generic/FreeAssociativeAlgebra-test.jl")
 include("generic/FreeAssociativeAlgebraGroebner-test.jl")
 
+#include("generic/OreOperator-test.jl")
+
 @testset "NCRings.oftype" begin
    F = GF(3)
    Fx, x = polynomial_ring(F, "x")

--- a/test/generic/OreOperator-test.jl
+++ b/test/generic/OreOperator-test.jl
@@ -1,0 +1,187 @@
+@testset "Generic.OreOperator" begin
+  R,x = polynomial_ring(QQ,:x)
+  @testset "Differential operators" verbose=true begin
+    δ = derivation(R)
+    AD,D = ore_extension(R,:D,δ)
+
+    @test order(D) == 1
+    @test length(D) == 2
+
+    a0 = zero(AD)
+    @test order(a0) == -1
+    @test length(a0) == 0
+    @test a0.coeffs == elem_type(R)[]
+    @test iszero(a0)
+    @test !is_unit(a0)
+
+    @test leading_coefficient(a0) |> iszero
+    @test leading_term(a0)  |> iszero
+    @test leading_monomial(a0) |> iszero
+
+    a1 = one(AD)
+    @test order(a1) == 0
+    @test length(a1) == 1
+    @test is_unit(a1)
+
+    @test leading_coefficient(a1) |> isone
+    @test leading_term(a1) |> isone
+    @test leading_monomial(a1) |> isone
+
+    @test a0 * a1 == a0
+    @test a1 * a1 == a1
+
+    a2 = D^2
+    @test order(a2) == 2
+    @test coefficients(a2) == R.([0,0,1])
+
+    a3 = 3*a2 + D
+    @test leading_coefficient(a3) == R(3)
+    @test leading_monomial(a3) == D^2
+    @test leading_term(a3) == leading_coefficient(a3)*leading_monomial(a3)
+
+#    @testset "Division with remainder" verbose=true begin
+#      @test rdivrem(D,D) == (one(AD),zero(AD))
+#      @test rdivrem(D^2+D,D) == (D+1,zero(AD))
+#    end
+
+    @testset "Arithmetic" verbose=true begin
+      c4 = [x, x^3, x^2, x^5]
+      a4 = (c4[1]*D + c4[2])*(c4[3]*D + c4[4])
+      @test coefficients(a4) == [c4[1]*δ(c4[4]) + c4[2]*c4[4], c4[1]*δ(c4[3]) + c4[2]*c4[3] + c4[1]*c4[4], c4[1]*c4[3]]
+      @test length(a4) == 3
+      @test order(a4) == 2
+    end
+  end
+
+  @testset "Euler operators" verbose=true begin
+    σ = identity_map(R)
+    δ = derivation(R,σ,x)
+    AE,θ = ore_extension(R,:θ,δ)
+
+    a1 = θ*x
+    @test order(a1) == 1
+    @test coefficients(a1) == [x,x]
+
+    a2 = θ*x^2
+    @test order(a2) == 1
+    @test coefficients(a2) == [2*x^2, x^2]
+  end
+
+  @testset "Forward differences" verbose=true begin
+    σ = hom(R,R,x+1)
+    δ = derivation(R,σ)
+    AF,F = ore_extension(R,:F,δ)
+
+    a1 = F*x
+    @test order(a1) == 1
+    @test coefficients(a1) == [one(R),x+1]
+
+    a2 = F*x^2
+    @test order(a2) == 1
+    @test coefficients(a2) == [2*x + 1, x^2 + 2*x + 1]
+  end
+
+  @testset "Recurrence operators" verbose=true begin
+    σ = hom(R,R,x+1)
+    δ = trivial_derivation(R,σ)
+    AS,S = ore_extension(R,:S,δ)
+
+#    @testset "Division with remainder" verbose=true begin
+#      @test rdivrem(S,S) == (one(AS),zero(AS))
+#      @test rdivrem(S^2+S,S) == (S+1,zero(AS))
+#    end
+
+    @testset "Arithmetic" verbose=true begin
+      c1 = [x, x^3, x^2, x^5]
+      a1 = (c1[1]*S + c1[2])*(c1[3]*S + c1[4])
+      @test coefficients(a1) == [c1[2]*c1[4],c1[1]*σ(c1[4]) + c1[2]*c1[3],c1[1]*σ(c1[3])]
+      @test length(a1) == 3
+      @test order(a1) == 2
+    end
+  end
+end
+
+#@testset "Univariate Ore algebra over $name" verbose=true for (name,(R,x)) in [
+#    ("univariate polynomial fraction field", begin
+#      R,x = polynomial_ring(QQ,:x)
+#      K = fraction_field(R)
+#      K,K(x)
+#     end),
+#    ("univariate polynomial function field", rational_function_field(QQ)),
+#  ]
+#
+#  @testset "Differential operators" verbose=true begin
+#    δ = derivation(R)
+#    σ = sigma_endomorphism(δ)
+#    AD,D = ore_extension(R,:D,δ)
+#
+#    U = AD([3x+1,2x-3,-(2x+1),3x+5])
+#    V = AD([-(3x+5),x+2])
+#    q,r = rdivrem(U,V)
+#    @test q*V + r == U
+#
+#    U = (x-1)*D^5 + 5*D^4
+#    V = (x-1)*D^3 + (6 - 3x)*D^2 + (27x^2 + 9x -42)*D + 117 - 54x
+#    g = grcd(U,V)
+#    @test g == D - (2x^2-x-7)//((x+2)*(x+1)*(x-1))
+#
+#    U = (2x+3)*x*D^2 + 2*(4x^2 + 3x - 3)*D + 2*(4x^2 - 3)
+#    V = (x+1)*(x-1)*D^2 + 2*(2x^2 - x - 2)*D + 2*(2x^2 - 2x - 1)
+#    f = lclm(U,V)
+#    @test iszero(rrem(f,U))
+#    @test iszero(rrem(f,V))
+#
+#    @testset "Hermite normal form" verbose=true begin
+#      H1 = AD[D-1 D; 0 D^2]
+#      @test hnf(H1) == H1
+#
+#      H2 = AD[D-(3x^2+4)//(x*(3x+2)) 6*(x-2)//(x*(3x+2)); -(3-x)//(3x+2) D-11//(3x+2)]
+#      @test hnf(H2) == AD[1 (3x+2)//(x-3)*D-11/(x-3); 0 D^2+(6-x^2)//(x*(x-3))*D+3*(x-2)//(x*(x-3))]
+#    end
+#
+#    @testset "Uncoupling" verbose=true begin
+#      H3 = R[(3x^2+4)//(x*(3x+2)) -6*(x-2)//(x*(3x+2)); (3-x)//(3x+2) 11//(3x+2)]
+#      P3 = R[1 0; (3x^2+4)//(x*(3x+2)) -6*(x-2)//(x*(3x+2))]
+#      @test uncouple(H3,δ) == P3
+#      @test gauge_transform(H3,δ) == (σ.(P3)*H3 + δ.(P3))*inv(P3)
+#    end
+#  end
+#  @testset "Recurrence operators" verbose=true begin
+#    σ = hom(R,R,x+1)
+#    δ = trivial_derivation(R,σ)
+#    AS,S = ore_extension(R,:S,δ)
+#
+#    U = AS([3x+1,2x-3,-(2x+1),3x+5])
+#    V = AS([-(3x+5),x+2])
+#    q,r = rdivrem(U,V)
+#    @test q*V + r == U
+#
+#    a1 = (x*S + x) * (2*x*S + x)
+#    @test a1 == x*2*(x+1)*S^2 + (x*(x+1) + x*2*x)*S + x*x
+#
+#    U = S^7 + 5S^6 + 9S^5 +5S^4 - 5S^3 - 9S^2 - 5S - 1
+#    V = (x+5)*S^5 + 6S^4 - 6S^3 - 2*(x-1)*S^2 - (x+19)*S + 2*(x+6)
+#    g = grcd(U,V)
+#    @test g == S^2 + 10*(x+4)//((x+2)*(2x+7))*S - (2x+9)*(x+6)//((2x+7)*(x+2))
+#
+#    U = (x+2)*(2x-1)*S^2 - 8*(x^2+3x-1)*S + 4*(x+4)*(2x+1)
+#    V = (x+4)*(x+3)*S^2 - 2*(x+5)*(2x+5)*S + 4*(x+4)*(x+5)
+#    f = lclm(U,V)
+#    @test iszero(rrem(f,U))
+#    @test iszero(rrem(f,V))
+#
+#    @testset "Division with remainder" verbose=true begin
+#      @test rdivrem(S,S) == (one(AS),zero(AS))
+#      @test rdivrem(S^2+S,S) == (S+1,zero(AS))
+#    end
+#
+#    @testset "Arithmetic" verbose=true begin
+#      c1 = [x, x^3, x^2, x^5]
+#      a1 = (c1[1]*S + c1[2])*(c1[3]*S + c1[4])
+#      @test coefficients(a1) == [c1[2]*c1[4],c1[1]*σ(c1[4]) + c1[2]*c1[3],c1[1]*σ(c1[3])]
+#      @test length(a1) == 3
+#      @test order(a1) == 2
+#    end
+#  end
+#end
+#

--- a/test/generic/OrePolyRing-test.jl
+++ b/test/generic/OrePolyRing-test.jl
@@ -99,24 +99,23 @@
       @test order(a1) == 2
     end
   end
-end
 
-#@testset "Univariate Ore algebra over $name" verbose=true for (name,(R,x)) in [
-#    ("univariate polynomial fraction field", begin
-#      R,x = polynomial_ring(QQ,:x)
-#      K = fraction_field(R)
-#      K,K(x)
-#     end),
-#    ("univariate polynomial function field", rational_function_field(QQ)),
-#  ]
-#
-#  @testset "Differential operators" verbose=true begin
-#    δ = derivation(R)
-#    σ = sigma_endomorphism(δ)
-#    AD,D = ore_extension(R,:D,δ)
-#
-#    U = AD([3x+1,2x-3,-(2x+1),3x+5])
-#    V = AD([-(3x+5),x+2])
+@testset "Univariate Ore algebra over $name" verbose=true for (name,(R,x)) in [
+    ("univariate polynomial fraction field", begin
+      R,x = polynomial_ring(QQ,:x)
+      K = fraction_field(R)
+      K,K(x)
+     end),
+    ("univariate polynomial function field", rational_function_field(QQ)),
+  ]
+
+  @testset "Differential operators" verbose=true begin
+    δ = derivation(R)
+    σ = sigma_endomorphism(δ)
+    AD,D = ore_extension(R,:D,δ)
+
+    U = AD([3x+1,2x-3,-(2x+1),3x+5])
+    V = AD([-(3x+5),x+2])
 #    q,r = rdivrem(U,V)
 #    @test q*V + r == U
 #
@@ -145,11 +144,11 @@ end
 #      @test uncouple(H3,δ) == P3
 #      @test gauge_transform(H3,δ) == (σ.(P3)*H3 + δ.(P3))*inv(P3)
 #    end
-#  end
-#  @testset "Recurrence operators" verbose=true begin
-#    σ = hom(R,R,x+1)
-#    δ = trivial_derivation(R,σ)
-#    AS,S = ore_extension(R,:S,δ)
+  end
+  @testset "Recurrence operators" verbose=true begin
+    σ = hom(R,R,x+1)
+    δ = trivial_derivation(R,σ)
+    AS,S = ore_extension(R,:S,δ)
 #
 #    U = AS([3x+1,2x-3,-(2x+1),3x+5])
 #    V = AS([-(3x+5),x+2])
@@ -175,13 +174,14 @@ end
 #      @test rdivrem(S^2+S,S) == (S+1,zero(AS))
 #    end
 #
-#    @testset "Arithmetic" verbose=true begin
-#      c1 = [x, x^3, x^2, x^5]
-#      a1 = (c1[1]*S + c1[2])*(c1[3]*S + c1[4])
-#      @test coefficients(a1) == [c1[2]*c1[4],c1[1]*σ(c1[4]) + c1[2]*c1[3],c1[1]*σ(c1[3])]
-#      @test length(a1) == 3
-#      @test order(a1) == 2
-#    end
-#  end
-#end
-#
+    @testset "Arithmetic" verbose=true begin
+      c1 = [x, x^3, x^2, x^5]
+      a1 = (c1[1]*S + c1[2])*(c1[3]*S + c1[4])
+      @test coefficients(a1) == [c1[2]*c1[4],c1[1]*σ(c1[4]) + c1[2]*c1[3],c1[1]*σ(c1[3])]
+      @test length(a1) == 3
+      @test order(a1) == 2
+    end
+  end
+end
+end
+


### PR DESCRIPTION
This pull request adds basic functionality for univariate Ore polynomials. This is implemented in pure Julia.
For now, this contains arithmetic capabilities and implements an interface similar or equal to `NCPolyRing` and such.

There are some minor additions that are technically required that would come with this PR.
Currently, there is no way to define a ring homomorphism of fraction fields (or function fields for that instance).
They are a rather common choice for coefficient fields of Ore algebras, that's why they are of interest.
Since for fraction fields of polynomial rings, the notion would naturally extend, I also introduce a type `PolyFracFieldAnyMap` that mimics `PolyRingAnyMap`.

I would keep this PR at this scope since this is also the point where we fix the interface for Ore algebras
which will be relevant as soon we make use of the implementation in FLINT for some specialised cases.