### PR TITLE
Parametrize `FunctionField` as `FunctionField{T, U}`

### DIFF
--- a/docs/src/function_field.md
+++ b/docs/src/function_field.md
@@ -191,10 +191,11 @@ These are implemented in a module implemented in
 ## Generic function field types
 
 Function field objects $K/k(x)$ in AbstractAlgebra have type
-`Generic.FunctionField{T}` where `T` is the type of elements of the field `k`.
+`Generic.FunctionField{T, U}` where `T` is the type of elements of the field `k`
+and `U` is the type of the univariate polynomials over that field.
 
 Corresponding function field elements have type
-`Generic.FunctionFieldElement{T}`. See the file `src/generic/GenericTypes.jl`
+`Generic.FunctionFieldElem{T, U}`. See the file `src/generic/GenericTypes.jl`
 for details.
 
 ## Abstract types
@@ -319,11 +320,11 @@ defining_polynomial(R::Generic.FunctionField)
 ```
 
 ```@docs
-Base.numerator(::Generic.FunctionField{T}, ::Bool=true) where T <: FieldElement
+Base.numerator(::Generic.FunctionField{T, U}, ::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
 ```
 
 ```@docs
-Base.numerator(::Generic.FunctionFieldElem{T}, ::Bool=true) where T <: FieldElement
+Base.numerator(::Generic.FunctionFieldElem{T, U}, ::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
 ```
 
 ```@docs
@@ -331,7 +332,7 @@ degree(::Generic.FunctionField)
 ```
 
 ```@docs
-gen(::Generic.FunctionField{T}) where T <: FieldElement
+gen(::Generic.FunctionField{T, U}) where {T <: FieldElement, U <: PolyRingElem{T}}
 ```
 
 ```@docs

--- a/src/generic/FunctionField.jl
+++ b/src/generic/FunctionField.jl
@@ -521,16 +521,13 @@ end
 #
 ###############################################################################
 
-parent_type(::Type{FunctionFieldElem{T}}) where T <: FieldElement = FunctionField{T}
+parent_type(::Type{FunctionFieldElem{T, U}}) where {T, U} = FunctionField{T, U}
 
-elem_type(::Type{FunctionField{T}}) where T <: FieldElement = FunctionFieldElem{T}
+elem_type(::Type{FunctionField{T, U}}) where {T, U} = FunctionFieldElem{T, U}
 
-function base_ring_type(::Type{FunctionField{T}}) where T <: FieldElement
-   U = poly_type(T)
-   return RationalFunctionField{T, U}
-end
+base_ring_type(::Type{FunctionField{T, U}}) where {T, U} = RationalFunctionField{T, U}
 
-base_ring(R::FunctionField{T}) where T <: FieldElement = R.base_ring::base_ring_type(R)
+base_ring(R::FunctionField{T, U}) where {T, U} = R.base_ring::RationalFunctionField{T, U}
 
 # For consistency with number fields in Hecke.jl
 @doc raw"""
@@ -576,25 +573,25 @@ defining_polynomial(R::FunctionField) = R.pol
 
 modulus(R::FunctionField) = defining_polynomial(R)
 
-function power_precomp(R::FunctionField{T}, n::Int) where T <: FieldElement
-   return R.powers[n + 1]::Poly{poly_type(T)}
+function power_precomp(R::FunctionField{T, U}, n::Int) where {T, U}
+   return R.powers[n + 1]
 end
 
-function power_precomp_den(R::FunctionField{T}, n::Int) where T <: FieldElement
-   return R.powers_den[n + 1]::poly_type(T)
+function power_precomp_den(R::FunctionField{T, U}, n::Int) where {T, U}
+   return R.powers_den[n + 1]
 end
 
-function trace_precomp(R::FunctionField{T}, n::Int) where T <: FieldElement
-   return R.traces[n + 1]::poly_type(T)
+function trace_precomp(R::FunctionField{T, U}, n::Int) where {T, U}
+   return R.traces[n + 1]
 end
 
-function trace_precomp_den(R::FunctionField{T}) where T <: FieldElement
-   return R.traces_den::poly_type(T)
+function trace_precomp_den(R::FunctionField{T, U}) where {T, U}
+   return R.traces_den
 end
 
 @doc raw"""
-    Base.numerator(R::FunctionField{T}, canonicalise::Bool=true) where T <: FieldElement
-    Base.denominator(R::FunctionField{T}, canonicalise::Bool=true) where T <: FieldElement
+    Base.numerator(R::FunctionField{T, U}, canonicalise::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
+    Base.denominator(R::FunctionField{T, U}, canonicalise::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
 
 Thinking of elements of the rational function field as fractions, put the
 defining polynomial of the function field over a common denominator
@@ -603,31 +600,26 @@ polynomials belong to a different ring than the original defining polynomial.
 The `canonicalise` is ignored, but exists for compatibility with the Generic
 interface.
 """
-function Base.numerator(R::FunctionField{T},
-                               canonicalise::Bool=true) where T <: FieldElement
-   # only used for type assert, so no need to canonicalise
-   return R.num::Poly{poly_type(T)}
+function Base.numerator(R::FunctionField{T, U}, canonicalise::Bool=true) where {T, U}
+   return R.num
 end
 
-function Base.denominator(R::FunctionField{T},
-                               canonicalise::Bool=true) where T <: FieldElement
-   # only used for type assert, so no need to canonicalise
-   return R.den::poly_type(T)
+function Base.denominator(R::FunctionField{T, U}, canonicalise::Bool=true) where {T, U}
+   return R.den
 end
 
 @doc raw"""
-    Base.numerator(a::FunctionFieldElem{T}, canonicalise::Bool=true) where T <: FieldElement
-    Base.denominator(a::FunctionFieldElem{T}, canonicalise::Bool=true) where T <: FieldElement
+    Base.numerator(a::FunctionFieldElem{T, U}, canonicalise::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
+    Base.denominator(a::FunctionFieldElem{T, U}, canonicalise::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
 
 Return the numerator and denominator of the function field element `a`.
 Note that elements are stored in fraction free form so that the denominator
 is a common denominator for the coefficients of the element `a`.
 If `canonicalise` is set to `true` the fraction is first canonicalised.
 """
-function Base.numerator(a::FunctionFieldElem{T},
-                               canonicalise::Bool=true) where T <: FieldElement
-   anum = a.num::Poly{poly_type(T)}
-   aden = a.den::poly_type(T)
+function Base.numerator(a::FunctionFieldElem{T, U}, canonicalise::Bool=true) where {T, U}
+   anum = a.num
+   aden = a.den
    if canonicalise
       u = canonical_unit(aden)
       return divexact(anum, u)
@@ -636,9 +628,8 @@ function Base.numerator(a::FunctionFieldElem{T},
    end
 end
 
-function Base.denominator(a::FunctionFieldElem{T},
-                               canonicalise::Bool=true) where T <: FieldElement
-   aden = a.den::poly_type(T)
+function Base.denominator(a::FunctionFieldElem{T, U}, canonicalise::Bool=true) where {T, U}
+   aden = a.den
    if canonicalise
       u = canonical_unit(aden)
       return divexact(aden, u)
@@ -661,17 +652,17 @@ zero(S::FunctionField) = S()
 one(S::FunctionField) = S(1)
 
 @doc raw"""
-    gen(S::FunctionField{T}) where T <: FieldElement
+    gen(S::FunctionField{T, U}) where {T <: FieldElement, U <: PolyRingElem{T}}
 
 Return the generator of the function field returned by the function field
 constructor.
 """
-function gen(S::FunctionField{T}) where T <: FieldElement
+function gen(S::FunctionField{T, U}) where {T, U}
    if degree(S) == 1
       return S(-coeff(modulus(S), 0)//coeff(modulus(S), 1))
    else
-      return FunctionFieldElem{T}(S, deepcopy(power_precomp(S, 1)),
-                                     deepcopy(power_precomp_den(S, 1)))
+      return FunctionFieldElem{T, U}(S, deepcopy(power_precomp(S, 1)),
+                                        deepcopy(power_precomp_den(S, 1)))
    end
 end
 
@@ -783,7 +774,7 @@ end
 #
 ###############################################################################
 
-function +(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function +(a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    check_parent(a, b)
    R = parent(a)
    n1, d1 = _rat_poly(a)
@@ -791,7 +782,7 @@ function +(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldEle
    return R(_rat_poly_add(n1, d1, n2, d2)...)
 end
 
-function -(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function -(a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    check_parent(a, b)
    R = parent(a)
    n1, d1 = _rat_poly(a)
@@ -799,7 +790,7 @@ function -(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldEle
    return R(_rat_poly_sub(n1, d1, n2, d2)...)
 end
 
-function *(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function *(a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    check_parent(a, b)
    R = parent(a)
    n1, d1 = _rat_poly(a)
@@ -822,15 +813,15 @@ end
 
 *(a::Union{Integer, Rational}, b::FunctionFieldElem) = b*a
 
-function *(a::FunctionFieldElem{T}, b::T) where T <: FieldElem
+function *(a::FunctionFieldElem{T, U}, b::T) where {T <: FieldElem, U}
    R = parent(a)
    num = numerator(a, false)*b
    return R(_rat_poly_canonicalise(num, denominator(a, false))...)
 end
 
-*(a::T, b::FunctionFieldElem{T}) where T <: FieldElem = b*a
+*(a::T, b::FunctionFieldElem{T, U}) where {T <: FieldElem, U} = b*a
 
-function *(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function *(a::FunctionFieldElem{T, U}, b::RationalFunctionFieldElem{T, U}) where {T, U}
    parent(b) != base_ring(a) && error("Could not coerce element")
    R = parent(a)
    num = numerator(a, false)*numerator(b, false)
@@ -838,25 +829,25 @@ function *(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {T
    return R(_rat_poly_canonicalise(num, den)...)
 end
 
-*(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T}) where {T <: FieldElement, U <: PolyRingElem} = b*a
+*(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U} = b*a
 
-function +(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function +(a::FunctionFieldElem{T, U}, b::RationalFunctionFieldElem{T, U}) where {T, U}
    parent(b) != base_ring(a) && error("Unable to coerce element")
    return a + parent(a)(b)
 end
 
-+(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T}) where {T <: FieldElement, U <: PolyRingElem} = b + a
++(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U} = b + a
 
 +(a::FunctionFieldElem, b::Union{Integer, Rational}) = a + base_ring(a)(b)
 
 +(a::Union{Integer, Rational}, b::FunctionFieldElem) = b + a
 
-function -(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function -(a::FunctionFieldElem{T, U}, b::RationalFunctionFieldElem{T, U}) where {T, U}
    parent(b) != base_ring(a) && error("Unable to coerce element")
    return a - parent(a)(b)
 end
 
-function -(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T}) where {T <: FieldElement, U <: PolyRingElem}
+function -(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    parent(a) != base_ring(b) && error("Unable to coerce element")
    return parent(b)(a) - b
 end
@@ -871,7 +862,7 @@ end
 #
 ###############################################################################
 
-function ^(a::FunctionFieldElem{T}, b::Int) where T <: FieldElement
+function ^(a::FunctionFieldElem{T, U}, b::Int) where {T, U}
    b < 0 && error("Not implemented")
    R = parent(a)
    if is_gen(a) && b < 2*length(numerator(R)) - 3 # special case powers of generator
@@ -909,7 +900,7 @@ end
 #
 ###############################################################################
 
-function ==(a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function ==(a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    check_parent(a, b)
    aden = denominator(a, true)
    bden = denominator(b, true)
@@ -927,7 +918,7 @@ end
 #
 ###############################################################################
 
-function ==(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function ==(a::FunctionFieldElem{T, U}, b::RationalFunctionFieldElem{T, U}) where {T, U}
    parent(b) != base_ring(a) && error("Unable to coerce element")
    if iszero(a) && iszero(b)
       return true
@@ -937,7 +928,7 @@ function ==(a::FunctionFieldElem{T}, b::RationalFunctionFieldElem{T, U}) where {
    return a == parent(a)(b)
 end
 
-==(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T}) where {T <: FieldElement, U <: PolyRingElem} = b == a
+==(a::RationalFunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U} = b == a
 
 ==(a::FunctionFieldElem, b::Union{Integer, Rational}) = a == base_ring(a)(b)
 
@@ -965,8 +956,9 @@ end
 #
 ###############################################################################
 
-function divexact(a::FunctionFieldElem{T},
-            b::FunctionFieldElem{T}; check::Bool=true) where T <: FieldElement
+function divexact(a::FunctionFieldElem{T, U},
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T <: FieldElement, U <: PolyRingElem{T}}
    return a*inv(b)
 end
 
@@ -977,7 +969,7 @@ end
 ###############################################################################
 
 function divexact(a::FunctionFieldElem,
-                                b::Union{Rational, Integer}; check::Bool=true)
+                  b::Union{Rational, Integer}; check::Bool=true)
    S = parent(a)
    anum = numerator(a, false)
    aden = denominator(a, false)
@@ -986,8 +978,8 @@ function divexact(a::FunctionFieldElem,
    return S(rnum, rden*aden)
 end
 
-function divexact(a::FunctionFieldElem{T},
-                                  b::T; check::Bool=true) where T <: FieldElem
+function divexact(a::FunctionFieldElem{T, U},
+                  b::T; check::Bool=true) where {T <: FieldElem, U <: PolyRingElem{T}}
    S = parent(a)
    anum = numerator(a, false)
    aden = denominator(a, false)
@@ -996,8 +988,8 @@ function divexact(a::FunctionFieldElem{T},
    return S(rnum, rden*aden)
 end
 
-function divexact(a::FunctionFieldElem{T},
-                          b::RationalFunctionFieldElem{T, U}; check::Bool=true) where {T <: FieldElement, U <: PolyRingElem}
+function divexact(a::FunctionFieldElem{T, U},
+                  b::RationalFunctionFieldElem{T, U}; check::Bool=true) where {T <: FieldElement, U <: PolyRingElem{T}}
    S = parent(a)
    base_ring(a) != parent(b) && error("Incompatible fields")
    bnum = numerator(b, false)
@@ -1012,27 +1004,32 @@ function divexact(a::FunctionFieldElem, b::RingElem; check::Bool=true)
 end
 
 function divexact(a::Union{Rational, Integer},
-            b::FunctionFieldElem{T}; check::Bool=true) where T <: FieldElement
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T, U}
    return a*inv(b)
 end
 
 function divexact(a::T,
-            b::FunctionFieldElem{T}; check::Bool=true) where T <: Integer
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T <: Integer, U}
    return a*inv(b)
 end
 
 function divexact(a::T,
-            b::FunctionFieldElem{T}; check::Bool=true) where T <: Rational
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T <: Rational, U}
    return a*inv(b)
 end
 
 function divexact(a::T,
-            b::FunctionFieldElem{T}; check::Bool=true) where T <: FieldElem
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T <: FieldElem, U}
    return a*inv(b)
 end
 
 function divexact(a::RationalFunctionFieldElem{T, U},
-   b::FunctionFieldElem{T}; check::Bool=true) where {T <: FieldElement, U <: PolyRingElem}
+                  b::FunctionFieldElem{T, U}; check::Bool=true
+                 ) where {T, U}
    return a*inv(b)
 end
 
@@ -1112,7 +1109,7 @@ function zero!(a::FunctionFieldElem)
    return a
 end
 
-function setcoeff!(a::FunctionFieldElem{T}, n::Int, c::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function setcoeff!(a::FunctionFieldElem{T, U}, n::Int, c::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem{T}}
    base_ring(a) != parent(c) && error("Unable to coerce element")
    n < 0 || n > degree(parent(a)) && error("Degree not in range")
    cnum = numerator(c.d, false)
@@ -1134,7 +1131,7 @@ function setcoeff!(a::FunctionFieldElem{T}, n::Int, c::RationalFunctionFieldElem
    return a
 end
 
-function setcoeff!(a::FunctionFieldElem{T}, n::Int, c::PolyRingElem{T}) where T <: FieldElement
+function setcoeff!(a::FunctionFieldElem{T, U}, n::Int, c::U) where {T <: FieldElement, U <: PolyRingElem{T}}
    parent(c) != parent(denominator(a, false)) && error("Unable to coerce element")
    n < 0 || n > degree(parent(a)) && error("Degree not in range")
    aden = denominator(a, false)
@@ -1150,7 +1147,7 @@ function setcoeff!(a::FunctionFieldElem, n::Int, c::RingElement)
    return setcoeff!(a, n, base_ring(a)(c))
 end
 
-function reduce!(a::FunctionFieldElem{T}) where T <: FieldElement
+function reduce!(a::FunctionFieldElem{T, U}) where {T, U}
    R = parent(a)
    len = length(numerator(R))
    num = numerator(a, false)
@@ -1168,24 +1165,23 @@ function reduce!(a::FunctionFieldElem{T}) where T <: FieldElement
    return a
 end
 
-function add!(c::FunctionFieldElem{T},
-      a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function add!(c::FunctionFieldElem{T, U},
+              a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    n1, d1 = _rat_poly(a)
    n2, d2 = _rat_poly(b)
    c.num, c.den = _rat_poly_add(n1, d1, n2, d2)
    return c
 end
 
-function add!(c::FunctionFieldElem{T}, a::FunctionFieldElem{T}) where
-                                                              T <: FieldElement
+function add!(c::FunctionFieldElem{T, U}, a::FunctionFieldElem{T, U}) where {T, U}
    n1, d1 = _rat_poly(c)
    n2, d2 = _rat_poly(a)
    c.num, c.den = _rat_poly_add(n1, d1, n2, d2)
    return c
 end
 
-function mul!(c::FunctionFieldElem{T},
-      a::FunctionFieldElem{T}, b::FunctionFieldElem{T}) where T <: FieldElement
+function mul!(c::FunctionFieldElem{T, U},
+              a::FunctionFieldElem{T, U}, b::FunctionFieldElem{T, U}) where {T, U}
    n1, d1 = _rat_poly(a)
    n2, d2 = _rat_poly(b)
    c.num, c.den = _rat_poly_mul(n1, d1, n2, d2)
@@ -1239,13 +1235,12 @@ end
 #
 ###############################################################################
 
-promote_rule(::Type{FunctionFieldElem{T}}, ::Type{FunctionFieldElem{T}}) where T <: FieldElement = FunctionFieldElem{T}
+promote_rule(::Type{FunctionFieldElem{T, U}}, ::Type{FunctionFieldElem{T, U}}) where {T, U} = FunctionFieldElem{T, U}
 
-function promote_rule(::Type{FunctionFieldElem{T}}, ::Type{V}) where
-      {T <: FieldElement, V <: RingElem}
-   # The base ring element type of FunctionFieldElem{T} is RationalFunctionFieldElem{T, U}, not T
-   U = poly_type(T)
-   promote_rule(RationalFunctionFieldElem{T, U}, V) == RationalFunctionFieldElem{T, U} ? FunctionFieldElem{T} : Union{}
+function promote_rule(::Type{FunctionFieldElem{T, U}}, ::Type{V}) where
+      {T, U, V <: RingElem}
+   # The base ring element type of FunctionFieldElem{T, U} is RationalFunctionFieldElem{T, U}, not T
+   promote_rule(RationalFunctionFieldElem{T, U}, V) == RationalFunctionFieldElem{T, U} ? FunctionFieldElem{T, U} : Union{}
 end
 
 ###############################################################################
@@ -1254,41 +1249,40 @@ end
 #
 ###############################################################################
 
-function (R::FunctionField{T})(p::Poly{S}, den::S) where
-                                          {T <: FieldElement, S <: PolyRingElem{T}}
-   z = FunctionFieldElem{T}(R, p, den)
+function (R::FunctionField{T, U})(p::Poly{U}, den::U) where {T, U}
+   z = FunctionFieldElem{T, U}(R, p, den)
    return z
 end
 
-function (R::FunctionField{T})() where T <: FieldElement
+function (R::FunctionField{T, U})() where {T, U}
    p = zero(parent(power_precomp(R, 0)))
    den = one(parent(power_precomp_den(R, 0)))
-   z = FunctionFieldElem{T}(R, p, den)
+   z = FunctionFieldElem{T, U}(R, p, den)
    return z
 end
 
-function (R::FunctionField{T})(a::Union{Rational, Integer}) where T <: FieldElement
+function (R::FunctionField{T, U})(a::Union{Rational, Integer}) where {T, U}
    p = parent(power_precomp(R, 0))(a)
    den = one(parent(power_precomp_den(R, 0)))
-   z = FunctionFieldElem{T}(R, p, den)
+   z = FunctionFieldElem{T, U}(R, p, den)
    return z
 end
 
-function (R::FunctionField{T})(a::T) where T <: FieldElem
+function (R::FunctionField{T, U})(a::T) where {T <: FieldElem, U <: PolyRingElem{T}}
    p = parent(power_precomp(R, 0))(a)
    den = one(parent(power_precomp_den(R, 0)))
-   z = FunctionFieldElem{T}(R, p, den)
+   z = FunctionFieldElem{T, U}(R, p, den)
    return z
 end
 
-function (R::FunctionField{T})(a::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem}
+function (R::FunctionField{T, U})(a::RationalFunctionFieldElem{T, U}) where {T <: FieldElement, U <: PolyRingElem{T}}
    p = parent(power_precomp(R, 0))([numerator(a, false)])
    den = parent(power_precomp_den(R, 0))(denominator(a, false))
-   z = FunctionFieldElem{T}(R, p, den)
+   z = FunctionFieldElem{T, U}(R, p, den)
    return z
 end
 
-function (R::FunctionField{T})(a::FunctionFieldElem) where T <: FieldElement
+function (R::FunctionField{T, U})(a::FunctionFieldElem) where {T <: FieldElement, U <: PolyRingElem{T}}
    parent(a) !== R && error("Unable to coerce element")
    return a
 end
@@ -1369,15 +1363,11 @@ function function_field(p::Poly{RationalFunctionFieldElem{T, U}}, s::VarName; ca
    length(p) < 2 && error("Polynomial must have degree at least 1")
    pol, den = _rat_poly(p, Symbol(s))
 
-   par = FunctionField{T}(pol, den, Symbol(s), cached)
+   par = FunctionField{T, U}(pol, den, Symbol(s), cached)
    par.monic, par.powers, par.powers_den = powers_precompute(pol, den)
    par.traces, par.traces_den = traces_precompute(pol, den)
    par.base_ring = base_ring(p)
    par.pol = p
 
    return par, gen(par)
-end
-
-function function_field(p::Poly{RationalFunctionFieldElem{T, U}}, s::VarName; cached::Bool=true) where {T <: FieldElement, U <: MPolyRingElem}
-   return FunctionField(p, Symbol(s); cached)
 end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -1015,35 +1015,34 @@ end
 #
 ###############################################################################
 
-@attributes mutable struct FunctionField{T <: FieldElement} <: AbstractAlgebra.Field
-   num::Poly{<:PolyRingElem{T}}
-   den::PolyRingElem{T}
+@attributes mutable struct FunctionField{T <: FieldElement, U <: PolyRingElem{T}} <: AbstractAlgebra.Field
+   num::Poly{U}
+   den::U
    S::Symbol
-   powers::Vector{Poly{<:PolyRingElem{T}}}
-   powers_den::Vector{<:PolyRingElem{T}}
-   traces::Vector{<:PolyRingElem{T}}
-   traces_den::PolyRingElem{T}
+   powers::Vector{Poly{U}}
+   powers_den::Vector{U}
+   traces::Vector{U}
+   traces_den::U
    monic::Bool
-   pol::Poly{RationalFunctionFieldElem{T, U}} where U <: PolyRingElem{T}
-   base_ring::RationalFunctionField{T, U} where U <: PolyRingElem{T}
+   pol::Poly{RationalFunctionFieldElem{T, U}}
+   base_ring::RationalFunctionField{T, U}
 
-   function FunctionField{T}(num::Poly{<:PolyRingElem{T}},
-             den::PolyRingElem{T}, s::Symbol, cached::Bool = true) where
-                                                          T <: FieldElement
+   function FunctionField{T, U}(num::Poly{U},
+             den::U, s::Symbol, cached::Bool = true) where {T, U}
       return get_cached!(FunctionFieldDict, (num, den, s), cached) do
-         new{T}(num, den, s)
-      end::FunctionField{T}
+         new{T, U}(num, den, s)
+      end::FunctionField{T, U}
    end
 end
 
 const FunctionFieldDict = CacheDictType{Tuple{Poly, PolyRingElem, Symbol}, Field}()
 
-mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
-   num::Poly{<:PolyRingElem{T}}
-   den::PolyRingElem{T}
-   parent::FunctionField{T}
+mutable struct FunctionFieldElem{T <: FieldElement, U <: PolyRingElem{T}} <: AbstractAlgebra.FieldElem
+   num::Poly{U}
+   den::U
+   parent::FunctionField{T, U}
 
-   function FunctionFieldElem{T}(R::FunctionField{T}, num::Poly{S}, den::S) where {T <: FieldElement, S <: PolyRingElem{T}}
+   function FunctionFieldElem{T, U}(R::FunctionField{T, U}, num::Poly{U}, den::U) where {T, U}
       if !iszero(num) #normalize the denominator
          c = content(den)
          if !is_one(c)
@@ -1051,7 +1050,7 @@ mutable struct FunctionFieldElem{T <: FieldElement} <: AbstractAlgebra.FieldElem
             den = divexact(den, c)
          end
       end
-      return new{T}(num, den, R)
+      return new{T, U}(num, den, R)
    end
 end
 

--- a/test/generic/FunctionField-test.jl
+++ b/test/generic/FunctionField-test.jl
@@ -18,15 +18,17 @@ P2 = [(x2 + 1)*z2 + (x2 + 2), z2 + (x2 + 1)//(x2 + 2), z2^2 + 3z2 + 1,
 #end
 
 @testset "Generic.FunctionField.constructors" begin
-   @test function_field(P1[1], "y")[1] === function_field(P1[1], "y", cached=true)[1]
-   @test function_field(P1[1], "y", cached=true)[1] !== function_field(P1[1], "y", cached=false)[1]
+   @test function_field(P1[1], :y)[1] === function_field(P1[1], :y; cached=true)[1]
+   @test function_field(P1[1], :y; cached=true)[1] !== function_field(P1[1], :y; cached=false)[1]
 
-   for (S, y) in  [function_field(P1[3], "y"), function_field(P2[3], "y")]
+   for (S, y) in  [function_field(P1[3], :y), function_field(P2[3], :y)]
       R = base_ring(base_ring(S))
+      T = elem_type(R)
+      U = dense_poly_type(T)
 
-      @test elem_type(S) == Generic.FunctionFieldElem{elem_type(R)}
-      @test elem_type(Generic.FunctionField{elem_type(R)}) == Generic.FunctionFieldElem{elem_type(R)}
-      @test parent_type(Generic.FunctionFieldElem{elem_type(R)}) == Generic.FunctionField{elem_type(R)}
+      @test elem_type(S) == Generic.FunctionFieldElem{T, U}
+      @test elem_type(Generic.FunctionField{T, U}) == Generic.FunctionFieldElem{T, U}
+      @test parent_type(Generic.FunctionFieldElem{T, U}) == Generic.FunctionField{T, U}
 
       @test S isa Generic.FunctionField
 


### PR DESCRIPTION
Adds a second type parameter `U <: PolyRingElem{T}` to `Generic.FunctionField` and `Generic.FunctionFieldElem`, mirroring `RationalFunctionField{T, U}`. Unlike the latter (whose `U` may be uni- or multivariate), here `U` is restricted to the univariate polynomial element type

