### PR TITLE
Remove "all rights reserved"

### DIFF
--- a/src/Assertions.jl
+++ b/src/Assertions.jl
@@ -2,12 +2,6 @@
 #
 #     Assertions.jl : Verbose printing and custom assertions
 #
-# This file was part of Hecke until Sep 2024 and was licensed under the
-# BSD 2-Clause "Simplified" License.
-#
-# (C) 2015-2019 Claus Fieker, Tommy Hofmann
-# All rights reserved.
-#
 ################################################################################
 
 ################################################################################


### PR DESCRIPTION
Fixes #2482 

I've removed the whole legal stuff in the respective file as it seems like that all of it is redundant according to the discussion in #2482. But I'm not entirely sure about the copyright notice. There is a copyright notice in the LICENSE.md which at least partially covers the notice which was in `Assertions.jl`. I guess @fieker @thofma have to look at this.