### PR TITLE
Disallow nondistinct variable names for universal rings

### DIFF
--- a/src/ConcreteTypes.jl
+++ b/src/ConcreteTypes.jl
@@ -27,6 +27,7 @@ end
   base_ring::Ring
 
   function UniversalRing(R::Ring)
+    @req allunique(symbols(R)) "Variable names must be unique"
     return new{elem_type(R), elem_type(coefficient_ring(R))}(R)
   end
 end


### PR DESCRIPTION
This is the first step in the direction of #2408.