### PR TITLE
Disallow nondistinct variable names for `gens(::UniversalRing, ...)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 version = "0.50.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -20,6 +21,7 @@ IJuliaExt = "IJulia"
 TestExt = "Test"
 
 [compat]
+Compat = "4.13.0"
 IJulia = "1"
 LinearAlgebra = "1.10"
 MacroTools = "0.5"

--- a/src/UniversalRing.jl
+++ b/src/UniversalRing.jl
@@ -60,6 +60,7 @@ end
 is_gen(p::UniversalRingElem) = is_gen(data(p))
 
 function _ensure_variables(S::UniversalRing, v::Vector{<:VarName})
+   @req allunique(v) "Variable names must be unique"
    idx = Int[]
    current_symbols = symbols(S)
    n = length(current_symbols)

--- a/src/UniversalRing.jl
+++ b/src/UniversalRing.jl
@@ -60,7 +60,7 @@ end
 is_gen(p::UniversalRingElem) = is_gen(data(p))
 
 function _ensure_variables(S::UniversalRing, v::Vector{<:VarName})
-   @req allunique(v) "Variable names must be unique"
+   @req allunique(Symbol, v) "Variable names must be unique"
    idx = Int[]
    current_symbols = symbols(S)
    n = length(current_symbols)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,3 +1,5 @@
+using Compat: allequal, allunique
+
 using Random: Random, AbstractRNG, SamplerTrivial
 using RandomExtensions: RandomExtensions, make, Make, Make2, Make3, Make4
 


### PR DESCRIPTION
Unfortunately, I forgot this in #2413.