### PR TITLE
Consistently use `check_square(::MatElem)`

### DIFF
--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -115,6 +115,11 @@ function check_square(S::MatSpace)
    S
 end
 
+function check_square(A::MatElem)
+   nrows(A) == ncols(A) || throw(DomainError(A, "Matrix must be a square matrix"))
+   A
+end
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -116,7 +116,7 @@ function check_square(S::MatSpace)
 end
 
 function check_square(A::MatElem)
-   nrows(A) == ncols(A) || throw(DomainError(A, "Matrix must be a square matrix"))
+   is_square(A) || throw(DomainError(A, "Argument must be a square matrix"))
    A
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1277,7 +1277,7 @@ Base.literal_pow(::typeof(^), x::T, ::Val{p}) where {p, U <: NCRingElement, T <:
 Return $a^b$. We require that the matrix $a$ is square.
 """
 function ^(a::MatElem{T}, b::Int) where T <: NCRingElement
-   !is_square(a) && error("Incompatible matrix dimensions in power")
+   check_square(a)
    if b < 0
       return inv(a)^(-b)
    end
@@ -1536,7 +1536,7 @@ Aliasing between `z` and `x` is permitted.
 The unary version reports an error if `x` is not a square matrix.
 """
 function transpose!(x::MatElem)
-  @req is_square(x) "Matrix must be a square matrix"
+  check_square(x)
   return transpose!(x, x)
 end
 
@@ -1658,7 +1658,7 @@ t^2 + 3*t + 2
 ```
 """
 function tr(x::MatElem{T}) where T <: NCRingElement
-   !is_square(x) && error("Not a square matrix in trace")
+   check_square(x)
    d = zero(base_ring(x))
    for i = 1:nrows(x)
       d = add!(d, x[i, i])
@@ -2451,7 +2451,7 @@ function det_fflu(M::MatElem{T}) where {T <: RingElement}
 end
 
 function det(M::MatElem{T}) where {T <: FieldElement}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    return det_fflu(M)
 end
 
@@ -2473,7 +2473,7 @@ x^3 - 1
 ```
 """
 function det(M::MatElem{T}) where {T <: RingElement}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    try
       return det_fflu(M)
@@ -2517,13 +2517,13 @@ function det_interpolation(M::MatElem{T}) where {T <: PolyRingElem}
 end
 
 function det(M::MatElem{T}) where {S <: FinFieldElem, T <: PolyRingElem{S}}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    return det_popov(M)
 end
 
 function det(M::MatElem{T}) where {T <: PolyRingElem}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    try
       return det_interpolation(M)
@@ -3940,14 +3940,14 @@ will be the determinant of $M$ up to sign. If $M$ is singular an exception
 is raised.
 """
 function pseudo_inv(M::MatElem{T}) where {T <: RingElement}
-   is_square(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
+   check_square(M)
    flag, X, d = _can_solve_with_solution_fflu(M, identity_matrix(M))
    !flag && error("Singular matrix in pseudo_inv")
    return X, d
 end
 
 function Base.inv(M::MatElem{T}) where {T <: FieldElement}
-   is_square(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
+   check_square(M)
    flag, A = can_solve_with_solution(M, identity_matrix(M))
    !flag && error("Singular matrix in inv")
    return A
@@ -3962,7 +3962,7 @@ identity matrix. If $M$ is not invertible over the base ring an exception is
 raised.
 """
 function Base.inv(M::MatElem{T}) where {T <: RingElement}
-   is_square(M) || throw(DomainError(M, "Cannot invert non-square Matrix"))
+   check_square(M)
    X, d = pseudo_inv(M)
    is_unit(d) || throw(DomainError(M, "Matrix is not invertible."))
    return divexact(X, d)
@@ -4148,7 +4148,7 @@ such that $A^k = 0$. If `A` is not square an exception is raised.
 """
 function is_nilpotent(A::MatElem{T}) where {T <: RingElement}
   is_domain_type(T) || error("Only supported over integral domains")
-  !is_square(A) && error("Dimensions don't match in is_nilpotent")
+  check_square(A)
   is_zero(tr(A)) || return false
   n = nrows(A)
   A = deepcopy(A)
@@ -4169,7 +4169,7 @@ end
 ###############################################################################
 
 function hessenberg!(A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in hessenberg")
+   check_square(A)
    R = base_ring(A)
    n = nrows(A)
    u = R()
@@ -4220,7 +4220,7 @@ above and on the diagonal and in the diagonal line immediately below the
 diagonal.
 """
 function hessenberg(A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in hessenberg")
+   check_square(A)
    M = deepcopy(A)
    hessenberg!(M)
    return M
@@ -4251,7 +4251,7 @@ end
 ###############################################################################
 
 function charpoly_hessenberg!(S::Ring, A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -4277,7 +4277,7 @@ function charpoly_hessenberg!(S::Ring, A::MatElem{T}) where {T <: RingElement}
 end
 
 function charpoly_danilevsky_ff!(S::Ring, A::MatrixElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -4395,7 +4395,7 @@ function charpoly_danilevsky_ff!(S::Ring, A::MatrixElem{T}) where {T <: RingElem
 end
 
 function charpoly_danilevsky!(S::Ring, A::MatrixElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -4527,7 +4527,7 @@ x^4 + 2*x^2 + 6*x + 2
 ```
 """
 function charpoly(S::PolyRing{T}, Y::MatElem{T}) where {T <: RingElement}
-   !is_square(Y) && error("Dimensions don't match in charpoly")
+   check_square(Y)
    R = base_ring(Y)
    base_ring(S) != base_ring(Y) && error("Cannot coerce into polynomial ring")
    n = nrows(Y)
@@ -4608,7 +4608,7 @@ end
 # extremely fast to compute over some fields).
 
 function minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) where {T <: FieldElement}
-   !is_square(M) && error("Not a square matrix in minpoly")
+   check_square(M)
    base_ring(S) != base_ring(M) && error("Unable to coerce polynomial")
    n = nrows(M)
    if n == 0
@@ -4730,7 +4730,7 @@ x^2 + 10*x
 ```
 """
 function minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
-   !is_square(M) && error("Not a square matrix in minpoly")
+   check_square(M)
    base_ring(S) != base_ring(M) && error("Unable to coerce polynomial")
    n = nrows(M)
    if n == 0
@@ -5949,7 +5949,7 @@ function rank_profile_popov(A::MatElem{T}) where {T <: PolyRingElem}
 end
 
 function det_popov(A::MatElem{T}) where {T <: PolyRingElem}
-   nrows(A) != ncols(A) && error("Not a square matrix in det_popov.")
+   check_square(A)
    B = deepcopy(A)
    n = ncols(B)
    R = base_ring(B)
@@ -7116,7 +7116,7 @@ with ones down the diagonal and zeroes elsewhere. `M` must be square.
 This is an alias for `one(M)`.
 """
 function identity_matrix(M::MatElem{T}) where T <: NCRingElement
-   is_square(M) || throw(DomainError(M, "matrix must be square"))
+   check_square(M)
    return identity_matrix(M, nrows(M))
 end
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -1556,7 +1556,7 @@ Base.literal_pow(::typeof(^), x::T, ::Val{p}) where {p, U <: NCRingElement, T <:
 Return $a^b$. We require that the matrix $a$ is square.
 """
 function ^(a::MatElem{T}, b::Int) where T <: NCRingElement
-   !is_square(a) && error("Incompatible matrix dimensions in power")
+   check_square(a)
    if b < 0
       return inv(a)^(-b)
    end
@@ -1815,7 +1815,7 @@ The binary version stores the transpose of `x` in `z` and returns `z`. The matri
 and incorrect dimensions may result in undefined behaviour.
 """
 function transpose!(x::MatElem)
-  @req is_square(x) "Matrix must be a square matrix"
+  check_square(x)
   return transpose!(x, x)
 end
 
@@ -1935,7 +1935,7 @@ t^2 + 3*t + 2
 ```
 """
 function tr(x::MatElem{T}) where T <: NCRingElement
-   !is_square(x) && error("Not a square matrix in trace")
+   check_square(x)
    d = zero(base_ring(x))
    for i = 1:nrows(x)
       d = add!(d, x[i, i])
@@ -2823,7 +2823,7 @@ function det_fflu(M::MatElem{T}) where {T <: RingElement}
 end
 
 function det(M::MatElem{T}) where {T <: FieldElement}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    return det_fflu(M)
 end
 
@@ -2846,7 +2846,7 @@ x^3 - 1
 ```
 """
 function det(M::MatElem{T}) where {T <: RingElement}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    try
       return det_fflu(M)
@@ -2890,13 +2890,13 @@ function det_interpolation(M::MatElem{T}) where {T <: PolyRingElem}
 end
 
 function det(M::MatElem{T}) where {S <: FinFieldElem, T <: PolyRingElem{S}}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    return det_popov(M)
 end
 
 function det(M::MatElem{T}) where {T <: PolyRingElem}
-   !is_square(M) && error("Not a square matrix in det")
+   check_square(M)
    nrows(M) == 0 && return one(base_ring(M))
    try
       return det_interpolation(M)
@@ -4386,14 +4386,14 @@ julia> pseudo_inv(M)
 ```
 """
 function pseudo_inv(M::MatElem{T}) where {T <: RingElement}
-   is_square(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
+   check_square(M)
    flag, X, d = _can_solve_with_solution_fflu(M, identity_matrix(M))
    !flag && error("Singular matrix in pseudo_inv")
    return X, d
 end
 
 function Base.inv(M::MatElem{T}) where {T <: FieldElement}
-   is_square(M) || throw(DomainError(M, "Can not invert non-square Matrix"))
+   check_square(M)
    flag, A = can_solve_with_solution(M, identity_matrix(M))
    !flag && error("Singular matrix in inv")
    return A
@@ -4423,7 +4423,7 @@ julia> inv(M)
 ```
 """
 function Base.inv(M::MatElem{T}) where {T <: RingElement}
-   is_square(M) || throw(DomainError(M, "Cannot invert non-square Matrix"))
+   check_square(M)
    X, d = pseudo_inv(M)
    is_unit(d) || throw(DomainError(M, "Matrix is not invertible."))
    return divexact(X, d)
@@ -4690,7 +4690,7 @@ false
 """
 function is_nilpotent(A::MatElem{T}) where {T <: RingElement}
   is_domain_type(T) || error("Only supported over integral domains")
-  !is_square(A) && error("Dimensions don't match in is_nilpotent")
+  check_square(A)
   is_zero(tr(A)) || return false
   n = nrows(A)
   A = deepcopy(A)
@@ -4711,7 +4711,7 @@ end
 ###############################################################################
 
 function hessenberg!(A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in hessenberg")
+   check_square(A)
    R = base_ring(A)
    n = nrows(A)
    u = R()
@@ -4783,7 +4783,7 @@ true
 ```
 """
 function hessenberg(A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in hessenberg")
+   check_square(A)
    M = deepcopy(A)
    hessenberg!(M)
    return M
@@ -4836,7 +4836,7 @@ end
 ###############################################################################
 
 function charpoly_hessenberg!(S::Ring, A::MatElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -4862,7 +4862,7 @@ function charpoly_hessenberg!(S::Ring, A::MatElem{T}) where {T <: RingElement}
 end
 
 function charpoly_danilevsky_ff!(S::Ring, A::MatrixElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -4980,7 +4980,7 @@ function charpoly_danilevsky_ff!(S::Ring, A::MatrixElem{T}) where {T <: RingElem
 end
 
 function charpoly_danilevsky!(S::Ring, A::MatrixElem{T}) where {T <: RingElement}
-   !is_square(A) && error("Dimensions don't match in charpoly")
+   check_square(A)
    R = base_ring(A)
    base_ring(S) != base_ring(A) && error("Cannot coerce into polynomial ring")
    n = nrows(A)
@@ -5112,7 +5112,7 @@ x^4 + 2*x^2 + 6*x + 2
 ```
 """
 function charpoly(S::PolyRing{T}, Y::MatElem{T}) where {T <: RingElement}
-   !is_square(Y) && error("Dimensions don't match in charpoly")
+   check_square(Y)
    R = base_ring(Y)
    base_ring(S) != base_ring(Y) && error("Cannot coerce into polynomial ring")
    n = nrows(Y)
@@ -5193,7 +5193,7 @@ end
 # extremely fast to compute over some fields).
 
 function minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) where {T <: FieldElement}
-   !is_square(M) && error("Not a square matrix in minpoly")
+   check_square(M)
    base_ring(S) != base_ring(M) && error("Unable to coerce polynomial")
    n = nrows(M)
    if n == 0
@@ -5315,7 +5315,7 @@ x^2 + 10*x
 ```
 """
 function minpoly(S::PolyRing{T}, M::MatElem{T}, charpoly_only::Bool = false) where {T <: RingElement}
-   !is_square(M) && error("Not a square matrix in minpoly")
+   check_square(M)
    base_ring(S) != base_ring(M) && error("Unable to coerce polynomial")
    n = nrows(M)
    if n == 0
@@ -6732,7 +6732,7 @@ function rank_profile_popov(A::MatElem{T}) where {T <: PolyRingElem}
 end
 
 function det_popov(A::MatElem{T}) where {T <: PolyRingElem}
-   nrows(A) != ncols(A) && error("Not a square matrix in det_popov.")
+   check_square(A)
    B = deepcopy(A)
    n = ncols(B)
    R = base_ring(B)
@@ -8181,8 +8181,8 @@ julia> identity_matrix(M)
 [0   1]
 ```
 """
-function identity_matrix(M::MatElem{T}) where {T <: NCRingElement}
-   is_square(M) || throw(DomainError(M, "matrix must be square"))
+function identity_matrix(M::MatElem{T}) where T <: NCRingElement
+   check_square(M)
    return identity_matrix(M, nrows(M))
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -4478,7 +4478,7 @@ end
   @test AbstractAlgebra.transpose!(x, x) == QQ[1 3; 2 4]
 
   # in-place transpose of non-square matrix does not work
-  @test_throws ArgumentError AbstractAlgebra.transpose!(a)
+  @test_throws DomainError AbstractAlgebra.transpose!(a)
 end
 
 @testset "Generic.Mat.MatSpace_iteration" begin


### PR DESCRIPTION
Currently includes https://github.com/Nemocas/AbstractAlgebra.jl/pull/2432; will get rebased once that is merged.

This is split off from https://github.com/Nemocas/AbstractAlgebra.jl/pull/2432 as it breaks the Nemo testsuite.