### PR TITLE
Split `promote` methods for `MatrixElem`

### DIFF
--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -559,6 +559,50 @@ end
 randmat_with_rank(S::MatRing{T}, rank::Int, v...) where {T <: RingElement} =
    randmat_with_rank(Random.default_rng(), S, rank, v...)
 
+################################################################################
+#
+#  Promotion
+#
+################################################################################
+
+function Base.promote(x::MatRingElem{S},
+                      y::MatRingElem{T}) where {S <: NCRingElement,
+                                                T <: NCRingElement}
+   U = promote_rule_sym(S, T)
+   if U === S
+      return x, change_base_ring(base_ring(x), y)
+   elseif U === T
+      return change_base_ring(base_ring(y), x), y
+   else
+      error("Cannot promote to common type")
+   end
+end
+
+# matrix * vec and vec * matrx
+function Base.promote(x::MatRingElem{S},
+                      y::Vector{T}) where {S <: NCRingElement,
+                                           T <: NCRingElement}
+   U = promote_rule_sym(S, T)
+   if U === S
+      return x, map(base_ring(x), y)::Vector{S}  # Julia needs help here
+   elseif U === T && length(y) != 0
+      return change_base_ring(parent(y[1]), x), y
+   else
+      error("Cannot promote to common type")
+   end
+end
+
+function Base.promote(x::Vector{S},
+                      y::MatRingElem{T}) where {S <: NCRingElement,
+                                                T <: NCRingElement}
+   yy, xx = promote(y, x)
+   return xx, yy
+end
+
+*(x::MatRingElem, y::Vector) = *(promote(x, y)...)
+
+*(x::Vector, y::MatRingElem) = *(promote(x, y)...)
+
 ###############################################################################
 #
 #   Conformance test element generation

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1175,9 +1175,9 @@ end
 #
 ################################################################################
 
-function Base.promote(x::MatrixElem{S},
-                      y::MatrixElem{T}) where {S <: NCRingElement,
-                                               T <: NCRingElement}
+function Base.promote(x::MatElem{S},
+                      y::MatElem{T}) where {S <: NCRingElement,
+                                            T <: NCRingElement}
    U = promote_rule_sym(S, T)
    if U === S
       return x, change_base_ring(base_ring(x), y)
@@ -1197,7 +1197,7 @@ end
 ==(x::MatElem, y::MatElem) = ==(promote(x, y)...)
 
 # matrix * vec and vec * matrx
-function Base.promote(x::MatrixElem{S},
+function Base.promote(x::MatElem{S},
                       y::Vector{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
    U = promote_rule_sym(S, T)
@@ -1211,15 +1211,15 @@ function Base.promote(x::MatrixElem{S},
 end
 
 function Base.promote(x::Vector{S},
-                      y::MatrixElem{T}) where {S <: NCRingElement,
+                      y::MatElem{T}) where {S <: NCRingElement,
                                                T <: NCRingElement}
    yy, xx = promote(y, x)
    return xx, yy
 end
 
-*(x::MatrixElem, y::Vector) = *(promote(x, y)...)
+*(x::MatElem, y::Vector) = *(promote(x, y)...)
 
-*(x::Vector, y::MatrixElem) = *(promote(x, y)...)
+*(x::Vector, y::MatElem) = *(promote(x, y)...)
 
 function Base.promote(x::MatElem{S}, y::T) where {S <: NCRingElement, T <: NCRingElement}
    U = promote_rule_sym(S, T)


### PR DESCRIPTION
Split off from https://github.com/Nemocas/AbstractAlgebra.jl/pull/2280. This currently also contains https://github.com/Nemocas/AbstractAlgebra.jl/pull/2419 since I get a bunch of ambiguity issues without it.

One could think that this is breaking due to removing the dispatch for `Base.promote(x::MatSpaceElem{S}, ::MatRingElem{T})` (and the other way around). But this is not the case, as this dispatch used to run into an ambiguity error:
```julia-repl
julia> R = matrix_ring(ZZ, 3);

julia> S = matrix_space(QQ, 3, 3);

julia> Base.promote(one(R), one(S)) # for different type parameters
ERROR: MethodError: promote(::AbstractAlgebra.Generic.MatRingElem{BigInt}, ::AbstractAlgebra.Generic.MatSpaceElem{Rational{BigInt}}) is ambiguous.

Candidates:
  promote(x::MatrixElem{S}, y::MatrixElem{T}) where {S<:NCRingElement, T<:NCRingElement}
    @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1178
  promote(x::S, y::MatElem{T}) where {S<:NCRingElement, T<:NCRingElement}
    @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1235

Possible fix, define
  promote(::S, ::MatElem{T}) where {S<:NCRingElement, S<:MatRingElem{S}, T<:NCRingElement}

julia> S = matrix_space(ZZ, 3, 3);

julia> Base.promote(one(R), one(S)) # for the same type parameter
ERROR: MethodError: promote(::AbstractAlgebra.Generic.MatRingElem{BigInt}, ::AbstractAlgebra.Generic.MatSpaceElem{BigInt}) is ambiguous.

Candidates:
  promote(x::MatrixElem{S}, y::MatrixElem{T}) where {S<:NCRingElement, T<:NCRingElement}
    @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1178
  promote(x::S, y::MatElem{T}) where {S<:NCRingElement, T<:NCRingElement}
    @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1235

Possible fix, define
  promote(::S, ::MatElem{T}) where {S<:NCRingElement, S<:MatRingElem{S}, T<:NCRingElement}
```

With this PR, the behavior is as follows:
```julia-repl
julia> R = matrix_ring(ZZ, 3);

julia> S = matrix_space(QQ, 3, 3);

julia> Base.promote(one(R), one(S)) # for different type parameters
ERROR: Cannot promote to common type
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] promote(x::AbstractAlgebra.Generic.MatSpaceElem{Rational{BigInt}}, y::AbstractAlgebra.Generic.MatRingElem{BigInt})
   @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1231
 [3] promote(x::AbstractAlgebra.Generic.MatRingElem{BigInt}, y::AbstractAlgebra.Generic.MatSpaceElem{Rational{BigInt}})
   @ AbstractAlgebra ~/code/julia/AbstractAlgebra.jl/src/Matrix.jl:1236
 [4] top-level scope
   @ REPL[57]:1

julia> S = matrix_space(ZZ, 3, 3);

julia> Base.promote(one(R), one(S)) # for the same type parameter
([1 0 0; 0 1 0; 0 0 1], [[1 0 0; 0 1 0; 0 0 1] [0 0 0; 0 0 0; 0 0 0] [0 0 0; 0 0 0; 0 0 0]; [0 0 0; 0 0 0; 0 0 0] [1 0 0; 0 1 0; 0 0 1] [0 0 0; 0 0 0; 0 0 0]; [0 0 0; 0 0 0; 0 0 0] [0 0 0; 0 0 0; 0 0 0] [1 0 0; 0 1 0; 0 0 1]])
```

I am not sure if we want to keep the last line like that. What happens is that the coefficient ring of the matrix space gets extended to the matrix ring, mapping the original coefficients to diagonal matrices.
However, we have to be careful with adding explicit errors here to not mess up with genuine use-cases where people use MatRingElems as coefficients in their matrices.