### PR TITLE
Split `==` and `isequal` methods for `MatrixElem`

### DIFF
--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -21,14 +21,8 @@ base_ring_type(::Type{<:MatRingElem{T}}) where T <: NCRingElement = parent_type(
 ###############################################################################
 
 function Base.hash(a::MatRingElem, h::UInt)
-   b = 0x6413942b83a26c65%UInt
-   for i in 1:nrows(a)
-      for j in 1:ncols(a)
-         b = xor(b, xor(hash(a[i, j], h), h))
-         b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
-      end
-   end
-   return b
+  # b = 0x6413942b83a26c65 % UInt # FIXME: comment in once `isequal(::MatRingElem, ::MatElem)` is removed.
+  return xor(b, hash(matrix(a), h))
 end
 
 vector_space_dim(a::MatRing{T}) where {T <: Union{FieldElem, Rational{BigInt}}} = nrows(a)^2
@@ -250,7 +244,30 @@ end
 
 ^(a::MatRingElem{T}, b::Int) where T <: NCRingElement = Generic.MatRingElem(matrix(a)^b)
 
-==(x::MatRingElem{T}, y::MatRingElem{T}) where {T <: NCRingElement} = matrix(x) == matrix(y)
+==(x::T, y::T) where {T <: MatRingElem} = matrix(x) == matrix(y)
+
+isequal(x::T, y::T) where {T <: MatRingElem} = isequal(matrix(x), matrix(y))
+
+# FIXME: maybe remove the below methods, or comment the errors in
+function ==(x::MatElem{T}, y::MatRingElem{T}) where {T <: NCRingElement}
+  # error("Equality comparison of MatElem with MatRingElem unsupported")
+  return x == matrix(y)
+end
+
+function ==(x::MatRingElem{T}, y::MatElem{T}) where {T <: NCRingElement}
+  # error("Equality comparison of MatRingElem with MatElem unsupported")
+  return matrix(x) == y
+end
+
+function isequal(x::MatElem{T}, y::MatRingElem{T}) where {T <: NCRingElement}
+  # error("Equality comparison of MatElem with MatRingElem unsupported")
+  return isequal(x, matrix(y))
+end
+
+function isequal(x::MatRingElem{T}, y::MatElem{T}) where {T <: NCRingElement}
+  # error("Equality comparison of MatRingElem with MatElem unsupported")
+  return isequal(matrix(x), y)
+end
 
 ###############################################################################
 #

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -21,7 +21,7 @@ base_ring_type(::Type{<:MatRingElem{T}}) where T <: NCRingElement = parent_type(
 ###############################################################################
 
 function Base.hash(a::MatRingElem, h::UInt)
-  # b = 0x6413942b83a26c65 % UInt # FIXME: comment in once `isequal(::MatRingElem, ::MatElem)` is removed.
+  b = 0x6413942b83a26c65 % UInt
   return xor(b, hash(matrix(a), h))
 end
 
@@ -188,50 +188,6 @@ end
 
 ###############################################################################
 #
-#   Ad hoc comparisons
-#
-###############################################################################
-
-function ==(x::MatRingElem, y::JuliaRingElement)
-   n = degree(x)
-   for i = 1:n
-      if x[i, i] != y
-         return false
-      end
-   end
-   for i = 1:n
-      for j = 1:n
-         if i != j && !is_zero_entry(x, i, j)
-            return false
-         end
-      end
-   end
-   return true
-end
-
-==(x::JuliaRingElement, y::MatRingElem) = y == x
-
-function ==(x::MatRingElem{T}, y::T) where T <: NCRingElem
-   n = degree(x)
-   for i = 1:n
-      if x[i, i] != y
-         return false
-      end
-   end
-   for i = 1:n
-      for j = 1:n
-         if i != j && !is_zero_entry(x, i, j)
-            return false
-         end
-      end
-   end
-   return true
-end
-
-==(x::T, y::MatRingElem{T}) where T <: NCRingElem = y == x
-
-###############################################################################
-#
 #   Basic arithmetic -- delegate to MatElem
 #
 ###############################################################################
@@ -247,27 +203,6 @@ end
 ==(x::T, y::T) where {T <: MatRingElem} = matrix(x) == matrix(y)
 
 isequal(x::T, y::T) where {T <: MatRingElem} = isequal(matrix(x), matrix(y))
-
-# FIXME: maybe remove the below methods, or comment the errors in
-function ==(x::MatElem{T}, y::MatRingElem{T}) where {T <: NCRingElement}
-  # error("Equality comparison of MatElem with MatRingElem unsupported")
-  return x == matrix(y)
-end
-
-function ==(x::MatRingElem{T}, y::MatElem{T}) where {T <: NCRingElement}
-  # error("Equality comparison of MatRingElem with MatElem unsupported")
-  return matrix(x) == y
-end
-
-function isequal(x::MatElem{T}, y::MatRingElem{T}) where {T <: NCRingElement}
-  # error("Equality comparison of MatElem with MatRingElem unsupported")
-  return isequal(x, matrix(y))
-end
-
-function isequal(x::MatRingElem{T}, y::MatElem{T}) where {T <: NCRingElement}
-  # error("Equality comparison of MatRingElem with MatElem unsupported")
-  return isequal(matrix(x), y)
-end
 
 ###############################################################################
 #
@@ -330,6 +265,59 @@ end
 function *(x::Vector{T}, y::MatRingElem{T}) where T <: NCRingElement
   return x * matrix(y)
 end
+
+###############################################################################
+#
+#   Ad hoc comparisons
+#
+###############################################################################
+
+function ==(x::MatRingElem{T}, y::JuliaRingElement) where T <: NCRingElement
+   return matrix(x) == y
+end
+
+==(x::JuliaRingElement, y::MatRingElem{T}) where T <: NCRingElement = y == x
+
+function ==(x::MatRingElem{T}, y::T) where {T <: NCRingElem}
+   return matrix(x) == y
+end
+
+==(x::T, y::MatRingElem{T}) where {T <: NCRingElem} = y == x
+
+function ==(x::MatElem{T}, y::MatRingElem) where {T <: NCRingElement}
+  error("Equality comparison of MatElem with MatRingElem unsupported. Call `x == matrix(y)` instead.")
+end
+
+function ==(x::MatRingElem, y::MatElem{T}) where {T <: NCRingElement}
+  error("Equality comparison of MatRingElem with MatElem unsupported. Call `matrix(x) == y` instead.")
+end
+
+function isequal(x::MatElem{T}, y::MatRingElem{T}) where {T <: NCRingElement}
+  error("Equality comparison of MatElem with MatRingElem unsupported. Call `isequal(x, matrix(y))` instead.")
+end
+
+function isequal(x::MatRingElem{T}, y::MatElem{T}) where {T <: NCRingElement}
+  error("Equality comparison of MatRingElem with MatElem unsupported. Call `isequal(matrix(x), y)` instead.")
+end
+
+# to resolve ambiguities:
+function ==(x::MatElem{T}, y::T) where {T <: MatRingElem}
+   for i = 1:min(nrows(x), ncols(x))
+      if x[i, i] != y
+         return false
+      end
+   end
+   for i = 1:nrows(x)
+      for j = 1:ncols(x)
+         if i != j && !is_zero_entry(x, i, j)
+            return false
+         end
+      end
+   end
+   return true
+end
+
+==(x::T, y::MatElem{T}) where {T <: MatRingElem} = y == x
 
 ###############################################################################
 #

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1352,7 +1352,7 @@ end
 #
 ###############################################################################
 
-function ==(x::MatrixElem{T}, y::JuliaRingElement) where T <: NCRingElement
+function ==(x::MatElem{T}, y::JuliaRingElement) where T <: NCRingElement
    for i = 1:min(nrows(x), ncols(x))
       if x[i, i] != y
          return false
@@ -1368,15 +1368,15 @@ function ==(x::MatrixElem{T}, y::JuliaRingElement) where T <: NCRingElement
    return true
 end
 
-==(x::JuliaRingElement, y::MatrixElem{T}) where T <: NCRingElement = y == x
+==(x::JuliaRingElement, y::MatElem{T}) where T <: NCRingElement = y == x
 
 @doc raw"""
-    ==(x::MatrixElem{<:NCRingElement}, y::NCRingElement)
+    ==(x::MatElem{<:NCRingElement}, y::NCRingElement)
 
 Return `true` if $x == S(y)$ arithmetically, where $S$ is the parent of $x$,
 otherwise return `false`.
 """
-function ==(x::MatrixElem{T}, y::T) where {T <: NCRingElem}
+function ==(x::MatElem{T}, y::T) where {T <: NCRingElem}
    for i = 1:min(nrows(x), ncols(x))
       if x[i, i] != y
          return false
@@ -1393,12 +1393,12 @@ function ==(x::MatrixElem{T}, y::T) where {T <: NCRingElem}
 end
 
 @doc raw"""
-    ==(x::NCRingElement, y::MatrixElem{<:NCRingElement})
+    ==(x::NCRingElement, y::MatElem{<:NCRingElement})
 
 Return `true` if $S(x) == y$ arithmetically, where $S$ is the parent of $y$,
 otherwise return `false`.
 """
-==(x::T, y::MatrixElem{T}) where {T <: NCRingElem} = y == x
+==(x::T, y::MatElem{T}) where {T <: NCRingElem} = y == x
 
 ###############################################################################
 #

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1306,13 +1306,13 @@ end
 ###############################################################################
 
 @doc raw"""
-    ==(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: NCRingElement}
+    ==(x::MatElem{T}, y::MatElem{T}) where {T <: NCRingElement}
 
 Return `true` if $x == y$ arithmetically, otherwise return `false`. Recall
 that power series to different precisions may still be arithmetically
 equal to the minimum of the two precisions.
 """
-function ==(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: NCRingElement}
+function ==(x::MatElem{T}, y::MatElem{T}) where {T <: NCRingElement}
    b = check_parent(x, y, false)
    !b && return false
    for i = 1:nrows(x)
@@ -1326,14 +1326,14 @@ function ==(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: NCRingElement}
 end
 
 @doc raw"""
-    isequal(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: NCRingElement}
+    isequal(x::MatElem{T}, y::MatElem{T}) where {T <: NCRingElement}
 
 Return `true` if $x == y$ exactly, otherwise return `false`. This function is
 useful in cases where the entries of the matrices are inexact, e.g. power
 series. Only if the power series are precisely the same, to the same precision,
 are they declared equal by this function.
 """
-function isequal(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: NCRingElement}
+function isequal(x::MatElem{T}, y::MatElem{T}) where {T <: NCRingElement}
    b = check_parent(x, y, false)
    !b && return false
    for i = 1:nrows(x)

--- a/test/Matrix-test.jl
+++ b/test/Matrix-test.jl
@@ -133,7 +133,7 @@ end
   @test Sa == S(Sa)
   @test Sa == S(Ra)
   @test matrix(Ra) == Sa
-  @test matrix(U, Ra) == Ra
+  @test matrix(U, Ra) == Sa
   @test matrix(Sa) == Sa
   @test matrix(U, Sa) == Sa
   @test Matrix(Ra) == a

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -1450,12 +1450,38 @@ end
 end
 
 @testset "Generic.MatRing.adhoc_equality" begin
-   # FIXME: may be removed, depending on how we decide to handle equality between MatRingElem and MatElem.
-   # Test equality comparison between MatRingElem & MatElem
    R = matrix_ring(ZZ, 2)
+   S = matrix_ring(QQ, 2)
    M = R(matrix(ZZ, 2,2, [1,2,3,4]))
-   @test M == matrix(M)
-   @test matrix(M) == M
-   @test M == matrix(QQ, M)
-   @test matrix(QQ, M) == M
+   N_ZZ = R(matrix(ZZ, 2,2, [1,2,3,4]))
+   N_QQ = S(matrix(QQ, 2,2, [1,2,3,4]))
+   @test M == N_ZZ
+   @test_throws ErrorException M == matrix(N_ZZ)
+   @test_throws ErrorException matrix(M) == N_ZZ
+   @test_throws NotImplementedError M == N_QQ
+   @test_throws ErrorException M == matrix(N_QQ)
+   @test_throws ErrorException matrix(M) == N_QQ
+
+   # MatRingElem as scalars in a MatSpace
+   A_R = matrix(R, 2,2, [1,2,3,4])
+   @test M != A_R
+   @test A_R != M
+   @test M == matrix(R, 2, 2, [M, 0, 0, M])
+   @test matrix(R, 2, 2, [M, 0, 0, M]) == M
+
+   # MatRings over MatRings
+   T = matrix_ring(R, 2)
+   @test one(T) == one(T)
+   @test one(T) == 1
+   @test 1 == one(T)
+   @test one(R) == one(T)
+   @test one(T) == one(R)
+
+   M2 = T(matrix(R, 2, 2, [M, 0, M, 5]))
+   A_T = matrix(T, 2,2, [1,2,3,4])
+   @test M2 != A_T
+   @test A_T != M2
+   @test M2 == matrix(T, 2, 2, [M2, 0, 0, M2])
+   @test matrix(T, 2, 2, [M2, 0, 0, M2]) == M2
+
 end

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -1448,3 +1448,14 @@ end
    @test v isa Vector{elem_type(M)}
    @test all(x -> parent(x) == M, v)
 end
+
+@testset "Generic.MatRing.adhoc_equality" begin
+   # FIXME: may be removed, depending on how we decide to handle equality between MatRingElem and MatElem.
+   # Test equality comparison between MatRingElem & MatElem
+   R = matrix_ring(ZZ, 2)
+   M = R(matrix(ZZ, 2,2, [1,2,3,4]))
+   @test M == matrix(M)
+   @test matrix(M) == M
+   @test M == matrix(QQ, M)
+   @test matrix(QQ, M) == M
+end


### PR DESCRIPTION
Closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/2280.

This currently contains https://github.com/Nemocas/AbstractAlgebra.jl/pull/2420, as that is needed for everything to kind of work.

## Current state
Triage needs to decide between the following scenarios:
1. Comparison between `MatElem` and `MatRingElem` throws an explicit error.
2. No explicit handling. The fallback will try to promote, and either throw a PromoteError or return `false` (if there was a promotion possible, see the last sentence in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2420#issue-4613311710).
3. Comparison between `MatElem` and `MatRingElem` unpacks the MatRingElem and uses the underlying matrix for the comparison. What about the case that the coefficient rings are different? Do we want to do the promotion on the level of `MatElem`s for this? (x-ref the failing test)

Option 1 is definitely "breaking", option 2 maybe.

## Needed work
For possibilities 1 and 2, there are a few "FIXME" comments in the code that need to be addressed.
For possibility 3, one would need to add a workaround for the failing test.