### PR TITLE
Fix svg inclusion in html docs

### DIFF
--- a/docs/src/visualizing_types.md
+++ b/docs/src/visualizing_types.md
@@ -13,7 +13,7 @@ The following diagram shows a complete list of all abstract types in
 AbstractAlgebra.jl.
 
 ```@raw html
-<img src="img/parents_diagram.svg" alt="Diagram of parent types"/>
+<img src="../assets/parents_diagram.svg" alt="Diagram of parent types"/>
 ```
 ```@raw latex
 \begin{figure}
@@ -28,7 +28,7 @@ Similarly the following diagram shows a complete list of all abstract types in
 AbstractAlgebra.jl.
 
 ```@raw html
-<img src="img/elements_diagram.svg" alt="Diagram of element types"/>
+<img src="../assets/elements_diagram.svg" alt="Diagram of element types"/>
 ```
 ```@raw latex
 \begin{figure}


### PR DESCRIPTION
This broke in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2324 (by @fingolfin), see https://nemocas.github.io/AbstractAlgebra.jl/dev/visualizing_types/
<img width="769" height="287" alt="image" src="https://github.com/user-attachments/assets/a6f50ccb-5dc2-486d-91f2-b97cc6f7f404" />

This patch fixes it at least for my local build.