### PR TITLE
Fix some issues found by JET

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -66,7 +66,7 @@ end
 @deprecate _extended_weak_popov(A::MatElem{T}, V::MatElem{T}, trafo::Type{Val{S}}) where {T <: PolyRingElem, S} _extended_weak_popov(A, V, Val(S))
 @deprecate _popov(A::MatElem{T}, trafo::Type{Val{S}}) where {T <: PolyRingElem, S} _popov(A, Val(S))
 @deprecate _hnf_via_popov(A::MatElem{T}, trafo::Type{Val{S}}) where {T <: PolyRingElem, S} _hnf_via_popov(A, Val(S))
-@deprecate gen(a::MPolyRing{T}, i::Int, ::Type{Val{ord}}) where {T <: RingElement, ord} gen(a, i, Val(ord))
+@deprecate gen(a::MPolyRing{T}, i::Int, ::Type{Val{ord}}) where {T <: RingElement, ord} gen(a, i)
 
 # deprecated in 0.43.0
 @deprecate change_base_ring(p::MPolyRingElem{T}, g, new_polynomial_ring) where {T<:RingElement} map_coefficients(g, p, parent = new_polynomial_ring)

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -472,7 +472,8 @@ function is_nilpotent(A::MatRingElem{T}) where {T <: RingElement}
 end
 
 function hessenberg!(A::MatRingElem{T}) where {T <: RingElement}
-  return Generic.MatRingElem(hessenberg!(matrix(A)))
+  hessenberg!(matrix(A))
+  return A
 end
 
 function hessenberg(A::MatRingElem{T}) where {T <: RingElement}

--- a/src/generic/LaurentMPoly.jl
+++ b/src/generic/LaurentMPoly.jl
@@ -28,6 +28,8 @@ symbols(R::LaurentMPolyWrapRing) = symbols(base_ring(R))
 number_of_variables(R::LaurentMPolyWrapRing) = number_of_variables(base_ring(R))
 number_of_generators(R::LaurentMPolyWrapRing) = number_of_variables(base_ring(R))
 
+is_univariate(R::LaurentMPolyWrapRing) = is_univariate(base_ring(R))
+
 is_domain_type(::Type{LaurentMPolyWrapRing{S, T}}) where {S, T} = is_domain_type(T)
 
 ###############################################################################

--- a/src/generic/PuiseuxMPoly.jl
+++ b/src/generic/PuiseuxMPoly.jl
@@ -378,7 +378,7 @@ end
 function divexact(f::PuiseuxMPolyRingElem{T}, a::T; check::Bool = true) where {T <: RingElement}
     @req !iszero(a) "division by zero"
     @req parent(a) === coefficient_ring(f) "coefficient rings must agree"
-    return puiseux_polynomial_ring_elem(parent(f), poly(f)*1//a, scale(f); skip_normalization=true)
+    return puiseux_polynomial_ring_elem(parent(f), divexact(poly(f), a; check = check), scale(f); skip_normalization=true)
 end
 
 function divexact(f::PuiseuxMPolyRingElem, a::Integer; check::Bool = true)

--- a/src/generic/RationalFunctionField.jl
+++ b/src/generic/RationalFunctionField.jl
@@ -612,7 +612,7 @@ function (a::RationalFunctionField{T, U})(b::Rational{<:Integer}) where {T <: Fi
    return z
 end
 
-function (a::RationalFunctionField)(b::RingElem)
+function (a::RationalFunctionField{T, U})(b::RingElement) where {T <: FieldElement, U <: Union{PolyRingElem, MPolyRingElem}}
    return a(underlying_fraction_field(a)(b))
 end
 

--- a/test/PuiseuxPolynomials-test.jl
+++ b/test/PuiseuxPolynomials-test.jl
@@ -60,6 +60,7 @@ import AbstractAlgebra: Generic.normalize!
         @test QQ == coefficient_ring(Kp)
         @test ngens(Kp) == 3
         @test gens(Kp) == [tp1,tp2,tp3]
+        @test !is_univariate(Kp)
 
         g = tp1^(1//2)+tp3^(1//3)
         @test elem_type(Kp) == typeof(g)
@@ -75,6 +76,7 @@ import AbstractAlgebra: Generic.normalize!
         @test scale(g) == 2*3*7
 
         K, (t,) = puiseux_polynomial_ring(QQ,["t"])
+        @test is_univariate(K)
         @test valuation(K(0)) == PosInf()
         @test valuation(t^(-1)) == -1
         @test valuation(t^(-2//3)+t^(-1//2)) == -2//3

--- a/test/PuiseuxPolynomials-test.jl
+++ b/test/PuiseuxPolynomials-test.jl
@@ -108,6 +108,9 @@ import AbstractAlgebra: Generic.normalize!
         @test (g)^0 == 1
 
         @test divexact(g, 2) == (1//2)*u^(1//2) + (1//2)*v^(1//3)
+        @test divexact(g, QQ(2)) == (1//2)*u^(1//2) + (1//2)*v^(1//3)
+        @test divexact(2*g, QQ(2)) == g
+        @test_throws ArgumentError divexact(g, QQ(0))
         # TODO: add some more divexact tests
 
         g = u^(1//2)*v^(2//3) + w^(1//4)

--- a/test/generic/LaurentMPoly-test.jl
+++ b/test/generic/LaurentMPoly-test.jl
@@ -13,6 +13,8 @@ end
     @test L == laurent_polynomial_ring(GF(5), 2, :x, cached = true)[1]
 
     @test is_domain_type(L)
+    @test !is_univariate(L)
+    @test is_univariate(laurent_polynomial_ring(GF(5), ["x"])[1])
 
     @test coefficient_ring(L) == GF(5)
     @test coefficient_ring_type(L) === typeof(GF(5))

--- a/test/generic/MatRing-test.jl
+++ b/test/generic/MatRing-test.jl
@@ -1148,6 +1148,11 @@ end # of @testset "Generic.MatRing.inversion"
          A = hessenberg(M)
 
          @test is_hessenberg(A)
+
+         B = deepcopy(M)
+         @test hessenberg!(B) === B
+         @test is_hessenberg(B)
+         @test B == A
       end
    end
 end

--- a/test/generic/RationalFunctionField-test.jl
+++ b/test/generic/RationalFunctionField-test.jl
@@ -22,6 +22,12 @@ end
 
    @test isa(T(BigInt(7)), Generic.RationalFunctionFieldElem)
 
+   @test isa(T(3//2), Generic.RationalFunctionFieldElem)
+
+   @test isa(T(QQ(3//2)), Generic.RationalFunctionFieldElem)
+
+   @test T(1.5) == T(3//2)
+
    @test isa(T(x + 2), Generic.RationalFunctionFieldElem)
 
    @test isa(T(numerator(x^2 + 2x + 1, false), numerator(x + 1, false)), Generic.RationalFunctionFieldElem)


### PR DESCRIPTION
Fixes a few issues found by running `JET.report_package(AbstractAlgebra)` (JET 0.12.1, Julia 1.12.7). The number of reports goes from 29 to 23.

- `hessenberg!(::MatRingElem)` always threw a `MethodError`, since the in-place `hessenberg!` on `MatElem` returns `nothing`.
- `is_univariate(::PuiseuxMPolyRing)` forwards to its Laurent base ring, which had no such method.
- The deprecation of `gen(::MPolyRing, ::Int, ::Type{Val})` pointed to `gen(a, i, Val(ord))`, which was removed in #2024, so the deprecated method raised a `MethodError` instead of a warning.
- `divexact(::PuiseuxMPolyRingElem, ::T)` computed `poly(f)*1//a`, which is not defined for all coefficient types and ignored the `check` keyword.
- `RationalFunctionField` now coerces any `RingElement` through its underlying fraction field, so that e.g. `setcoeff!` on function field elements works for all coefficient types.

<details>
<summary>JET reports that are gone with this PR</summary>

```
┌ hessenberg!(A::MatRingElem{T}) where T<:RingElement @ AbstractAlgebra src/MatRing.jl:475
│ no matching method found `AbstractAlgebra.Generic.MatRingElem(::Nothing)`: (Generic).MatRingElem::Type{AbstractAlgebra.Generic.MatRingElem}(hessenberg!(matrix(A::MatRingElem{T} where T<:RingElement)::AbstractAlgebra.Generic.MatSpaceElem{T} where T<:RingElement)::Nothing)
└────────────────────

┌ is_univariate(R::PuiseuxMPolyRing) @ AbstractAlgebra.Generic src/generic/PuiseuxMPoly.jl:202
│ no matching method found `is_univariate(::AbstractAlgebra.Generic.LaurentMPolyWrapRing{T1, AbstractAlgebra.Generic.MPolyRing{T}} where {T<:RingElement, T1<:RingElement})`: AbstractAlgebra.Generic.is_univariate(AbstractAlgebra.Generic.base_ring(R::PuiseuxMPolyRing)::AbstractAlgebra.Generic.LaurentMPolyWrapRing{…} where {…})
└────────────────────

┌ divexact(f::PuiseuxMPolyRingElem{T}, a::T; check::Bool) where T<:RingElement @ AbstractAlgebra.Generic src/generic/PuiseuxMPoly.jl:381
│ no matching method found `//(::Int64, ::AbstractFloat)` (1/4 union split): (1 AbstractAlgebra.Generic.:// a::RingElement)
└────────────────────

┌ setcoeff!(a::AbstractAlgebra.Generic.AbsSimpleFunctionFieldElem, n::Int64, c::RingElement) @ AbstractAlgebra.Generic src/generic/FunctionField.jl:1147
│ no matching method found `(::AbstractAlgebra.Generic.RationalFunctionField{T, U} where {T<:FieldElement, U<:PolyRingElem{T}})(::AbstractFloat)` (1/4 union split): AbstractAlgebra.Generic.base_ring(a::AbstractAlgebra.Generic.AbsSimpleFunctionFieldElem)::AbstractAlgebra.Generic.RationalFunctionField{T, U} where {T<:FieldElement, U<:PolyRingElem{T}}(c::RingElement)
└────────────────────

┌ setcoeff!(a::AbstractAlgebra.Generic.AbsSimpleFunctionFieldElem, n::Int64, c::RingElement) @ AbstractAlgebra.Generic src/generic/FunctionField.jl:1147
│ no matching method found `(::AbstractAlgebra.Generic.RationalFunctionField{T, U} where {T<:FieldElement, U<:PolyRingElem{T}})(::AbstractFloat)` (1/4 union split): AbstractAlgebra.Generic.base_ring(a::AbstractAlgebra.Generic.AbsSimpleFunctionFieldElem)::AbstractAlgebra.Generic.RationalFunctionField{T, U} where {T<:FieldElement, U<:PolyRingElem{T}}(c::RingElement)::Any
└────────────────────

┌ gen(a::MPolyRing{T}, i::Int64, ::Type{Val{ord}}) where {T<:RingElement, ord} @ AbstractAlgebra ./deprecated.jl:215
│ no matching method found `gen(::MPolyRing, ::Int64, ::Val)`: gen(a::MPolyRing, i::Int64, AbstractAlgebra.Val(ord::Any)::Val)
└────────────────────
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
