### PR TITLE
Use m for the snf matrix argument

### DIFF
--- a/docs/src/matrix_normal_forms.md
+++ b/docs/src/matrix_normal_forms.md
@@ -46,7 +46,7 @@ hnf_with_transform(A::MatElem{T}) where {T <: RingElement}
 ## Smith normal form
 
 ```@docs
-snf(A::MatElem{T}) where {T <: RingElement}
+snf(m::MatElem{T}) where {T <: RingElement}
 snf_with_transform(A::MatElem{T}) where {T <: RingElement}
 ```
 

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -6295,7 +6295,7 @@ function snf_kb!(S::MatElem{T}, U::MatElem{T}, K::MatElem{T}, with_trafo::Bool =
 end
 
 @doc raw"""
-    snf(A::MatElem{T}) where {T <: RingElement}
+    snf(m::MatElem{T}) where {T <: RingElement}
 
 Return the Smith normal form of $A$.
 
@@ -6319,8 +6319,8 @@ julia> is_snf(S)
 true
 ```
 """
-function snf(A::MatElem{T}) where {T <: RingElement}
-  return snf_kb(A)
+function snf(m::MatElem{T}) where {T <: RingElement}
+  return snf_kb(m)
 end
 
 @doc raw"""


### PR DESCRIPTION
This isolates the `snf(A::MatElem)` to `snf(m::MatElem)` argument rename from #2474.

The printed method signature is currently captured by an Oscar book example, so this PR is intentionally left as a draft for the next breaking release, when the corresponding book output can be updated.

Co-authored-by: Codex <codex@openai.com>

cc @lgoettgens 