### PR TITLE
feat: add hook to for improved A .= B performance in broadcasting

### DIFF
--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -109,6 +109,20 @@ end
 
 Base.maybeview(A::MatElem, x...) = view(A, x...)
 
+function set!(dest::MatElem, src)
+  for I in eachindex(dest)
+    dest[I] = src[I]
+  end
+  return dest
+end
+
+set!(dest::MatElem, src::MatElem) = map_entries!(identity, dest, src)
+
+function Base.copyto!(dest::MatElem, src)
+  set!(dest, src)
+  return dest
+end
+
 ################################################################################
 #
 #  Similar functionality
@@ -132,7 +146,8 @@ Base.copyto!(dest::MatElem, bc::Broadcast.Broadcasted) = Base.copyto!(dest, conv
 function Base.copyto!(dest::MatElem, bc::Broadcast.Broadcasted{Nothing})
   axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
   # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
-  if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
+  if bc.f === identity && bc.args isa Tuple{Union{AbstractArray, MatElem}} # only a single input argument to broadcast!
+    # this takes care of assignments of the form A .= B (in this case bc.args = (B, ))
     A = bc.args[1]
     if axes(dest) == axes(A)
       return copyto!(dest, A)

--- a/test/broadcasting-test.jl
+++ b/test/broadcasting-test.jl
@@ -13,6 +13,15 @@
   @test_throws ErrorException [1, 2] .* A
   @test_throws ErrorException A .* 2 .* 2 .* [1, 2]
 
+  A = ZZ[1 2; 3 4]
+  B = ZZ[5 6; 7 8]
+  @test (A .= B) === A
+  @test A == B
+
+  B = [9 10; 11 12]
+  @test (A .= B) === A
+  @test A == ZZ[9 10; 11 12]
+
   let # fix assignment bug with views #2151
     R, (x, y) = polynomial_ring(QQ,[:x,:y])
     mr = ones_matrix(R,2,2)


### PR DESCRIPTION
For `A`, `B`, before this PR the call `A .= B` went through the generic path, which does
```
for y in B
  A[..] = y
end
```
Now it goes through the other branch, which calls `copyto!`. I then made `copyto!` call `set!`, and `set!` call `map_entries!(identity, ...`).

I am not superhappy with the indirections, since it is also not clear from the matrix interface, which functions it should eventually be calling. But with the current version it will go through `set!`, which will work for `ZZMatrix` from Nemo (which was our original aim).