### PR TITLE
Remove unusable method `evaluate(::MPolyRingElem, ::Integer)`

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -93,10 +93,6 @@ function evaluate(x::PolyRingElem{T}, y::Integer) where T <: RingElem
    return evaluate(x, base_ring(x)(y))
 end
 
-function evaluate(x::MPolyRingElem{T}, y::Integer) where T <: RingElem
-   return evaluate(x, base_ring(x)(y))
-end
-
 ###############################################################################
 #
 #   Type traits


### PR DESCRIPTION
Fix #2472