### PR TITLE
Fix construction of direct sums of modules

### DIFF
--- a/src/generic/DirectSum.jl
+++ b/src/generic/DirectSum.jl
@@ -235,6 +235,7 @@ function direct_sum(m::Vector{<:AbstractAlgebra.FPModule{T}}) where T <: RingEle
            new_rels[rel] = new_rel
            rel += 1
         end
+        start += degs[i]
      end
    end
    # Construct DirectSumModule object
@@ -301,4 +302,3 @@ function hom_direct_sum(A::DirectSumModule{T}, B::DirectSumModule{T}, M::Matrix{
   end
   return s
 end
-

--- a/test/generic/DirectSum-test.jl
+++ b/test/generic/DirectSum-test.jl
@@ -29,6 +29,14 @@
 
    @test_throws ArgumentError gen(D, 0)
    @test_throws ArgumentError gen(D, ngens(D) + 1)
+
+   F = free_module(ZZ, 1)
+   S, _ = sub(F, [2*gen(F, 1)])
+   Q, _ = quo(F, S)
+   D, _, _ = direct_sum(Q, Q)
+
+   @test relations(D) == [matrix(ZZ, 1, 2, [2, 0]), matrix(ZZ, 1, 2, [0, 2])]
+   @test invariant_factors(D) == BigInt[2, 2]
 end
 
 @testset "Generic.DirectSum.basic_manipulation" begin
@@ -89,4 +97,3 @@ end
       end
    end
 end
-


### PR DESCRIPTION
Resolves https://github.com/Nemocas/AbstractAlgebra.jl/issues/2435.

# Fix direct_sum for FP modules

`direct_sum` allocated the correct total number of generators, but when copying each summand's relations into the combined relation rows it did not advance the column offset between summands. As a result, relations from later summands were written into the first block. For example, Z/2 ⊕ Z/2 would have relations [[2 0], [2 0]], so relation-based operations such as `invariant_factors` saw Z/2 ⊕ Z.

## Summary
- Fix relation assembly in `direct_sum` so each summand's relators are placed in the correct generator block.
- Add a test which checks that Z/2 ⊕ Z/2 has invariant factors `[2,2]`.
- Verify the resulting direct sum has block-diagonal relations and invariant factors `[2, 2]`.

This change increments the offset after processing each summand, so relators land in their corresponding block.

## Tests
- Added test for this specific example (Z/2 ⊕ Z/2) in `test/generic/DirectSum-test.jl`

*Disclaimer* The text of this pull request was partially written by Codex (and partially by me).