### PR TITLE
Third step for linear algebra documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -73,6 +73,7 @@ makedocs(
                  "Working with matrices" => [
                     "matrix_construction.md",
                     "matrix_manipulation.md",
+                    "matrix_predicates.md",
                  ],
                  "matrix_spaces.md",
                  "matrix_algebras.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -70,10 +70,14 @@ makedocs(
              ],
              "Matrices" => [
                  "matrix_introduction.md",
-                 "matrix.md",
+                 "Working with matrices" => [
+                    "matrix_construction.md",
+                 ],
                  "matrix_spaces.md",
-                 "matrix_implementation.md",
                  "matrix_algebras.md",
+                 "Developer documentation" => [
+                    "matrix_implementation.md"
+                 ],
              ],
              "Maps" => [
                  "map_introduction.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -72,6 +72,7 @@ makedocs(
                  "matrix_introduction.md",
                  "Working with matrices" => [
                     "matrix_construction.md",
+                    "matrix_manipulation.md",
                  ],
                  "matrix_spaces.md",
                  "matrix_algebras.md",

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -8,73 +8,11 @@ DocTestSetup = AbstractAlgebra.doctestsetup()
 
 ## Basic matrix functionality
 
-As well as the Ring and Matrix interfaces, the following functions are provided to
-manipulate matrices and to set and retrieve entries and other basic data associated
-with the matrices.
-
-It is possible to create matrices directly, without first
-creating a corresponding matrix space. The following constructors are necessary,
-because unfortunately, Julia's matrices and linear algebra cannot be made to work in
-our context due to two independent problems:
-- In empty matrices (0 rows or columns) all that is known is the type of the matrix entries,
-however for the complex types used in AbstractAlgebra, this information is not sufficient to create elements,
-hence `zero(T)` or friends cannot work
-- Many functions (e.g. `det`) assume that all types used embed into the real or complex numbers,
-in Julia `det(ones(Int, (1,1))) == 1.0`, so the fact that this is exactly the integer `1` is lost.
-Furthermore, more general rings cannot be embedded into the reals at all.
-
-```julia
-matrix(R::Ring, arr::Matrix{T}) where T <: RingElement
-```
-
-Given an $m\times n$ Julia matrix of entries, construct the corresponding
-AbstractAlgebra.jl matrix over the given ring `R`, assuming all the entries can be
-coerced into `R`.
-
-
-```julia
-matrix(R::Ring, r::Int, c::Int, A::Vector{T}) where T <: RingElement
-```
-
-Construct the given $r\times c$ AbstractAlgebra.jl matrix over the ring `R` whose
-$(i, j)$ entry is given by `A[c*(i - 1) + j]`, assuming that all the entries can be
-coerced into `R`.
-
-```julia
-zero_matrix(R::Ring, r::Int, c::Int)
-```
-
-Construct the $r\times c$ AbstractAlgebra.jl zero matrix over the ring `R`.
-
-**Examples**
-
-```jldoctest
-julia> M = matrix(ZZ, BigInt[3 1 2; 2 0 1])
-[3   1   2]
-[2   0   1]
-
-julia> N = matrix(ZZ, 3, 2, BigInt[3, 1, 2, 2, 0, 1])
-[3   1]
-[2   2]
-[0   1]
-
-julia> P = zero_matrix(ZZ, 3, 2)
-[0   0]
-[0   0]
-[0   0]
-```
-
 ```@docs
 number_of_rows(::MatElem)
 number_of_columns(::MatElem)
 length(::MatrixElem{T}) where T <: RingElement
 isempty(::MatrixElem{T}) where T <: RingElement
-identity_matrix(::Ring, ::Int)
-identity_matrix(::MatElem{T}) where T <: RingElement
-ones_matrix(::Ring, ::Int, ::Int)
-scalar_matrix(R::Ring, n::Int, a::RingElement)
-diagonal_matrix(::RingElement, ::Int, ::Int)
-diagonal_matrix(::NCRing, ::AbstractVector{<:NCRingElement})
 zero(::MatElem{T}, ::Ring) where T <: RingElement
 one(::MatElem{T}) where T <: RingElement
 transpose(::MatElem)
@@ -82,10 +20,6 @@ transpose!(::MatElem)
 tr(::MatElem{T}) where T <: RingElement
 det(::MatElem{T}) where T <: RingElem
 rank(::MatElem{T}) where T <: RingElem
-lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-strictly_lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-strictly_upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
 is_lower_triangular(::MatElem)
 is_upper_triangular(::MatElem)
 is_diagonal(::MatElem)
@@ -288,44 +222,6 @@ julia> Q = vcat(M, N)
 ## Linear solving
 
 See [Linear Solving & Kernel](@ref solving_chapter)
-
-## Block diagonal matrix constructors
-
-It is also possible to create block diagonal matrices from a vector of
-existing matrices. It is also possible to construct them from Julia
-matrices if one supplies the base ring.
-
-Note that if the input matrices are not square, the output matrix may
-not be square.
-
-```@docs
-block_diagonal_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
-block_diagonal_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
-```
-
-**Examples**
-
-```jldoctest
-julia> block_diagonal_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
-[1   2   0   0   0]
-[3   4   0   0   0]
-[0   0   4   5   6]
-[0   0   7   8   9]
-
-julia> M = matrix(ZZ, [1 2; 3 4])
-[1   2]
-[3   4]
-
-julia> N = matrix(ZZ, [4 5 6; 7 8 9])
-[4   5   6]
-[7   8   9]
-
-julia> block_diagonal_matrix([M, N])
-[1   2   0   0   0]
-[3   4   0   0   0]
-[0   0   4   5   6]
-[0   0   7   8   9]
-```
 
 ## Similar and zero
 

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -12,7 +12,6 @@ DocTestSetup = AbstractAlgebra.doctestsetup()
 number_of_rows(::MatElem)
 number_of_columns(::MatElem)
 length(::MatrixElem{T}) where T <: RingElement
-isempty(::MatrixElem{T}) where T <: RingElement
 zero(::MatElem{T}, ::Ring) where T <: RingElement
 one(::MatElem{T}) where T <: RingElement
 transpose(::MatElem)
@@ -20,9 +19,6 @@ transpose!(::MatElem)
 tr(::MatElem{T}) where T <: RingElement
 det(::MatElem{T}) where T <: RingElem
 rank(::MatElem{T}) where T <: RingElem
-is_lower_triangular(::MatElem)
-is_upper_triangular(::MatElem)
-is_diagonal(::MatElem)
 change_base_ring(::Ring, ::MatElem{T}) where T <: RingElement
 ```
 
@@ -30,8 +26,6 @@ change_base_ring(::Ring, ::MatElem{T}) where T <: RingElement
 
 ```@docs; canonical=false
 Base.inv(::MatElem{T}) where T <: RingElement
-is_invertible(::MatElem{T}) where T <: RingElement
-is_invertible_with_inverse(::MatElem{T}) where T <: RingElement
 pseudo_inv(M::MatElem{T}) where T <: RingElement
 ```
 
@@ -269,9 +263,6 @@ julia> r, d, P, L, U = fflu(M)
 ```@docs; canonical=false
 rref_rational(::MatElem{T}) where T <: RingElem
 rref(::MatElem{T}) where T <: FieldElem
-
-is_rref(::MatElem{T}) where T <: RingElem
-is_rref(::MatElem{T}) where T <: FieldElem
 ```
 
 **Examples**
@@ -302,16 +293,6 @@ true
 
 ## Other functionality
 
-### Symmetry testing
-
-```@docs
-is_symmetric(::MatElem)
-
-is_skew_symmetric(::MatElem)
-
-is_alternating(::MatElem)
-```
-
 ### Powering
 
 ```@docs
@@ -334,12 +315,6 @@ content(::MatElem{T}) where T <: RingElement
 
 ```@docs
 *(::Perm, ::MatElem{T}) where T <: RingElement
-```
-
-### Nilpotency
-
-```@docs
-is_nilpotent(::MatElem{T}) where {T <: RingElement}
 ```
 
 ### Minors
@@ -396,8 +371,6 @@ nullspace(::MatElem{T}) where T <: FieldElem
 
 ```@docs; canonical=false
 hessenberg(::MatElem{T}) where T <: RingElem
-
-is_hessenberg(::MatElem{T}) where T <: RingElem
 ```
 
 **Examples**
@@ -444,8 +417,6 @@ similarity!(::MatElem{T}, ::Int, ::T) where T <: RingElem
 ```@docs
 hnf(::MatElem{T}) where T <: RingElem
 hnf_with_transform(::MatElem{T}) where T <: RingElem
-
-is_hnf(::MatElem{T}) where T <: RingElem
 ```
 
 **Examples**
@@ -476,8 +447,6 @@ julia> U*A
 ### Smith normal form
 
 ```@docs
-is_snf(::MatElem{T}) where T <: RingElement
-
 snf(::MatElem{T}) where T <: RingElem
 snf_with_transform(::MatElem{T}) where T <: RingElem
 ```
@@ -510,8 +479,6 @@ AbstractAlgebra.jl provides algorithms for computing the (weak) Popov of a matri
 entries in a univariate polynomial ring over a field.
 
 ```@docs
-is_weak_popov(P::MatrixElem{T}, rank::Int) where T <: Generic.Poly
-
 weak_popov(::MatElem{T}) where T <: PolyRingElem
 weak_popov_with_transform(::MatElem{T}) where T <: PolyRingElem
 popov(::MatElem{T}) where T <: PolyRingElem

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -24,8 +24,6 @@ is_lower_triangular(::MatElem)
 is_upper_triangular(::MatElem)
 is_diagonal(::MatElem)
 change_base_ring(::Ring, ::MatElem{T}) where T <: RingElement
-Base.map(f, ::MatrixElem{T}) where T <: RingElement
-Base.map!(f, ::MatrixElem{S}, ::MatrixElem{T}) where {S <: RingElement, T <: RingElement}
 ```
 
 ## Inverse
@@ -120,58 +118,6 @@ julia> R = N1*N2
 [20   29]
 ```
 
-## Elementary row and column operations
-
-```@docs
-add_column(::MatElem{T}, ::Int, ::Int, ::Int) where T <: RingElement
-add_column!(::MatElem{T}, ::Int, ::Int, ::Int) where T <: RingElement
-add_row(::MatElem{T}, ::Int, ::Int, ::Int) where T <: RingElement
-add_row!(::MatElem{T}, ::Int, ::Int, ::Int) where T <: RingElement
-multiply_column(::MatElem{T}, ::Int, ::Int) where T <: RingElement
-multiply_column!(::MatElem{T}, ::Int, ::Int) where T <: RingElement
-multiply_row(::MatElem{T}, ::Int, ::Int) where T <: RingElement
-multiply_row!(::MatElem{T}, ::Int, ::Int) where T <: RingElement
-```
-
-**Examples**
-```jldoctest
-julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
-[1   2   3]
-[2   3   4]
-[4   5   5]
-
-julia> add_column(M, 2, 3, 1)
-[ 7   2   3]
-[10   3   4]
-[14   5   5]
-
-julia> add_row(M, 1, 2, 3)
-[1   2   3]
-[2   3   4]
-[6   8   9]
-
-julia> multiply_column(M, 2, 3)
-[1   2    6]
-[2   3    8]
-[4   5   10]
-
-julia> multiply_row(M, 2, 3)
-[1    2    3]
-[2    3    4]
-[8   10   10]
-```
-
-## Swapping rows and columns
-
-```@docs
-swap_rows(a::MatElem{T}, i::Int, j::Int) where T <: RingElement
-swap_rows!(a::MatElem{T}, i::Int, j::Int) where T <: RingElement
-swap_cols(a::MatElem{T}, i::Int, j::Int) where T <: RingElement
-swap_cols!(a::MatElem{T}, i::Int, j::Int) where T <: RingElement
-```
-
-Swap the rows of `M` in place. The function returns the mutated matrix (since
-matrices are assumed to be mutable in AbstractAlgebra.jl).
 
 ## Concatenation
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -198,7 +198,7 @@ julia> block_diagonal_matrix([M, N])
 
 ## Triangular matrices
 
-Create (strictly) trianngular matrices over the ring `R`.
+Create (strictly) triangular matrices over the ring `R`.
 
 Why does this not require the ring as an argument?
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -100,24 +100,13 @@ identity_matrix(M::MatElem{T}, n::Int) where T <: NCRingElement
 identity_matrix(::Type{MatElem}, R::Ring, n::Int)
 ```
 
-### Scalar matrices
 
-Create the $n \times n$ diagonal matrix over the ring `R`, whose diagonal entries are all
-equal to the image of `a` in `R`.
+### Scalar matrices
 
 ```@docs
 scalar_matrix(R::Ring, n::Int, a::RingElement)
+scalar_matrix(n::Int, a::NCRingElement)
 ```
-
-**Examples**
-
-```jldoctest
-julia> scalar_matrix(QQ, 3, 1//2)
-[1//2   0//1   0//1]
-[0//1   1//2   0//1]
-[0//1   0//1   1//2]
-```
-
 
 
 ### Diagonal matrices

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 DocTestSetup = AbstractAlgebra.doctestsetup()
 ```
 
-# [Constructing Matrices](@id matrix_construction)
+# [Constructing Algebraic Matrices](@id matrix_construction)
 
 
 ## Why Julia matrices are not sufficient

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -10,6 +10,8 @@ There are several functions for creating algebraic matrices -- in each case you 
 ring to which the matrix elements belong, unless this is already unambiguously indicated
 by the ring to which the arguments belong.  Here we present several of the basic functions for
 constructing matrices.
+
+
 ## Why Julia matrices are not sufficient
 
 Unfortunately, Julia's matrices cannot be used in our context due to two independent problems:

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -1,0 +1,230 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
+
+# [Constructing Matrices](@id matrix_construction)
+
+
+## Why Julia matrices are not sufficient
+
+Unfortunately, Julia's matrices cannot be used in our context due to two independent problems:
+
+- In empty matrices (0 rows or columns) all that is known about a Julia matrix is the type of its entries,
+however for the complex algebraic types, this information is not sufficient to create elements,
+hence `zero(T)` or friends cannot work.
+- Many Julia functions (e.g. `det`) assume that all types used embed into the real or complex numbers. For
+instance, in Julia `det(ones(Int, (1,1))) == 1.0`, so the fact that the determinant is exactly the integer `1`
+is lost. Furthermore, more general rings cannot be embedded into the reals at all.
+
+For this reason, the matrix constructors below must accept (or infer) the ring in which all entries of the
+matrix reside.
+
+
+## Generic constructors
+
+Given an $r \times c$ Julia matrix, the following command constructs the corresponding
+matrix over the given ring `R`, assuming all the entries can be coerced into `R`.
+
+```julia
+matrix(R::Ring, arr::Matrix{T}) where T <: RingElement
+```
+
+Likewise, we construct the $r \times c$ matrix over the ring `R` whose $(i, j)$ entry is
+given by `A[c*(i - 1) + j]`, assuming that all the entries can be coerced into `R`, as
+follows:
+
+```julia
+matrix(R::Ring, r::Int, c::Int, A::Vector{T}) where T <: RingElement
+```
+
+**Examples**
+
+```jldoctest
+julia> M = matrix(ZZ, BigInt[3 1 2; 2 0 1])
+[3   1   2]
+[2   0   1]
+
+julia> N = matrix(ZZ, 3, 2, BigInt[3, 1, 2, 2, 0, 1])
+[3   1]
+[2   2]
+[0   1]
+```
+
+
+## Special constructors
+
+### The zero matrix
+
+Construct the $r \times c$ matrix over the ring `R` whose entries are all zero in `R`.
+
+```julia
+zero_matrix(R::Ring, r::Int, c::Int)
+```
+
+**Examples**
+
+```jldoctest
+julia> P = zero_matrix(ZZ, 3, 2)
+[0   0]
+[0   0]
+[0   0]
+```
+
+
+### The identity matrix
+
+Create the $n \times n$ identity matrix over the ring `R`.
+
+```@docs
+identity_matrix(::Ring, ::Int)
+```
+
+**Examples**
+
+```jldoctest
+julia> identity_matrix(ZZ, 2)
+[1   0]
+[0   1]
+```
+
+
+### The ones matrix
+
+Create the $r \times c$ matrix over the unital ring `R` whose entries are
+all equal to the multiplicative identity of `R`.
+
+```@docs
+ones_matrix(::Ring, ::Int, ::Int)
+```
+
+**Examples**
+
+```jldoctest
+julia> I = ones_matrix(ZZ, 3, 2)
+[1   1]
+[1   1]
+[1   1]
+```
+
+
+### Scalar matrices
+
+Create the $n \times n$ matrix over the ring `R`, whose entries are all
+identical to a given scalar `a` in `R`.
+
+```@docs
+scalar_matrix(R::Ring, n::Int, a::RingElement)
+```
+
+**Examples**
+
+```jldoctest
+julia> scalar_matrix(QQ, 3, 1//2)
+[1//2      0      0]
+[   0   1//2      0]
+[   0      0   1//2]
+```
+
+
+
+### Diagonal matrices
+
+Create a matrix over the ring `R` whose entries are all zero except for
+the diagonal entries. Two constructors are provided. One creates a rectangular
+diagonal matrix whose diagonal entries are all equal to a given scalar. The
+other constructs a diagonal matrix whose diagonal entries are taken from a given
+vector.
+
+```@docs
+diagonal_matrix(::RingElement, ::Int, ::Int)
+diagonal_matrix(::NCRing, ::AbstractVector{<:NCRingElement})
+```
+
+**Examples**
+
+```jldoctest
+julia> diagonal_matrix(1, 3, 4)
+[1   0   0   0]
+[0   1   0   0]
+[0   0   1   0]
+
+julia> diagonal_matrix(ZZ, [1,2,3])
+[1   0   0]
+[0   2   0]
+[0   0   3]
+```
+
+
+
+## Block diagonal matrix constructors
+
+Create block diagonal matrices from a vector of existing matrices.
+If Julia matrices are provided, one also has to supply the base ring.
+
+Note that if the input matrices are not square, the output matrix may
+not be square.
+
+```@docs
+block_diagonal_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
+block_diagonal_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
+```
+
+**Examples**
+
+```jldoctest
+julia> block_diagonal_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> N = matrix(ZZ, [4 5 6; 7 8 9])
+[4   5   6]
+[7   8   9]
+
+julia> block_diagonal_matrix([M, N])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+```
+
+
+## Triangular matrices
+
+Create (strictly) trianngular matrices over the ring `R`.
+
+Why does this not require the ring as an argument?
+
+```@docs
+lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
+upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
+strictly_lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
+strictly_upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
+```
+
+**Examples**
+
+```jldoctest
+julia> lower_triangular_matrix([1, 2, 3])
+[1   0]
+[2   3]
+
+julia> strictly_lower_triangular_matrix([5])
+[0   0]
+[5   0]
+
+julia> upper_triangular_matrix([3, 2, 1])
+[3   2]
+[0   1]
+
+julia> strictly_upper_triangular_matrix([-2])
+[0   -2]
+[0   0]
+```

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -112,7 +112,7 @@ julia> I = ones_matrix(ZZ, 3, 2)
 ### Scalar matrices
 
 Create the $n \times n$ diagonal matrix over the ring `R`, whose diagonal entries are all
-identical to a given scalar `a` in `R`.
+equal to the image of `a` in `R`.
 
 ```@docs
 scalar_matrix(R::Ring, n::Int, a::RingElement)

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -112,8 +112,7 @@ scalar_matrix(n::Int, a::NCRingElement)
 ### Diagonal matrices
 
 ```@docs
-diagonal_matrix(x::NCRingElement, m::Int, n::Int)
-diagonal_matrix(x::NCRingElement, m::Int)
+diagonal_matrix(x::NCRingElement, m::Int, n::Int = m)
 diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
 ```
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -226,5 +226,5 @@ julia> upper_triangular_matrix([3, 2, 1])
 
 julia> strictly_upper_triangular_matrix([-2])
 [0   -2]
-[0   0]
+[0    0]
 ```

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -132,7 +132,7 @@ julia> scalar_matrix(QQ, 3, 1//2)
 ### Diagonal matrices
 
 Create a matrix over the ring `R` whose entries are all zero except for
-the diagonal entries. Two constructors are provided. One creates a rectangular
+the diagonal entries. Two constructors are provided. One function creates a rectangular
 diagonal matrix whose diagonal entries are all equal to a given scalar. The
 other constructs a diagonal matrix whose diagonal entries are taken from a given
 vector.

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -79,6 +79,13 @@ zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int)
 ```
 
 
+### The ones matrix
+
+```@docs
+ones_matrix(R::NCRing, r::Int, c::Int)
+```
+
+
 ### The identity matrix
 
 Create the $n \times n$ identity matrix over the ring `R`.
@@ -93,25 +100,6 @@ identity_matrix(::Ring, ::Int)
 julia> identity_matrix(ZZ, 2)
 [1   0]
 [0   1]
-```
-
-
-### The ones matrix
-
-Create the $r \times c$ matrix over the ring `R` whose entries are
-all equal to the multiplicative identity of `R`.
-
-```@docs
-ones_matrix(::Ring, ::Int, ::Int)
-```
-
-**Examples**
-
-```jldoctest
-julia> I = ones_matrix(ZZ, 3, 2)
-[1   1]
-[1   1]
-[1   1]
 ```
 
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -88,20 +88,17 @@ ones_matrix(R::NCRing, r::Int, c::Int)
 
 ### The identity matrix
 
-Create the $n \times n$ identity matrix over the ring `R`.
-
 ```@docs
-identity_matrix(::Ring, ::Int)
+identity_matrix(R::NCRing, n::Int)
+identity_matrix(M::MatElem{T}) where T <: NCRingElement
 ```
 
-**Examples**
+The following additional signatures are also supported:
 
-```jldoctest
-julia> identity_matrix(ZZ, 2)
-[1   0]
-[0   1]
+```julia
+identity_matrix(M::MatElem{T}, n::Int) where T <: NCRingElement
+identity_matrix(::Type{MatElem}, R::Ring, n::Int)
 ```
-
 
 ### Scalar matrices
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -111,7 +111,7 @@ julia> I = ones_matrix(ZZ, 3, 2)
 
 ### Scalar matrices
 
-Create the $n \times n$ matrix over the ring `R`, whose entries are all
+Create the $n \times n$ diagonal matrix over the ring `R`, whose diagonal entries are all
 identical to a given scalar `a` in `R`.
 
 ```@docs

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -25,7 +25,7 @@ matrix reside.
 ## Generic constructors
 
 Given an $r \times c$ Julia matrix, the following command constructs the corresponding
-matrix over the given ring `R`, assuming all the entries can be coerced into `R`.
+matrix over the given ring `R`, provided that all the entries can be coerced into `R`.
 
 ```julia
 matrix(R::Ring, arr::Matrix{T}) where T <: RingElement

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -135,33 +135,9 @@ block_diagonal_matrix(R::NCRing, V::Vector{<:Matrix{T}}) where {T <: NCRingEleme
 
 ## Triangular matrices
 
-Create (strictly) triangular matrices over the ring `R`.
-
-Why does this not require the ring as an argument?
-
 ```@docs
-lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-strictly_lower_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-strictly_upper_triangular_matrix(L::AbstractVector{T}) where {T <: RingElement}
-```
-
-**Examples**
-
-```jldoctest
-julia> lower_triangular_matrix([1, 2, 3])
-[1   0]
-[2   3]
-
-julia> strictly_lower_triangular_matrix([5])
-[0   0]
-[5   0]
-
-julia> upper_triangular_matrix([3, 2, 1])
-[3   2]
-[0   1]
-
-julia> strictly_upper_triangular_matrix([-2])
-[0   -2]
-[0    0]
+lower_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
+upper_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
+strictly_lower_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
+strictly_upper_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
 ```

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -68,19 +68,14 @@ matrix(R::NCRing, arr::AbstractVector{<:AbstractVector})
 
 ### The zero matrix
 
-Construct the $r \times c$ matrix over the ring `R` whose entries are all zero.
-
-```julia
-zero_matrix(R::Ring, r::Int, c::Int)
+```@docs
+zero_matrix(R::NCRing, r::Int, c::Int)
 ```
 
-**Examples**
+The following convenience method is also supported:
 
-```jldoctest
-julia> P = zero_matrix(ZZ, 3, 2)
-[0   0]
-[0   0]
-[0   0]
+```julia
+zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int)
 ```
 
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -122,9 +122,9 @@ scalar_matrix(R::Ring, n::Int, a::RingElement)
 
 ```jldoctest
 julia> scalar_matrix(QQ, 3, 1//2)
-[1//2      0      0]
-[   0   1//2      0]
-[   0      0   1//2]
+[1//2   0//1   0//1]
+[0//1   1//2   0//1]
+[0//1   0//1   1//2]
 ```
 
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -134,7 +134,7 @@ julia> scalar_matrix(QQ, 3, 1//2)
 Create a matrix over the ring `R` whose entries are all zero except for
 the diagonal entries. Two constructors are provided. One function creates a rectangular
 diagonal matrix whose diagonal entries are all equal to a given scalar. The
-other constructs a diagonal matrix whose diagonal entries are taken from a given
+other constructs a square diagonal matrix whose diagonal entries are taken from a given
 vector.
 
 ```@docs

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -104,7 +104,7 @@ identity_matrix(::Type{MatElem}, R::Ring, n::Int)
 ### Scalar matrices
 
 ```@docs
-scalar_matrix(R::Ring, n::Int, a::RingElement)
+scalar_matrix(R::NCRing, n::Int, a::NCRingElement)
 scalar_matrix(n::Int, a::NCRingElement)
 ```
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -8,7 +8,7 @@ DocTestSetup = AbstractAlgebra.doctestsetup()
 
 There are several functions for creating algebraic matrices -- in each case you need to indicate the
 ring to which the matrix elements belong, unless this is already unambiguously indicated
-by the ring to which the arguments belong.  Here we present several of the basic functions for
+by the ring to which the arguments belong. Here we present several of the basic functions for
 constructing matrices.
 
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -111,31 +111,11 @@ scalar_matrix(n::Int, a::NCRingElement)
 
 ### Diagonal matrices
 
-Create a matrix over the ring `R` whose entries are all zero except for
-the diagonal entries. Two constructors are provided. One function creates a rectangular
-diagonal matrix whose diagonal entries are all equal to a given scalar. The
-other constructs a square diagonal matrix whose diagonal entries are taken from a given
-vector.
-
 ```@docs
-diagonal_matrix(::RingElement, ::Int, ::Int)
-diagonal_matrix(::NCRing, ::AbstractVector{<:NCRingElement})
+diagonal_matrix(x::NCRingElement, m::Int, n::Int)
+diagonal_matrix(x::NCRingElement, m::Int)
+diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
 ```
-
-**Examples**
-
-```jldoctest
-julia> diagonal_matrix(ZZ(1), 3, 4)
-[1   0   0   0]
-[0   1   0   0]
-[0   0   1   0]
-
-julia> diagonal_matrix(ZZ, [1,2,3])
-[1   0   0]
-[0   2   0]
-[0   0   3]
-```
-
 
 
 ## Block diagonal matrix constructors

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -160,7 +160,7 @@ julia> diagonal_matrix(ZZ, [1,2,3])
 
 ## Block diagonal matrix constructors
 
-Create block diagonal matrices from a vector of existing matrices.
+Create a block diagonal matrix from a vector of existing matrices.
 If Julia matrices are provided, one also has to supply the base ring.
 
 Note that if the input matrices are not square, the output matrix may

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -92,7 +92,7 @@ julia> identity_matrix(ZZ, 2)
 
 ### The ones matrix
 
-Create the $r \times c$ matrix over the unital ring `R` whose entries are
+Create the $r \times c$ matrix over the ring `R` whose entries are
 all equal to the multiplicative identity of `R`.
 
 ```@docs

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -117,42 +117,19 @@ diagonal_matrix(x::NCRingElement, m::Int)
 diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
 ```
 
+Diagonal matrices can also be constructed from matrix blocks. This is
+an alias for `block_diagonal_matrix`.
+
+```@docs
+diagonal_matrix(V::Vector{T}) where {T <: MatElem}
+```
+
 
 ## Block diagonal matrix constructors
 
-Create a block diagonal matrix from a vector of existing matrices.
-If Julia matrices are provided, one also has to supply the base ring.
-
-Note that if the input matrices are not square, the output matrix may
-not be square.
-
 ```@docs
-block_diagonal_matrix(::Vector{<:MatElem{T}}) where T <: RingElement
-block_diagonal_matrix(::Ring, ::Vector{<:Matrix{T}}) where T <: RingElement
-```
-
-**Examples**
-
-```jldoctest
-julia> block_diagonal_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
-[1   2   0   0   0]
-[3   4   0   0   0]
-[0   0   4   5   6]
-[0   0   7   8   9]
-
-julia> M = matrix(ZZ, [1 2; 3 4])
-[1   2]
-[3   4]
-
-julia> N = matrix(ZZ, [4 5 6; 7 8 9])
-[4   5   6]
-[7   8   9]
-
-julia> block_diagonal_matrix([M, N])
-[1   2   0   0   0]
-[3   4   0   0   0]
-[0   0   4   5   6]
-[0   0   7   8   9]
+block_diagonal_matrix(V::Vector{<:MatElem{T}}) where {T <: NCRingElement}
+block_diagonal_matrix(R::NCRing, V::Vector{<:Matrix{T}}) where {T <: NCRingElement}
 ```
 
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -34,7 +34,7 @@ matrix over the given ring `R`, provided that all the entries can be coerced int
 matrix(R::Ring, arr::Matrix{T}) where T <: RingElement
 ```
 
-Likewise, we construct the $r \times c$ matrix over the ring `R` whose $(i, j)$ entry is
+We can construct row-wise the $r \times c$ matrix over the ring `R` whose $(i, j)$ entry is
 given by `A[c*(i - 1) + j]`, provided that all the entries can be coerced into `R`, as
 follows:
 

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -17,7 +17,7 @@ constructing matrices.
 Unfortunately, Julia's matrices cannot be used in our context due to two independent problems:
 
 - In empty matrices (0 rows or columns) all that is known about a Julia matrix is the type of its entries,
-however for the complex algebraic types, this information is not sufficient to create elements,
+however for advanced algebraic types, this information is insufficient to create elements,
 hence `zero(T)` or friends cannot work.
 - Many Julia functions (e.g. `det`) assume that all types used embed into the real or complex numbers. For
 instance, in Julia `det(ones(Int, (1,1))) == 1.0`, so the fact that the determinant is exactly the integer `1`

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -57,7 +57,7 @@ julia> N = matrix(ZZ, 3, 2, BigInt[3, 1, 2, 2, 0, 1])
 
 ### The zero matrix
 
-Construct the $r \times c$ matrix over the ring `R` whose entries are all zero in `R`.
+Construct the $r \times c$ matrix over the ring `R` whose entries are all zero.
 
 ```julia
 zero_matrix(R::Ring, r::Int, c::Int)

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -6,7 +6,10 @@ DocTestSetup = AbstractAlgebra.doctestsetup()
 
 # [Constructing Algebraic Matrices](@id matrix_construction)
 
-
+There are several functions for creating algebraic matrices -- in each case you need to indicate the
+ring to which the matrix elements belong, unless this is already unambiguously indicated
+by the ring to which the arguments belong.  Here we present several of the basic functions for
+constructing matrices.
 ## Why Julia matrices are not sufficient
 
 Unfortunately, Julia's matrices cannot be used in our context due to two independent problems:

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -32,7 +32,7 @@ matrix(R::Ring, arr::Matrix{T}) where T <: RingElement
 ```
 
 Likewise, we construct the $r \times c$ matrix over the ring `R` whose $(i, j)$ entry is
-given by `A[c*(i - 1) + j]`, assuming that all the entries can be coerced into `R`, as
+given by `A[c*(i - 1) + j]`, provided that all the entries can be coerced into `R`, as
 follows:
 
 ```julia

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -145,7 +145,7 @@ diagonal_matrix(::NCRing, ::AbstractVector{<:NCRingElement})
 **Examples**
 
 ```jldoctest
-julia> diagonal_matrix(1, 3, 4)
+julia> diagonal_matrix(ZZ(1), 3, 4)
 [1   0   0   0]
 [0   1   0   0]
 [0   0   1   0]

--- a/docs/src/matrix_construction.md
+++ b/docs/src/matrix_construction.md
@@ -29,32 +29,38 @@ matrix reside.
 
 ## Generic constructors
 
-Given an $r \times c$ Julia matrix, the following command constructs the corresponding
-matrix over the given ring `R`, provided that all the entries can be coerced into `R`.
-
-```julia
-matrix(R::Ring, arr::Matrix{T}) where T <: RingElement
+```@docs
+matrix(R::NCRing, arr::AbstractMatrix{T}) where {T}
+matrix(R::NCRing, r::Int, c::Int, arr::AbstractVecOrMat{T}) where {T}
 ```
 
-We can construct row-wise the $r \times c$ matrix over the ring `R` whose $(i, j)$ entry is
-given by `A[c*(i - 1) + j]`, provided that all the entries can be coerced into `R`, as
-follows:
+Several other signatures are supported. Existing matrices can be converted
+to a different base ring:
 
 ```julia
-matrix(R::Ring, r::Int, c::Int, A::Vector{T}) where T <: RingElement
+matrix(R::NCRing, arr::MatElem)
+matrix(R::NCRing, arr::MatRingElem)
 ```
 
-**Examples**
+We can also create a deep copy of an existing algebraic matrix:
 
-```jldoctest
-julia> M = matrix(ZZ, BigInt[3 1 2; 2 0 1])
-[3   1   2]
-[2   0   1]
+```julia
+matrix(mat::MatElem{T}) where {T<:NCRingElement}
+```
 
-julia> N = matrix(ZZ, 3, 2, BigInt[3, 1, 2, 2, 0, 1])
-[3   1]
-[2   2]
-[0   1]
+The base ring can also be inferred from the entries:
+
+```julia
+matrix(arr::AbstractMatrix{T}) where {T<:NCRingElement}
+matrix(arr::AbstractVector{T}) where {T<:NCRingElement}
+matrix(arr::AbstractVector{<:AbstractVector{T}}) where {T<:NCRingElement}
+```
+
+Finally, nested vectors can be used to construct matrices over a specified
+base ring:
+
+```julia
+matrix(R::NCRing, arr::AbstractVector{<:AbstractVector})
 ```
 
 

--- a/docs/src/matrix_manipulation.md
+++ b/docs/src/matrix_manipulation.md
@@ -1,0 +1,48 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
+
+# [Manipulating algebraic matrices](@id matrix_manipulation)
+
+This page describes functions for modifying or rearranging algebraic matrices.
+Many operations are available both as in-place and non-mutating variants.
+
+
+## Entry-wise operations
+
+```@docs
+map_entries(f, a::MatElem{T}) where T <: NCRingElement
+map_entries!(f, dst::MatElem{T}, src::MatElem{U}) where {T <: NCRingElement, U <: NCRingElement}
+Base.map(f, a::MatrixElem{T}) where T <: NCRingElement
+Base.map!(f, dst::MatrixElem{T}, src::MatrixElem{U}) where {T <: NCRingElement, U <: NCRingElement}
+```
+
+
+## Elementary row and column operations
+
+```@docs
+add_column(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
+add_column!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
+add_row(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
+add_row!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
+multiply_column(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
+multiply_column!(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
+multiply_row(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
+multiply_row!(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
+```
+
+
+## Swapping and reversing rows and columns
+
+```@docs
+swap_rows(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
+swap_rows!(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
+swap_cols(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
+swap_cols!(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
+reverse_rows(a::MatElem{T}) where T <: NCRingElement
+reverse_rows!(a::MatElem{T}) where T <: NCRingElement
+reverse_cols(a::MatElem{T}) where T <: NCRingElement
+reverse_cols!(a::MatElem{T}) where T <: NCRingElement
+```

--- a/docs/src/matrix_predicates.md
+++ b/docs/src/matrix_predicates.md
@@ -1,0 +1,68 @@
+```@meta
+CurrentModule = AbstractAlgebra
+CollapsedDocStrings = true
+DocTestSetup = AbstractAlgebra.doctestsetup()
+```
+
+# [Matrix predicates](@id matrix_predicates)
+
+This page collects predicates, i.e. functions returning `true` or `false`,
+for testing whether matrices satisfy certain structural or normal-form conditions.
+
+
+## Basic predicates
+
+Algebraic matrices support `iszero` and `isone` for testing whether a matrix
+is the zero matrix or the identity matrix, respectively.
+
+```@docs
+isempty(a::MatrixElem{T}) where {T <: NCRingElement}
+Base.isassigned(a::MatrixElem{T}, i::Int, j::Int) where {T <: NCRingElement}
+is_zero_row(M::Union{Matrix,MatrixElem}, i::Int)
+is_zero_column(M::Union{Matrix,MatrixElem}, j::Int)
+```
+
+
+## Triangular and diagonal matrices
+
+```@docs
+is_lower_triangular(M::MatElem)
+is_upper_triangular(M::MatElem)
+is_diagonal(A::MatElem)
+is_hessenberg(A::MatElem{T}) where {T <: RingElement}
+```
+
+
+## Invertibility
+
+```@docs
+is_invertible_with_inverse(A::MatrixElem{T}; side::Symbol = :left) where {T <: RingElement}
+is_invertible(A::MatElem{T}) where {T <: RingElement}
+```
+
+
+## Symmetry
+
+```@docs
+is_symmetric(M::MatElem)
+is_skew_symmetric(M::MatElem)
+is_alternating(M::MatElem)
+```
+
+
+## Nilpotency
+
+```@docs
+is_nilpotent(A::MatElem{T}) where {T <: RingElement}
+```
+
+
+## Normal forms
+
+```@docs
+is_rref(M::MatrixElem{T}) where {T <: RingElement}
+is_hnf(M::MatElem{T}) where {T <: RingElement}
+is_snf(A::MatElem{T}) where {T <: RingElement}
+is_weak_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
+is_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
+```

--- a/docs/src/matrix_spaces.md
+++ b/docs/src/matrix_spaces.md
@@ -140,7 +140,7 @@ julia> c = M[1, 1]
 
 ## Inverses
 
-```@docs
+```@docs; canonical=false
 Base.inv(::MatElem{T}) where T <: RingElement
 is_invertible(::MatElem{T}) where T <: RingElement
 is_invertible_with_inverse(::MatElem{T}) where T <: RingElement
@@ -223,7 +223,7 @@ julia> r, d, P, L, U = fflu(A)
 
 ## Reduced row-echelon form
 
-```@docs
+```@docs; canonical=false
 rref_rational(::MatElem{T}) where T <: RingElem
 rref(::MatElem{T}) where T <: FieldElem
 
@@ -369,7 +369,7 @@ julia> P = R[1; 2; t] # create a column vector
 
 ### Hessenberg form
 
-```@docs
+```@docs; canonical=false
 hessenberg(::MatElem{T}) where T <: RingElem
 
 is_hessenberg(::MatElem{T}) where T <: RingElem

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7265,41 +7265,32 @@ end
 ################################################################################
 
 @doc raw"""
-    diagonal_matrix(x::NCRingElement, m::Int, n::Int)
+    diagonal_matrix(x::NCRingElement, m::Int, n::Int = m)
+
 
 Return the $m \times n$ matrix over the ring `parent(x)` with `x` along the
-main diagonal and zeros elsewhere.
+main diagonal and zeros elsewhere. If `n` is omitted, return an $m \times m$
+matrix.
 
 # Examples
 ```jldoctest
 julia> diagonal_matrix(ZZ(2), 2, 3)
 [2   0   0]
 [0   2   0]
-```
-"""
-function diagonal_matrix(x::NCRingElement, m::Int, n::Int)
-   z = zero_matrix(parent(x), m, n)
-   for i in 1:min(m, n)
-      z[i, i] = x
-   end
-   return z
-end
 
-@doc raw"""
-    diagonal_matrix(x::NCRingElement, m::Int)
-
-Return the $m \times m$ matrix over the ring `parent(x)` with `x` along the
-main diagonal and zeros elsewhere.
-
-# Examples
-```jldoctest
 julia> diagonal_matrix(QQ(-1), 3)
 [-1//1    0//1    0//1]
 [ 0//1   -1//1    0//1]
 [ 0//1    0//1   -1//1]
 ```
 """
-diagonal_matrix(x::NCRingElement, m::Int) = diagonal_matrix(x, m, m)
+function diagonal_matrix(x::NCRingElement, m::Int, n::Int = m)
+   z = zero_matrix(parent(x), m, n)
+   for i in 1:min(m, n)
+      z[i, i] = x
+   end
+   return z
+end
 
 @doc raw"""
     diagonal_matrix(R::NCRing, entries::AbstractVector{<:NCRingElement})

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6937,12 +6937,12 @@ julia> N = zero_matrix(ZZ, 2, 2)
 [0   0]
 
 julia> map_entries!(x -> x^2, N, M)
-[ 1    4]
-[ 9   16]
+[1    4]
+[9   16]
 
 julia> N
-[ 1    4]
-[ 9   16]
+[1    4]
+[9   16]
 ```
 """
 function map_entries!(f::S, dst::MatElem{T}, src::MatElem{U}) where {S, T <: NCRingElement, U <: NCRingElement}
@@ -6976,8 +6976,8 @@ julia> M = matrix(ZZ, [1 2; 3 4])
 [3   4]
 
 julia> M2 = map_entries(x -> x^2, M)
-[ 1    4]
-[ 9   16]
+[1    4]
+[9   16]
 ```
 """
 function map_entries(f::S, a::MatElem{T}) where {S, T <: NCRingElement}

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -200,15 +200,53 @@ Return the number of entries in the given matrix.
 length(a::MatrixElem{T}) where T <: NCRingElement = nrows(a) * ncols(a)
 
 @doc raw"""
-    isempty(a::MatrixElem{T}) where T <: NCRingElement
+    isempty(a::MatrixElem{T}) where {T <: NCRingElement}
 
-Return `true` if `a` does not contain any entry (i.e. `length(a) == 0`), and `false` otherwise.
+Return `true` if `a` has no entries, that is, if either the number
+of rows or the number of columns is zero. Otherwise, return `false`.
+
+# Examples
+
+```jldoctest
+julia> A = zero_matrix(ZZ, 0, 3)
+0 by 3 empty matrix
+
+julia> isempty(A)
+true
+
+julia> B = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> isempty(B)
+false
+```
 """
-isempty(a::MatrixElem{T}) where T <: NCRingElement = (nrows(a) == 0) | (ncols(a) == 0)
+isempty(a::MatrixElem{T}) where {T <: NCRingElement} = (nrows(a) == 0) || (ncols(a) == 0)
 
 Base.eltype(::Type{<:MatrixElem{T}}) where {T <: NCRingElement} = T
 
-function Base.isassigned(a::MatrixElem{T}, i, j) where T <: NCRingElement
+@doc raw"""
+    Base.isassigned(a::MatrixElem{T}, i::Int, j::Int) where {T <: NCRingElement}
+
+Return `true` if the matrix `a` has an entry at position `(i, j)`,
+and `false` otherwise.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [3 1 2; 2 0 1])
+[3   1   2]
+[2   0   1]
+
+julia> isassigned(M, 1, 2)
+true
+
+julia> isassigned(M, 4, 4)
+false
+```
+"""
+function Base.isassigned(a::MatrixElem{T}, i, j) where {T <: NCRingElement}
     try
         a[i, j]
         true
@@ -300,8 +338,24 @@ Return `is_negative(M[i,j])`, but possibly more efficiently.
 @doc raw"""
     is_zero_row(M::Union{Matrix,MatrixElem}, i::Int)
 
-Return `true` if the $i$-th row of the matrix $M$ is zero,
-but possibly more efficiently than checking all entries individually.
+Return `true` if the $i$-th row of the matrix $M$ is zero, and `false`
+otherwise.
+
+This may be more efficient than checking all entries individually.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 2 3; 0 0 0])
+[1   2   3]
+[0   0   0]
+
+julia> is_zero_row(M, 1)
+false
+
+julia> is_zero_row(M, 2)
+true
+```
 """
 function is_zero_row(M::Union{Matrix,MatrixElem}, i::Int)
   @boundscheck 1 <= i <= nrows(M) || Base.throw_boundserror(M, (i, 1:ncols(M)))
@@ -316,8 +370,25 @@ end
 @doc raw"""
     is_zero_column(M::Union{Matrix,MatrixElem}, j::Int)
 
-Return `true` if the $j$-th column of the matrix $M$ is zero,
-but possibly more efficiently than checking all entries individually.
+Return `true` if the $j$-th column of the matrix $M$ is zero, and
+`false` otherwise.
+
+This may be more efficient than checking all entries individually.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 0; 2 0; 3 0])
+[1   0]
+[2   0]
+[3   0]
+
+julia> is_zero_column(M, 1)
+false
+
+julia> is_zero_column(M, 2)
+true
+```
 """
 function is_zero_column(M::Union{Matrix,MatrixElem}, j::Int)
   @boundscheck 1 <= j <= ncols(M) || Base.throw_boundserror(M, (1:nrows(M), j))
@@ -1486,7 +1557,7 @@ end
 #
 ###############################################################################
 
-"""
+@doc raw"""
     is_symmetric(M::MatElem)
 
 Return `true` if the given matrix is symmetric with respect to its main
@@ -2251,9 +2322,41 @@ end
 
 @doc raw"""
     is_rref(M::MatrixElem{T}) where {T <: RingElement}
+    is_rref(M::MatrixElem{T}) where {T <: FieldElement}
 
-Return `true` if $M$ is in reduced row echelon form, otherwise return
-`false`.
+Return `true` if $M$ is in reduced row echelon form, and `false`
+otherwise.
+
+For matrices over fields, leading entries are required to be normalized
+to one.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(QQ, [1 0 2; 0 1 3; 0 0 0])
+[1//1   0//1   2//1]
+[0//1   1//1   3//1]
+[0//1   0//1   0//1]
+
+julia> is_rref(A)
+true
+
+julia> B = matrix(QQ, [2 0 4; 0 1 3; 0 0 0])
+[2//1   0//1   4//1]
+[0//1   1//1   3//1]
+[0//1   0//1   0//1]
+
+julia> is_rref(B)
+false
+
+julia> C = matrix(ZZ, [2 0 4; 0 3 6; 0 0 0])
+[2   0   4]
+[0   3   6]
+[0   0   0]
+
+julia> is_rref(C)
+true
+```
 """
 function is_rref(M::MatrixElem{T}) where {T <: RingElement}
    m = nrows(M)
@@ -2279,12 +2382,6 @@ function is_rref(M::MatrixElem{T}) where {T <: RingElement}
    return true
 end
 
-@doc raw"""
-    is_rref(M::MatrixElem{T}) where {T <: FieldElement}
-
-Return `true` if $M$ is in reduced row echelon form, otherwise return
-`false`.
-"""
 function is_rref(M::MatrixElem{T}) where {T <: FieldElement}
    m = nrows(M)
    n = ncols(M)
@@ -2726,12 +2823,32 @@ end
 #
 ###############################################################################
 
-"""
+@doc raw"""
     is_alternating(M::MatElem)
 
-Return whether the form corresponding to the matrix `M` is alternating,
-i.e. `M == -transpose(M)` and `M` has zeros on the diagonal.
-Return `false` if `M` is not a square matrix.
+Return `true` if `M` is alternating, that is, if `M` is skew-symmetric
+and all entries on the main diagonal are zero. Return `false` otherwise.
+
+Non-square matrices are not considered alternating.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [0 2 -3; -2 0 5; 3 -5 0])
+[ 0    2   -3]
+[-2    0    5]
+[ 3   -5    0]
+
+julia> is_alternating(M)
+true
+
+julia> N = matrix(ZZ, [1 2; -2 1])
+[ 1   2]
+[-2   1]
+
+julia> is_alternating(N)
+false
+```
 """
 function is_alternating(M::MatElem)
   is_skew_symmetric(M) || return false
@@ -2741,13 +2858,14 @@ function is_alternating(M::MatElem)
   return true
 end
 
-"""
+@doc raw"""
     is_skew_symmetric(M::MatElem)
 
 Return `true` if the given matrix is skew symmetric with respect to its main
 diagonal, i.e., `transpose(M) == -M`, otherwise return `false`.
 
 # Examples
+
 ```jldoctest
 julia> M = matrix(ZZ, [0 -1 -2; 1 0 -3; 2 3 0])
 [0   -1   -2]
@@ -2756,7 +2874,6 @@ julia> M = matrix(ZZ, [0 -1 -2; 1 0 -3; 2 3 0])
 
 julia> is_skew_symmetric(M)
 true
-
 ```
 """
 function is_skew_symmetric(M::MatElem)
@@ -3722,9 +3839,9 @@ end
 ###############################################################################
 
 @doc raw"""
-    is_upper_triangular(A::MatElem)
+    is_upper_triangular(M::MatElem)
 
-Return `true` if $A$ is an upper triangular matrix, that is,
+Return `true` if $M$ is an upper triangular matrix, that is,
 all entries below the main diagonal are zero. Note that this
 definition also applies to non-square matrices.
 
@@ -3887,9 +4004,9 @@ end
 ###############################################################################
 
 @doc raw"""
-    is_lower_triangular(A::MatElem)
+    is_lower_triangular(M::MatElem)
 
-Return `true` if $A$ is an lower triangular matrix, that is,
+Return `true` if $M$ is a lower triangular matrix, that is,
 all entries above the main diagonal are zero. Note that this
 definition also applies to non-square matrices.
 
@@ -3925,7 +4042,7 @@ end
     is_diagonal(A::MatElem)
 
 Return `true` if $A$ is a diagonal matrix, that is,
-all entries off the main diagonal are zero. Note that this
+if all entries off the main diagonal are zero. Note that this
 definition also applies to non-square matrices.
 
 Alias for `LinearAlgebra.isdiag`.
@@ -4003,18 +4120,60 @@ end
 #
 ###############################################################################
 
+
 @doc raw"""
-    is_invertible_with_inverse(A::MatElem{T}; side::Symbol = :left) where {T <: RingElement}
+    is_invertible_with_inverse(A::MatrixElem{T}; side::Symbol = :left) where {T <: RingElement}
 
-Given an $n \times m$ matrix $A$ over a ring, return a tuple `(flag, B)`. If
-`side` is `:right` and `flag` is `true`, $B$ is a right inverse of $A$ i.e.
-$A B$ is the $n \times n$ unit matrix. If `side` is `:left` and `flag` is
-`true`, $B$ is a left inverse of $A$ i.e. $B A$ is the $m \times m$ unit matrix.
-If `flag` is `false`, no right or left inverse exists.
+Return a tuple `(flag, B)` indicating whether the matrix $A$ has a one-sided
+inverse.
 
-To get the space of all inverses, note that if $B$ and $C$ are both right
-inverses, then $A (B - C) = 0$, and similar for left inverses. Hence from one
-inverse one can find all by making suitable use of [`kernel`](@ref).
+If $A$ is an $n \times m$ matrix and `side == :right`, then `flag` is `true`
+precisely if a right inverse exists. In this case, $B$ is an $m \times n$
+matrix such that $A B$ is the $n \times n$ identity matrix.
+
+If `side == :left`, then `flag` is `true` precisely if a left inverse exists.
+In this case, $B$ is an $m \times n$ matrix such that $B A$ is the
+$m \times m$ identity matrix.
+
+If `flag` is `false`, then no inverse exists on the requested side.
+
+To compute all one-sided inverses from one inverse, use the kernel: if $B$
+and $C$ are both right inverses, then $A(B - C) = 0$, and similarly for left
+inverses.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(QQ, [1 2; 3 4])
+[1//1   2//1]
+[3//1   4//1]
+
+julia> flag, B = is_invertible_with_inverse(A);
+
+julia> flag
+true
+
+julia> B
+[-2//1    1//1]
+[ 3//2   -1//2]
+
+julia> B*A == one(parent(A))
+true
+```
+
+```jldoctest
+julia> A = matrix(QQ, [1 0 0; 0 1 0])
+[1//1   0//1   0//1]
+[0//1   1//1   0//1]
+
+julia> flag, B = is_invertible_with_inverse(A; side = :right);
+
+julia> flag
+true
+
+julia> A*B == one(parent(A*B))
+true
+```
 """
 function is_invertible_with_inverse(A::MatrixElem{T}; side::Symbol = :left) where {T <: RingElement}
    if (side == :left && nrows(A) < ncols(A)) || (side == :right && ncols(A) < nrows(A))
@@ -4030,8 +4189,26 @@ end
 @doc raw"""
     is_invertible(A::MatElem{T}) where {T <: RingElement}
 
-Return true if a given square matrix is invertible, false otherwise. If
-the inverse should also be computed, use `is_invertible_with_inverse`.
+Return `true` if the square matrix $A$ is invertible, and `false`
+otherwise. To also compute an inverse, use [`is_invertible_with_inverse`](@ref).
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> is_invertible(A)
+false
+
+julia> B = matrix(QQ, [1 2; 3 4])
+[1//1   2//1]
+[3//1   4//1]
+
+julia> is_invertible(B)
+true
+```
 """
 is_invertible(A::MatElem{T}) where {T <: RingElement} = is_square(A) && is_unit(det(A))
 
@@ -4172,8 +4349,30 @@ end
 @doc raw"""
     is_nilpotent(A::MatElem{T}) where {T <: RingElement}
 
-Return if `A` is nilpotent, i.e. if there exists a natural number $k$
-such that $A^k = 0$. If `A` is not square an exception is raised.
+Return `true` if `A` is nilpotent, that is, if there exists a positive
+integer $k$ such that $A^k = 0$. Return `false` otherwise.
+
+If `A` is not square, an exception is raised. The test is only supported
+for matrices defined over integral domains.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [0 1 0; 0 0 1; 0 0 0])
+[0   1   0]
+[0   0   1]
+[0   0   0]
+
+julia> is_nilpotent(A)
+true
+
+julia> B = matrix(ZZ, [1 1; 0 1])
+[1   1]
+[0   1]
+
+julia> is_nilpotent(B)
+false
+```
 """
 function is_nilpotent(A::MatElem{T}) where {T <: RingElement}
   is_domain_type(T) || error("Only supported over integral domains")
@@ -4258,7 +4457,29 @@ end
 @doc raw"""
     is_hessenberg(A::MatElem{T}) where {T <: RingElement}
 
-Return `true` if $M$ is in Hessenberg form, otherwise returns `false`.
+Return `true` if $A$ is in (upper) Hessenberg form, that is, if
+all entries below the first subdiagonal are zero, and `false`
+otherwise.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [1 2 3; 4 5 6; 0 7 8])
+[1   2   3]
+[4   5   6]
+[0   7   8]
+
+julia> is_hessenberg(A)
+true
+
+julia> B = matrix(ZZ, [1 2 3; 4 5 6; 7 8 9])
+[1   2   3]
+[4   5   6]
+[7   8   9]
+
+julia> is_hessenberg(B)
+false
+```
 """
 function is_hessenberg(A::MatElem{T}) where {T <: RingElement}
    is_square(A) || return false
@@ -5458,11 +5679,32 @@ function hnf_with_transform(A::MatElem{T}) where {T <: RingElement}
 end
 
 @doc raw"""
-    is_hnf(M::MatElem{T}) where T <: RingElement
+    is_hnf(M::MatElem{T}) where {T <: RingElement}
 
-Return `true` if the matrix is in Hermite normal form.
+Return `true` if the matrix $M$ is in Hermite normal form, and `false`
+otherwise.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [2 3 -1; 3 5 7; 11 1 12])
+[ 2   3   -1]
+[ 3   5    7]
+[11   1   12]
+
+julia> is_hnf(A)
+false
+
+julia> H = hnf(A)
+[1   0   255]
+[0   1    17]
+[0   0   281]
+
+julia> is_hnf(H)
+true
+```
 """
-function is_hnf(M::MatElem{T}) where T <: RingElement
+function is_hnf(M::MatElem{T}) where {T <: RingElement}
    r = nrows(M)
    c = ncols(M)
    row = 1
@@ -5512,11 +5754,28 @@ end
 ###############################################################################
 
 @doc raw"""
-    is_snf(A::MatElem{T}) where T <: RingElement
+    is_snf(A::MatElem{T}) where {T <: RingElement}
 
-Return `true` if $A$ is in Smith Normal Form.
+Return `true` if $A$ is in Smith normal form, and `false` otherwise.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [2 4 4; -6 6 12; 10 -4 -16])
+[ 2    4     4]
+[-6    6    12]
+[10   -4   -16]
+
+julia> S = snf(A)
+[2   0    0]
+[0   6    0]
+[0   0   12]
+
+julia> is_snf(S)
+true
+```
 """
-function is_snf(A::MatElem{T}) where T <: RingElement
+function is_snf(A::MatElem{T}) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    a = A[1, 1]
@@ -5687,11 +5946,31 @@ end
 ################################################################################
 
 @doc raw"""
-    is_weak_popov(P::MatrixElem{T}, rank::Int) where T <: PolyRingElem
+    is_weak_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
 
-Return `true` if $P$ is a matrix in weak Popov form of the given rank.
+Return `true` if $P$ is in weak Popov form with the given rank, and
+`false` otherwise.
+
+# Examples
+
+```jldoctest
+julia> R, x = polynomial_ring(QQ, :x);
+
+julia> A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]));
+
+julia> P = weak_popov(A)
+[   1                        2                    3   x]
+[   0                        0                    0   0]
+[-x^3   -2*x^3 + x^2 - 2*x + 1   -2*x^3 + x^2 - 3*x   1]
+
+julia> is_weak_popov(P, 2)
+true
+
+julia> is_weak_popov(P, 3)
+false
+```
 """
-function is_weak_popov(P::MatrixElem{T}, rank::Int) where T <: PolyRingElem
+function is_weak_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
    zero_rows = 0
    pivots = zeros(ncols(P))
    for r = 1:nrows(P)
@@ -5713,11 +5992,31 @@ function is_weak_popov(P::MatrixElem{T}, rank::Int) where T <: PolyRingElem
 end
 
 @doc raw"""
-    is_popov(P::MatrixElem{T}, rank::Int) where T <: PolyRingElem
+    is_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
 
-Return `true` if $P$ is a matrix in Popov form with the given rank.
+Return `true` if $P$ is in Popov form with the given rank, and `false`
+otherwise.
+
+# Examples
+
+```jldoctest
+julia> R, x = polynomial_ring(QQ, :x);
+
+julia> A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]));
+
+julia> P = popov(A)
+[       0                           0                         0       0]
+[       1                           2                         3       x]
+[1//2*x^3   x^3 - 1//2*x^2 + x - 1//2   x^3 - 1//2*x^2 + 3//2*x   -1//2]
+
+julia> is_popov(P, 1)
+false
+
+julia> is_popov(P, 2)
+true
+```
 """
-function is_popov(P::MatrixElem{T}, rank::Int) where T <: PolyRingElem
+function is_popov(P::MatrixElem{T}, rank::Int) where {T <: PolyRingElem}
    zero_rows = 0
    for r = 1:nrows(P)
       p = find_pivot_popov(P, r)

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6386,10 +6386,12 @@ end
 @doc raw"""
     swap_rows(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
 
-Return a matrix $b$ with the entries of $a$, where the $i$-th and $j$-th
-rows are swapped.
+Return a new matrix obtained from `a` by swapping the `i`-th and `j`-th rows.
+
+The original matrix `a` remains unchanged.
 
 # Examples
+
 ```jldoctest
 julia> M = identity_matrix(ZZ, 3)
 [1   0   0]
@@ -6401,7 +6403,7 @@ julia> swap_rows(M, 1, 2)
 [1   0   0]
 [0   0   1]
 
-julia> M  # was not modified
+julia> M
 [1   0   0]
 [0   1   0]
 [0   0   1]
@@ -6417,9 +6419,10 @@ end
 @doc raw"""
     swap_rows!(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
 
-Swap the $i$-th and $j$-th rows of $a$ in place. The function returns the mutated
-matrix (since matrices are assumed to be mutable in AbstractAlgebra.jl).  It is
-the caller's responsibility to ensure that the indices $i$ and $j$ are in range.
+Swap the `i`-th and `j`-th rows of `a` in place and return the modified
+matrix `a`.
+
+No bounds checking is performed; the indices `i` and `j` must be in range.
 
 # Examples
 ```jldoctest
@@ -6433,7 +6436,7 @@ julia> swap_rows!(M, 1, 2)
 [1   0   0]
 [0   0   1]
 
-julia> M  # was modified
+julia> M
 [0   1   0]
 [1   0   0]
 [0   0   1]
@@ -6451,8 +6454,8 @@ end
 @doc raw"""
     swap_cols(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
 
-Return a matrix $b$ with the entries of $a$, where the $i$-th and $j$-th
-columns are swapped.
+Return a new matrix obtained from `a` by swapping the `i`-th and `j`-th
+columns.
 """
 function swap_cols(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
    (1 <= i <= ncols(a) && 1 <= j <= ncols(a)) || throw(BoundsError())
@@ -6464,9 +6467,10 @@ end
 @doc raw"""
     swap_cols!(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
 
-Swap the $i$-th and $j$-th columns of $a$ in place. The function returns the mutated
-matrix (since matrices are assumed to be mutable in AbstractAlgebra.jl).  It is
-the caller's responsibility to ensure that the indices $i$ and $j$ are in range.
+Swap the `i`-th and `j`-th columns of `a` in place and return the modified
+matrix `a`.
+
+No bounds checking is performed; the indices `i` and `j` must be in range.
 """
 function swap_cols!(a::MatElem{T}, i::Int, j::Int) where T <: NCRingElement
    if i != j
@@ -6480,9 +6484,8 @@ end
 @doc raw"""
     reverse_rows!(a::MatElem{T}) where T <: NCRingElement
 
-Swap the $i$-th and $(r - i)$-th rows of $a$ for each $1 \leq i \leq r/2$,
-where $r$ is the number of rows of $a$.  The swaps are performed in place.
-The return value is the modified matrix.
+Reverse the order of the rows of `a` in place and return the modified
+matrix `a`.
 """
 function reverse_rows!(a::MatElem{T}) where T <: NCRingElement
    k = div(nrows(a), 2)
@@ -6495,9 +6498,7 @@ end
 @doc raw"""
     reverse_rows(a::MatElem{T}) where T <: NCRingElement
 
-Return a matrix $b$ with the entries of $a$, where the $i$-th and $(r - i)$-th
-rows are swapped for each $1 \leq i \leq r/2$, where $r$ is the number of rows of
-$a$.
+Return a new matrix obtained from `a` by reversing the order of its rows.
 """
 function reverse_rows(a::MatElem{T}) where T <: NCRingElement
    b = deepcopy(a)
@@ -6507,9 +6508,8 @@ end
 @doc raw"""
     reverse_cols!(a::MatElem{T}) where T <: NCRingElement
 
-Swap the $i$-th and $(r - i)$-th columns of $a$ for each $1 \leq i \leq c/2$,
-where $c$ is the number of columns of $a$.  The swaps are performed in place.
-The return value is the modified matrix.
+Reverse the order of the columns of `a` in place and return the modified
+matrix `a`.
 """
 function reverse_cols!(a::MatElem{T}) where T <: NCRingElement
    k = div(ncols(a), 2)
@@ -6522,8 +6522,7 @@ end
 @doc raw"""
     reverse_cols(a::MatElem{T}) where T <: NCRingElement
 
-Return a matrix $b$ with the entries of $a$, where the $i$-th and $(r - i)$-th
-columns are swapped for each $1 \leq i \leq c/2$, where $c$ is the number of columns of $a$.
+Return a new matrix obtained from `a` by reversing the order of its columns.
 """
 function reverse_cols(a::MatElem{T}) where T <: NCRingElement
    b = deepcopy(a)
@@ -6539,10 +6538,36 @@ end
 @doc raw"""
     add_column!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
 
-Add $s$ times the $i$-th row to the $j$-th row of $a$.
+Add `s` times the `i`-th column to the `j`-th column of `a` and return the
+modified matrix `a`.
 
-By default, the transformation is applied to all rows of $a$. This can be
-changed using the optional `rows` argument.
+By default, this operation modifies all entries of the `j`-th column.
+An optional final argument restricts the operation to entries in the
+specified rows.
+
+# Examples
+
+```jldoctest
+julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
+[1   2   3]
+[2   3   4]
+[4   5   5]
+
+julia> add_column!(M, 2, 3, 1)
+[ 7   2   3]
+[10   3   4]
+[14   5   5]
+
+julia> M
+[ 7   2   3]
+[10   3   4]
+[14   5   5]
+
+julia> add_column!(M, 2, 3, 1, 1:1)
+[13   2   3]
+[10   3   4]
+[14   5   5]
+```
 """
 function add_column!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
    v = base_ring(a)(s)
@@ -6560,11 +6585,36 @@ end
 @doc raw"""
     add_column(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
 
-Create a copy of $a$ and add $s$ times the $i$-th row to the $j$-th row of $a$.
+Return a new matrix obtained from `a` by adding `s` times the `i`-th
+column to the `j`-th column.
 
-By default, the transformation is applied to all rows of $a$. This can be
-changed using the optional `rows` argument.
+By default, this operation changes all entries of the `j`-th column
+in the returned matrix. An optional final argument restricts the operation
+to entries in the specified rows.
 
+# Examples
+
+```jldoctest
+julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
+[1   2   3]
+[2   3   4]
+[4   5   5]
+
+julia> add_column(M, 2, 3, 1)
+[ 7   2   3]
+[10   3   4]
+[14   5   5]
+
+julia> M
+[1   2   3]
+[2   3   4]
+[4   5   5]
+
+julia> add_column(M, 2, 3, 1, 1:1)
+[7   2   3]
+[2   3   4]
+[4   5   5]
+```
 """
 function add_column(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, rows = 1:nrows(a)) where T <: RingElement
    b = deepcopy(a)
@@ -6574,10 +6624,12 @@ end
 @doc raw"""
     add_row!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
 
-Add $s$ times the $i$-th row to the $j$-th row of $a$.
+Add `s` times the `i`-th row to the `j`-th row of `a` and return the modified
+matrix `a`.
 
-By default, the transformation is applied to all columns of $a$. This can be
-changed using the optional `cols` argument.
+By default, this operation modifies all entries of the `j`-th row.
+An optional final argument restricts the operation to entries in the
+specified columns.
 """
 function add_row!(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
    v = base_ring(a)(s)
@@ -6595,10 +6647,12 @@ end
 @doc raw"""
     add_row(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
 
-Create a copy of $a$ and add $s$ times the $i$-th row to the $j$-th row of $a$.
+Return a new matrix obtained from `a` by adding `s` times the `i`-th
+row to the `j`-th row.
 
-By default, the transformation is applied to all columns of $a$. This can be
-changed using the optional `cols` argument.
+By default, this operation changes all entries of the `j`-th row in the returned
+matrix. An optional final argument restricts the operation to entries in the
+specified columns.
 """
 function add_row(a::MatrixElem{T}, s::RingElement, i::Int, j::Int, cols = 1:ncols(a)) where T <: RingElement
    b = deepcopy(a)
@@ -6610,15 +6664,16 @@ end
 @doc raw"""
     multiply_column!(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
 
-Multiply the $i$-th column of $a$ with $s$.
+Multiply the `i`-th column of `a` by `s` and return the modified matrix `a`.
 
-By default, the transformation is applied to all rows of $a$. This can be
-changed using the optional `rows` argument.
+By default, this operation modifies all entries of the `i`-th column.
+An optional final argument restricts the operation to entries in the
+specified rows.
 """
 function multiply_column!(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
    c = base_ring(a)(s)
    nc = ncols(a)
-   !_checkbounds(nc, i) && error("Row index ($i) must be between 1 and $nc")
+   !_checkbounds(nc, i) && error("Column index ($i) must be between 1 and $nc")
    temp = base_ring(a)()
    for r in rows
       a[r, i] = c*a[r, i] # cannot mutate matrix entries
@@ -6629,10 +6684,11 @@ end
 @doc raw"""
     multiply_column(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
 
-Create a copy of $a$ and multiply the $i$-th column of $a$ with $s$.
+Return a new matrix obtained from `a` by multiplying the `i`-th column by `s`.
 
-By default, the transformation is applied to all rows of $a$. This can be
-changed using the optional `rows` argument.
+By default, this operation changes all entries of the `i`-th column in the returned
+matrix. An optional final argument restricts the operation to entries in the
+specified rows.
 """
 function multiply_column(a::MatrixElem{T}, s::RingElement, i::Int, rows = 1:nrows(a)) where T <: RingElement
    b = deepcopy(a)
@@ -6644,10 +6700,11 @@ end
 @doc raw"""
     multiply_row!(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
 
-Multiply the $i$-th row of $a$ with $s$.
+Multiply the `i`-th row of `a` by `s` and return the modified matrix `a`.
 
-By default, the transformation is applied to all columns of $a$. This can be
-changed using the optional `cols` argument.
+By default, this operation modifies all entries of the `i`-th row.
+An optional final argument restricts the operation to entries in the
+specified columns.
 """
 function multiply_row!(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
    c = base_ring(a)(s)
@@ -6663,10 +6720,35 @@ end
 @doc raw"""
     multiply_row(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
 
-Create a copy of $a$ and multiply the $i$-th row of $a$ with $s$.
+Return a new matrix obtained from `a` by multiplying the `i`-th row by `s`.
 
-By default, the transformation is applied to all columns of $a$. This can be
-changed using the optional `cols` argument.
+By default, this operation changes all entries of the `i`-th row in the returned
+matrix. An optional final argument restricts the operation to entries in the
+specified columns.
+
+# Examples
+
+```jldoctest
+julia> M = ZZ[1 2 3; 2 3 4; 4 5 5]
+[1   2   3]
+[2   3   4]
+[4   5   5]
+
+julia> multiply_row(M, 2, 3)
+[1    2    3]
+[2    3    4]
+[8   10   10]
+
+julia> M
+[1   2   3]
+[2   3   4]
+[4   5   5]
+
+julia> multiply_row(M, 2, 3, 2:2)
+[1    2   3]
+[2    3   4]
+[4   10   5]
+```
 """
 function multiply_row(a::MatrixElem{T}, s::RingElement, i::Int, cols = 1:ncols(a)) where T <: RingElement
    b = deepcopy(a)
@@ -6836,10 +6918,32 @@ end
 #
 ###############################################################################
 
+
 @doc raw"""
     map_entries!(f, dst::MatElem{T}, src::MatElem{U}) where {T <: NCRingElement, U <: NCRingElement}
 
-Like `map_entries`, but stores the result in `dst` rather than a new matrix.
+Apply `f` to each entry of `src`, store the result in the given
+matrix `dst` and return the modified matrix `dst`.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> N = zero_matrix(ZZ, 2, 2)
+[0   0]
+[0   0]
+
+julia> map_entries!(x -> x^2, N, M)
+[ 1    4]
+[ 9   16]
+
+julia> N
+[ 1    4]
+[ 9   16]
+```
 """
 function map_entries!(f::S, dst::MatElem{T}, src::MatElem{U}) where {S, T <: NCRingElement, U <: NCRingElement}
    for i = 1:nrows(src), j = 1:ncols(src)
@@ -6851,15 +6955,30 @@ end
 @doc raw"""
     map!(f, dst::MatrixElem{T}, src::MatrixElem{U}) where {T <: NCRingElement, U <: NCRingElement}
 
-Like `map`, but stores the result in `dst` rather than a new matrix.
-This is equivalent to `map_entries!(f, dst, src)`.
+Apply `f` to each entry of `src`, store the result in the given
+matrix `dst` and return the modified matrix `dst`.
+
+This is equivalent to `map_entries!(f, dst, src)`, see [`map_entries!`](@ref).
 """
 Base.map!(f::S, dst::MatrixElem{T}, src::MatrixElem{U}) where {S, T <: NCRingElement, U <: NCRingElement} = map_entries!(f, dst, src)
 
 @doc raw"""
     map_entries(f, a::MatElem{T}) where T <: NCRingElement
 
-Transform matrix `a` by applying `f` to each element.
+Return a new matrix obtained by applying `f` to each entry of the
+matrix `a`.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> M2 = map_entries(x -> x^2, M)
+[ 1    4]
+[ 9   16]
+```
 """
 function map_entries(f::S, a::MatElem{T}) where {S, T <: NCRingElement}
    isempty(a) && return _change_base_ring(parent(f(zero(base_ring(a)))), a)
@@ -6876,8 +6995,10 @@ end
 @doc raw"""
     map(f, a::MatrixElem{T}) where T <: NCRingElement
 
-Transform matrix `a` by applying `f` to each element.
-This is equivalent to `map_entries(f, a)`.
+Return a new matrix obtained by applying `f` to each entry of the
+matrix `a`.
+
+This is equivalent to `map_entries(f, a)`, see [`map_entries`](@ref).
 """
 Base.map(f::S, a::MatrixElem{T}) where {S, T <: NCRingElement} = map_entries(f, a)
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6973,9 +6973,10 @@ end
 ################################################################################
 
 @doc raw"""
-    matrix(R::Ring, arr::AbstractMatrix{T}) where {T}
+    matrix(R::NCRing, arr::AbstractMatrix{T}) where {T}
 
-Constructs the matrix over $R$ with entries as in `arr`.
+Return the matrix over the ring `R` with entries as in the Julia
+`AbstractMatrix` `arr`. All entries of `arr` must be coercible into `R`.
 
 # Examples
 
@@ -6984,9 +6985,9 @@ julia> matrix(GF(3), [1 2 ; 3 4])
 [1   2]
 [0   1]
 
-julia> using LinearAlgebra ; matrix(GF(5), I(2))
-[1   0]
-[0   1]
+julia> matrix(ZZ, BigInt[3 1 2; 2 0 1])
+[3   1   2]
+[2   0   1]
 ```
 """
 function matrix(R::NCRing, arr::AbstractMatrix{T}) where {T}
@@ -7035,12 +7036,25 @@ function matrix(R::NCRing, arr::AbstractVector{<:AbstractVector})
 end
 
 @doc raw"""
-    matrix(R::Ring, r::Int, c::Int, arr::AbstractVector{T}) where {T}
+    matrix(R::NCRing, r::Int, c::Int, arr::AbstractVecOrMat{T}) where {T}
 
-Constructs the $r \times c$ matrix over $R$, where the entries are taken
-row-wise from `arr`.
+Return the `r` by `c` matrix over the ring `R` from the entries of `arr`.
+
+If `arr` is a vector, its entries are read row-wise, so the ``(i, j)`` entry is
+given by `arr[c*(i - 1) + j]`. All entries must be coercible into `R`.
+
+If `arr` is a matrix, this is equivalent to `matrix(R, arr)`.
+
+# Examples
+
+```jldoctest
+julia> matrix(ZZ, 3, 2, BigInt[3, 1, 2, 2, 0, 1])
+[3   1]
+[2   2]
+[0   1]
+```
 """
-function matrix(R::NCRing, r::Int, c::Int, arr::AbstractVecOrMat{T}) where T
+function matrix(R::NCRing, r::Int, c::Int, arr::AbstractVecOrMat{T}) where {T}
    _check_dim(r, c, arr)
    ndims(arr) == 2 && return matrix(R, arr)
    if elem_type(R) === T && all(e -> parent(e) === R, arr)

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7379,9 +7379,9 @@ julia> diagonal_matrix([A, B])
 [0   0   5   6]
 
 julia> diagonal_matrix(QQ, [A, B])
-[1   2   0   0]
-[3   4   0   0]
-[0   0   5   6]
+[1//1   2//1   0//1   0//1]
+[3//1   4//1   0//1   0//1]
+[0//1   0//1   5//1   6//1]
 
 julia> diagonal_matrix(B, A)
 [5   6   0   0]

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7132,16 +7132,37 @@ end
 @doc raw"""
     identity_matrix(R::NCRing, n::Int)
 
-Return the $n \times n$ identity matrix over $R$.
+Return the $n \times n$ identity matrix over the ring `R`.
+
+# Examples
+
+```jldoctest
+julia> identity_matrix(ZZ, 2)
+[1   0]
+[0   1]
+```
 """
 identity_matrix(R::NCRing, n::Int) = diagonal_matrix(one(R), n)
 
 @doc raw"""
     identity_matrix(M::MatElem{T}) where T <: NCRingElement
 
-Construct the identity matrix in the same matrix space as `M`, i.e.
-with ones down the diagonal and zeroes elsewhere. `M` must be square.
+Return the identity matrix with the same base ring and dimensions
+as the given abstract matrix `M`. The matrix `M` must be square.
+
 This is an alias for `one(M)`.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> identity_matrix(M)
+[1   0]
+[0   1]
+```
 """
 function identity_matrix(M::MatElem{T}) where T <: NCRingElement
    is_square(M) || throw(DomainError(M, "matrix must be square"))

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7233,19 +7233,14 @@ end
 @doc raw"""
     diagonal_matrix(x::NCRingElement, m::Int, [n::Int])
 
-Return the $m \times n$ matrix over $R$ with `x` along the main diagonal and
-zeroes elsewhere. If `n` is not specified, it defaults to `m`.
+Return the $m \times n$ matrix over the ring `parent(x)` with `x` along the
+main diagonal and zeros elsewhere.
 
 # Examples
 ```jldoctest
 julia> diagonal_matrix(ZZ(2), 2, 3)
 [2   0   0]
 [0   2   0]
-
-julia> diagonal_matrix(QQ(-1), 3)
-[-1//1    0//1    0//1]
-[ 0//1   -1//1    0//1]
-[ 0//1    0//1   -1//1]
 ```
 """
 function diagonal_matrix(x::NCRingElement, m::Int, n::Int)
@@ -7256,16 +7251,34 @@ function diagonal_matrix(x::NCRingElement, m::Int, n::Int)
    return z
 end
 
+@doc raw"""
+    diagonal_matrix(x::NCRingElement, m::Int)
+
+Return the $m \times m$ matrix over the ring `parent(x)` with `x` along the
+main diagonal and zeros elsewhere.
+
+# Examples
+```jldoctest
+julia> diagonal_matrix(QQ(-1), 3)
+[-1//1    0//1    0//1]
+[ 0//1   -1//1    0//1]
+[ 0//1    0//1   -1//1]
+```
+"""
 diagonal_matrix(x::NCRingElement, m::Int) = diagonal_matrix(x, m, m)
 
 @doc raw"""
-    diagonal_matrix(x::T...) where T <: NCRingElement -> MatElem{T}
-    diagonal_matrix(x::AbstractVector{T}) where T <: NCRingElement -> MatElem{T}
-    diagonal_matrix(R::NCRing, x::AbstractVector{T}) where T <: NCRingElement -> MatElem{T}
+    diagonal_matrix(R::NCRing, entries::AbstractVector{<:NCRingElement})
+    diagonal_matrix(entries::AbstractVector{<:NCRingElement})
+    diagonal_matrix(x::T, xs::T...) where {T<:NCRingElement}
 
-Returns a diagonal matrix whose diagonal entries are the elements of $x$.
-If a ring $R$ is given then it is used a parent for the entries of the created
-matrix. Otherwise the parent is inferred from the vector $x$.
+Return a diagonal matrix with the given entries on the main diagonal.
+
+For the vector forms, the diagonal entries are the elements of `entries`.
+For the vararg form, the diagonal entries are `x, xs...`.
+
+If the ring `R` is given, the entries are coerced into `R`. Otherwise, the base
+ring is inferred from the entries.
 
 # Examples
 
@@ -7274,32 +7287,32 @@ julia> diagonal_matrix(ZZ(1), ZZ(2))
 [1   0]
 [0   2]
 
-julia> diagonal_matrix([ZZ(3), ZZ(4)])
-[3   0]
-[0   4]
-
 julia> diagonal_matrix(ZZ, [5, 6])
 [5   0]
 [0   6]
+
+julia> diagonal_matrix([ZZ(3), ZZ(4)])
+[3   0]
+[0   4]
 ```
 """
-function diagonal_matrix(R::NCRing, x::AbstractVector{<:NCRingElement})
-    Base.require_one_based_indexing(x)
-    x = R.(x)
-    M = zero_matrix(R, length(x), length(x))
-    for i = 1:length(x)
-        M[i, i] = x[i]
+function diagonal_matrix(R::NCRing, entries::AbstractVector{<:NCRingElement})
+    Base.require_one_based_indexing(entries)
+    entries = R.(entries)
+    M = zero_matrix(R, length(entries), length(entries))
+    for i = 1:length(entries)
+        M[i, i] = entries[i]
     end
     return M
 end
 
-function diagonal_matrix(x::T, xs::T...) where {T<:NCRingElement}
-    return diagonal_matrix([x, xs...])
+function diagonal_matrix(entries::AbstractVector{<:NCRingElement})
+   @req !isempty(entries) "Cannot infer base ring from empty vector; consider passing the desired base ring as first argument to `diagonal_matrix`"
+   return diagonal_matrix(parent(first(entries)), entries)
 end
 
-function diagonal_matrix(x::AbstractVector{<:NCRingElement})
-   @req !isempty(x) "Cannot infer base ring from empty vector; consider passing the desired base ring as first argument to `diagonal_matrix`"
-   return diagonal_matrix(parent(first(x)), x)
+function diagonal_matrix(x::T, xs::T...) where {T<:NCRingElement}
+    return diagonal_matrix([x, xs...])
 end
 
 @doc raw"""

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7188,15 +7188,38 @@ identity_matrix(::Type{MatElem}, R::Ring, n::Int) = identity_matrix(R, n)
 
 @doc raw"""
     scalar_matrix(R::NCRing, n::Int, a::NCRingElement)
-    scalar_matrix(n::Int, a::NCRingElement)
 
-Return the $n \times n$ matrix over `R` with `a` along the main diagonal and
-zeroes elsewhere. If `R` is not specified, it defaults to `parent(a)`.
+Return the $n \times n$ diagonal matrix over the ring `R` whose diagonal entries
+are all equal to the ring element `a` of `R`.
+
+# Examples
+
+```jldoctest
+julia> scalar_matrix(QQ, 3, 1//2)
+[1//2   0//1   0//1]
+[0//1   1//2   0//1]
+[0//1   0//1   1//2]
+```
 """
 function scalar_matrix(R::NCRing, n::Int, a::NCRingElement)
    return diagonal_matrix(R(a), n)
 end
 
+@doc raw"""
+    scalar_matrix(n::Int, a::NCRingElement)
+
+Return the $n \times n$ diagonal matrix over `parent(a)` whose diagonal entries
+are all equal to the ring element `a`.
+
+# Examples
+
+```jldoctest
+julia> scalar_matrix(3, ZZ(5))
+[5   0   0]
+[0   5   0]
+[0   0   5]
+```
+"""
 function scalar_matrix(n::Int, a::NCRingElement)
    return diagonal_matrix(a, n)
 end

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7415,12 +7415,11 @@ end
 @doc raw"""
     lower_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
 
-Return the $n$ by $n$ matrix whose entries on and below the main diagonal are
-the elements of `L`, and which has zeroes elsewhere.
-The value of $n$ is determined by the condition that `L` has length
-$n(n+1)/2$.
+Return the $n \times n$ lower triangular matrix whose entries on and below the
+main diagonal are given by the elements of `L`. The entries are filled row by row.
 
-An exception is thrown if there is no integer $n$ with this property.
+The size $n$ is determined by the condition that `L` has length $n(n + 1)/2$.
+An exception is thrown if no such integer $n$ exists.
 
 # Examples
 ```jldoctest
@@ -7454,12 +7453,11 @@ end
 @doc raw"""
     upper_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
 
-Return the $n$ by $n$ matrix whose entries on and above the main diagonal are
-the elements of `L`, and which has zeroes elsewhere.
-The value of $n$ is determined by the condition that `L` has length
-$n(n+1)/2$.
+Return the $n \times n$ upper triangular matrix whose entries on and below the
+main diagonal are given by the elements of `L`. The entries are filled row by row.
 
-An exception is thrown if there is no integer $n$ with this property.
+The size $n$ is determined by the condition that `L` has length $n(n + 1)/2$.
+An exception is thrown if no such integer $n$ exists.
 
 # Examples
 ```jldoctest
@@ -7493,12 +7491,11 @@ end
 @doc raw"""
     strictly_lower_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
 
-Return the $n$ by $n$ matrix whose entries below the main diagonal are
-the elements of `L`, and which has zeroes elsewhere.
-The value of $n$ is determined by the condition that `L` has length
-$(n-1)n/2$.
+Return the $n \times n$ strictly lower triangular matrix whose entries below
+the main diagonal are given by the elements of `L`. The entries are filled row by row.
 
-An exception is thrown if there is no integer $n$ with this property.
+The size $n$ is determined by the condition that `L` has length $n(n - 1)/2$.
+An exception is thrown if no such integer $n$ exists.
 
 # Examples
 ```jldoctest
@@ -7533,12 +7530,12 @@ end
 @doc raw"""
     strictly_upper_triangular_matrix(L::AbstractVector{T}) where {T <: NCRingElement}
 
-Return the $n$ by $n$ matrix whose entries above the main diagonal are
-the elements of `L`, and which has zeroes elsewhere.
-The value of $n$ is determined by the condition that `L` has length
-$(n-1)n/2$.
+Return the $n \times n$ strictly upper triangular matrix whose entries above
+the main diagonal are given by the elements of `L`. The entries are filled
+row by row.
 
-An exception is thrown if there is no integer $n$ with this property.
+The size $n$ is determined by the condition that `L` has length $n(n - 1)/2$.
+An exception is thrown if no such integer $n$ exists.
 
 # Examples
 ```jldoctest

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -336,10 +336,30 @@ end
 ###############################################################################
 
 @doc raw"""
-    block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: NCRingElement
+    block_diagonal_matrix(V::Vector{<:MatElem{T}}) where {T <: NCRingElement}
 
-Create the block diagonal matrix whose blocks are given by the matrices in `V`.
-There must be at least one matrix in V.
+Return the block diagonal matrix whose diagonal blocks are the matrices in `V`.
+
+The vector `V` must be non-empty, since otherwise the base ring cannot be
+inferred.
+
+# Examples
+
+```jldoctest
+julia> M = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> N = matrix(ZZ, [4 5 6; 7 8 9])
+[4   5   6]
+[7   8   9]
+
+julia> block_diagonal_matrix([M, N])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+```
 """
 function block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: NCRingElement
    @req !isempty(V) "Cannot infer base ring from empty vector; consider passing the desired base ring as first argument to `block_diagonal_matrix`"
@@ -369,11 +389,25 @@ function block_diagonal_matrix(V::Vector{<:MatElem{T}}) where T <: NCRingElement
    return M
 end
 
-@doc raw"""
-    block_diagonal_matrix(R::NCRing, V::Vector{<:Matrix{T}}) where T <: NCRingElement
 
-Create the block diagonal matrix over the ring `R` whose blocks are given
-by the matrices in `V`. Entries are coerced into `R` upon creation.
+@doc raw"""
+    block_diagonal_matrix(R::NCRing, V::Vector{<:Matrix{T}}) where {T <: NCRingElement}
+
+Return the block diagonal matrix over the ring `R` whose diagonal blocks are the
+matrices in `V`.
+
+The entries of the blocks are coerced into `R`. If `V` is empty, the $0 \times 0$
+zero matrix over `R` is returned.
+
+# Examples
+
+```jldoctest
+julia> block_diagonal_matrix(ZZ, [[1 2; 3 4], [4 5 6; 7 8 9]])
+[1   2   0   0   0]
+[3   4   0   0   0]
+[0   0   4   5   6]
+[0   0   7   8   9]
+```
 """
 function block_diagonal_matrix(R::NCRing, V::Vector{<:Matrix{T}}) where T <: NCRingElement
    if length(V) == 0
@@ -7316,16 +7350,47 @@ function diagonal_matrix(x::T, xs::T...) where {T<:NCRingElement}
 end
 
 @doc raw"""
-    diagonal_matrix(V::Vector{T}) where T <: MatElem -> MatElem
+    diagonal_matrix(V::Vector{T}) where {T <: MatElem}
+    diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
+    diagonal_matrix(x::T, xs::T...) where {T <: MatElem}
 
-Returns a block diagonal matrix whose diagonal blocks are the matrices in $x$.
+Return the block diagonal matrix whose diagonal blocks are the given matrices.
+
+For the vector forms, the diagonal blocks are the elements of `V`.
+For the vararg form, the diagonal blocks are `x, xs...`.
+
+If the ring `R` is given, the entries of the blocks are coerced into `R`.
+
+These constructors use the corresponding `block_diagonal_matrix` functionality.
+
+# Examples
+
+```jldoctest
+julia> A = matrix(ZZ, [1 2; 3 4])
+[1   2]
+[3   4]
+
+julia> B = matrix(ZZ, [5 6])
+[5   6]
+
+julia> diagonal_matrix([A, B])
+[1   2   0   0]
+[3   4   0   0]
+[0   0   5   6]
+
+julia> diagonal_matrix(QQ, [A, B])
+[1   2   0   0]
+[3   4   0   0]
+[0   0   5   6]
+
+julia> diagonal_matrix(B, A)
+[5   6   0   0]
+[0   0   1   2]
+[0   0   3   4]
+```
 """
 function diagonal_matrix(V::Vector{T}) where {T<:MatElem}
     return block_diagonal_matrix(V)
-end
-
-function diagonal_matrix(x::T, xs::T...) where {T<:MatElem}
-    return block_diagonal_matrix([x, xs...])
 end
 
 function diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
@@ -7334,6 +7399,10 @@ function diagonal_matrix(R::NCRing, V::Vector{<:MatElem})
     else
         return block_diagonal_matrix(map(x -> change_base_ring(R, x), V))
     end
+end
+
+function diagonal_matrix(x::T, xs::T...) where {T<:MatElem}
+    return block_diagonal_matrix([x, xs...])
 end
 
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7073,9 +7073,18 @@ end
 ################################################################################
 
 @doc raw"""
-    zero_matrix(R::Ring, r::Int, c::Int)
+    zero_matrix(R::NCRing, r::Int, c::Int)
 
-Return the $r \times c$ zero matrix over $R$.
+Return the $r \times c$ matrix over the ring `R` whose entries are all zero.
+
+# Examples
+
+```jldoctest
+julia> P = zero_matrix(ZZ, 3, 2)
+[0   0]
+[0   0]
+[0   0]
+```
 """
 function zero_matrix(R::NCRing, r::Int, c::Int)
   (r < 0 || c < 0) && error("Dimensions must be non-negative")

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7265,7 +7265,7 @@ end
 ################################################################################
 
 @doc raw"""
-    diagonal_matrix(x::NCRingElement, m::Int, [n::Int])
+    diagonal_matrix(x::NCRingElement, m::Int, n::Int)
 
 Return the $m \times n$ matrix over the ring `parent(x)` with `x` along the
 main diagonal and zeros elsewhere.

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -7101,9 +7101,19 @@ zero_matrix(::Type{MatElem}, R::Ring, n::Int, m::Int) = zero_matrix(R, n, m)
 ################################################################################
 
 @doc raw"""
-    ones_matrix(R::Ring, r::Int, c::Int)
+    ones_matrix(R::NCRing, r::Int, c::Int)
 
-Return the $r \times c$ ones matrix over $R$.
+Return the $r \times c$ matrix over the ring `R` whose entries are
+all equal to the multiplicative identity of `R`.
+
+# Examples
+
+```jldoctest
+julia> ones_matrix(ZZ, 3, 2)
+[1   1]
+[1   1]
+[1   1]
+```
 """
 function ones_matrix(R::NCRing, r::Int, c::Int)
    z = dense_matrix_type(R)(R, undef, r, c)


### PR DESCRIPTION
Matrix predicates page introduced.

Currently, this PR includes the changes in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2456 (and #2455), which should be reviewed and merged first.