### PR TITLE
Fix in-place entry mutation in polynomial HNF/Popov routines

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -4904,11 +4904,11 @@ function hnf_cohen!(H::MatrixElem{T}, U::MatrixElem{T}) where {T <: RingElement}
          q = -div(H[j,i], H[k, i])
          for c = i:n
             t = mul!(t, q, H[k, c])
-            H[j, c] = add!(H[j, c], t)
+            H[j, c] += t
          end
          for c = 1:m
             t = mul!(t, q, U[k, c])
-            U[j, c] = add!(U[j, c], t)
+            U[j, c] += t
          end
       end
       k += 1
@@ -5872,17 +5872,17 @@ function weak_popov_with_pivots!(P::MatElem{T}, W::MatElem{T}, U::MatElem{T}, pi
             q = -div(P[pivots[i][j], i], P[pivot, i])
             for c = 1:n
                t = mul!(t, q, P[pivot, c])
-               P[pivots[i][j], c] = add!(P[pivots[i][j], c], t)
+               P[pivots[i][j], c] += t
             end
             if with_trafo
                for c = 1:ncols(U)
                   t = mul!(t, q, U[pivot, c])
-                  U[pivots[i][j], c] = add!(U[pivots[i][j], c], t)
+                  U[pivots[i][j], c] += t
                end
             end
             if extended
                t = mul!(t, q, W[pivot,1])
-               W[pivots[i][j], 1] = add!(W[pivots[i][j], 1], t)
+               W[pivots[i][j], 1] += t
             end
          end
          old_pivots = pivots[i]
@@ -6122,12 +6122,12 @@ function popov!(P::MatElem{T}, U::MatElem{T}, with_trafo::Bool = false) where {T
          q = -div(P[r, c2], P[r2, c2])
          for c = 1:n
             t = mul!(t, q, P[r2, c])
-            P[r, c] = add!(P[r, c], t)
+            P[r, c] += t
          end
          if with_trafo
             for c = 1:ncols(U)
                t = mul!(t, q, U[r2, c])
-               U[r, c] = add!(U[r, c], t)
+               U[r, c] += t
             end
          end
       end
@@ -6186,12 +6186,12 @@ function hnf_via_popov_reduce_row!(H::MatElem{T}, U::MatElem{T}, pivots_hermite:
       q = -div(H[r, c], H[pivot, c])
       for j = c:n
          t = mul!(t, q, H[pivot, j])
-         H[r, j] = add!(H[r, j], t)
+         H[r, j] += t
       end
       if with_trafo
          for j = 1:ncols(U)
             t = mul!(t, q, U[pivot, j])
-            U[r, j] = add!(U[r, j], t)
+            U[r, j] += t
          end
       end
    end
@@ -6213,12 +6213,12 @@ function hnf_via_popov_reduce_column!(H::MatElem{T}, U::MatElem{T}, pivots_hermi
       q = -div(H[i, c], H[r, c])
       for j = 1:n
          t = mul!(t, q, H[r, j])
-         H[i, j] = add!(H[i, j], t)
+         H[i, j] += t
       end
       if with_trafo
          for j = 1:ncols(U)
             t = mul!(t, q, U[r, j])
-            U[i, j] = add!(U[i, j], t)
+            U[i, j] += t
          end
       end
    end
@@ -6258,12 +6258,12 @@ function hnf_via_popov!(H::MatElem{T}, U::MatElem{T}, with_trafo::Bool = false) 
          q = -div(H[r1, c], H[r2, c])
          for j = 1:n
             t = mul!(t, q, H[r2, j])
-            H[r1, j] = add!(H[r1, j], t)
+            H[r1, j] += t
          end
          if with_trafo
             for j = 1:ncols(U)
                t = mul!(t, q, U[r2, j])
-               U[r1, j] = add!(U[r1, j], t)
+               U[r1, j] += t
             end
          end
          hnf_via_popov_reduce_row!(H, U, pivots_hermite, r1, with_trafo)

--- a/test/Matrix-test.jl
+++ b/test/Matrix-test.jl
@@ -257,3 +257,50 @@ end
   # @test_throws AbstractAlgebra.rank_interpolation(A)
   # @test_throws AbstractAlgebra.rank_interpolation_mc(A, 0.01)
 end
+
+@testset "hnf_via_popov! doesn't mutate matrix entries" begin
+  R, x = polynomial_ring(QQ, "x")
+
+  A = matrix(R, [x+1 0 0; 0 x+1 0; -1 1 1]); Asaved = deepcopy(A)
+  M = vcat(A, zero_matrix(R, 1, 3))
+
+  # vcat copies references. If we ever stop doing this, this test will fail
+  @test M[1, 1] === A[1, 1]
+
+  AbstractAlgebra.hnf_via_popov!(M, similar(M, 0, 0), false)
+
+  # if hnf_via_popov! mutates matrix elements in place it will mutate
+  #   A (since M contains references to the elements of A)
+  @test A == Asaved
+end
+
+@testset "popov! doesn't mutate matrix entries" begin
+  R, x = polynomial_ring(QQ, "x")
+
+  # Already in weak-Popov form, so only popov! itself does actual work
+  A = matrix(R, [x^3 x^2; R(1) x]);  Asaved = deepcopy(A)
+  M = vcat(A, zero_matrix(R, 1, 2))
+
+  # vcat copies references. If we ever stop doing this, this test will fail
+  @test M[1, 1] === A[1, 1]
+
+  # if popov! mutates matrix elements in place it will mutate A
+  #   (since M contains references to the elements of A)
+  AbstractAlgebra.popov!(M, similar(M, 0, 0), false)
+  @test A == Asaved
+end
+
+@testset "hnf_cohen! doesn't mutate matrix entries" begin
+  R, x = polynomial_ring(QQ, "x")
+
+  A = matrix(R, [x x; R(0) R(1)]); Asaved = deepcopy(A)
+  M = vcat(A, zero_matrix(R, 1, 2))
+
+  # vcat copies references. If we ever stop doing this, this test will fail
+  @test M[1, 1] === A[1, 1]
+
+  # if hnf_cohen! mutates matrix elements in place it will mutate A
+  #   (since M contains references to the elements of A)
+  AbstractAlgebra.hnf_cohen!(M, identity_matrix(R, nrows(M)))
+  @test A == Asaved
+end


### PR DESCRIPTION
`hnf_via_popov!`, `popov!`, and `hnf_cohen!` rewrote matrix entries in place via `M[i,j] = add!(M[i,j], t)` and the like. Use `M[i,j] += t` instead (as `hnf_kb!` already does).

`_hnf_minors!` internally deepcopy all the entries; was left as is.

`M[i,j] += t` creates a temp object, but doing deepcopy (like `hnf_kb!`) would do the same. 