### PR TITLE
CI: Run doctests less often

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,10 +112,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: |
-          julia --color=yes --project=docs/ docs/make.jl --pdf
+          julia --color=yes --project=docs/ docs/make.jl --pdf --nodoctests
       - name: Upload PDF
         uses: actions/upload-artifact@v7
         with:
           path: docs/build/AbstractAlgebra.jl.pdf
           archive: false
-          if-no-files-found: warn 
+          if-no-files-found: error

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,8 +105,8 @@ jobs:
               fonts-dejavu-extra
       - name: Prepare building docs
         run: |
-          julia --color=yes --code-coverage --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-          julia --color=yes --code-coverage --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
+          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We are currently running doctests as part of the `test / julia 1.10` job and additionally in the docs build. https://github.com/Nemocas/AbstractAlgebra.jl/pull/2307 added a flag to disable the latter, but did not use it.

Furthermore, I think we want to error if the pdf build did not produce a valid pdf documentation file (instead of just printing a warning).