### PR TITLE
Add iterator for all free modules over finite rings

### DIFF
--- a/src/Module.jl
+++ b/src/Module.jl
@@ -363,27 +363,31 @@ rand(M::FPModule, vals...) = rand(Random.default_rng(), M, vals...)
 #
 ###############################################################################
 
-Base.length(M::FPModule{T}) where T <: FinFieldElem = Int(order(M))
+Base.length(M::FPModule{T}) where T = Int(order(M))
 
-function Base.iterate(M::FPModule{T}) where T <: FinFieldElem
+Base.eltype(::Type{S}) where {S <: FPModule} = elem_type(S)
+
+function Base.iterate(M::FPModule{T}) where T
   k = base_ring(M)
-  if dim(M) == 0
+  d = M isa Generic.FreeModule ? rank(M) : dim(M)
+  if d == 0
     return zero(M), iterate([1])
   end
-  p = Base.Iterators.ProductIterator(Tuple([k for i=1:dim(M)]))
+  p = Base.Iterators.ProductIterator(Tuple([k for i=1:d]))
   f = iterate(p)
   @assert f !== nothing
-  return M(elem_type(k)[f[1][i] for i=1:dim(M)]), (f[2], p)
+  return M(elem_type(k)[f[1][i] for i=1:d]), (f[2], p)
 end
 
-function Base.iterate(M::FPModule{T}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator}) where T <: FinFieldElem
+function Base.iterate(M::FPModule{T}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator}) where T
   n = iterate(st[2], st[1])
   if n === nothing
     return n
   end
-  return M(elem_type(base_ring(M))[n[1][i] for i=1:dim(M)]), (n[2], st[2])
+  d = M isa Generic.FreeModule ? rank(M) : dim(M)
+  return M(elem_type(base_ring(M))[n[1][i] for i=1:d]), (n[2], st[2])
 end
 
-function Base.iterate(::FPModule{<:FinFieldElem}, ::Tuple{Int64, Int64})
+function Base.iterate(::FPModule, ::Tuple{Int64, Int64})
   return nothing
 end

--- a/src/generic/FreeModule.jl
+++ b/src/generic/FreeModule.jl
@@ -46,6 +46,8 @@ Return the dimension of the given vector space.
 dim(M::FreeModule{T}) where T <: FieldElement = M.rank
 vector_space_dim(M::FreeModule{T}) where T <: FieldElement = M.rank
 
+order(M::FreeModule) = order(base_ring(M))^rank(M)
+
 number_of_generators(M::FreeModule{T}) where T <: NCRingElement = M.rank
 
 function gens(N::FreeModule{T}) where T <: NCRingElement

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -133,6 +133,39 @@ end
 
 ###############################################################################
 #
+#   Some functions for residue rings of integers
+#
+###############################################################################
+
+function order(R::EuclideanRingResidueRing{BigInt})
+  return abs(modulus(R))
+end
+
+function length(R::EuclideanRingResidueRing{BigInt})
+  return order(R)
+end
+
+function Base.iterate(R::EuclideanRingResidueRing{BigInt})
+  I = big(0):(modulus(R) - 1)
+  _st = Base.iterate(I)
+  if _st === nothing
+    return nothing
+  end
+  x, st = _st
+  return R(x), (I, st)
+end
+
+function Base.iterate(R::EuclideanRingResidueRing{BigInt}, (I, st))
+  _st = Base.iterate(I, st)
+  if _st === nothing
+    return nothing
+  end
+  x, st = _st
+  return R(x), (I, st)
+end
+
+###############################################################################
+#
 #   Unsafe functions
 #
 ###############################################################################

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -44,6 +44,7 @@ import Base: isequal
 import Base: isless
 import Base: isone
 import Base: iszero
+import Base: iterate
 import Base: lcm
 import Base: length
 import Base: mod

--- a/test/generic/FreeModule-test.jl
+++ b/test/generic/FreeModule-test.jl
@@ -30,6 +30,22 @@ end
    @test rank(M) == 5
 end
 
+@testset "Generic.FreeModule.order_and_iteration" begin
+   R, = residue_ring(ZZ, 4)
+   M = free_module(R, 2)
+
+   @test order(M) == 16
+   @test length(M) == 16
+   @test eltype(M) == elem_type(M)
+   @test collect(M) == [M([i, j]) for j in 0:3 for i in 0:3]
+
+   N = free_module(R, 0)
+
+   @test order(N) == 1
+   @test length(N) == 1
+   @test collect(N) == [zero(N)]
+end
+
 @testset "Generic.FreeModule.unary_ops" begin
    R, x = polynomial_ring(ZZ, "x")
 

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -118,6 +118,19 @@ end
    @test is_trivial(R)
 end
 
+@testset "EuclideanRingResidueRingElem.order_and_iteration" begin
+   R, = residue_ring(ZZ, 4)
+
+   @test order(R) == 4
+   @test length(R) == 4
+   @test collect(R) == [R(i) for i in 0:3]
+
+   R, = residue_ring(ZZ, 1)
+
+   @test order(R) == 1
+   @test collect(R) == [zero(R)]
+end
+
 @testset "EuclideanRingResidueRingElem.rand" begin
    R, = Generic.residue_ring(ZZ, 49)
 


### PR DESCRIPTION
- add some iterator interface functions for residue rings of ZZ to be
  able to write some tests
- closes #2491

With this PR, the following works:

```
julia> R, = residue_ring(ZZ, 4);

julia> natural_gset(G)
G-set of
  matrix group of degree 2 over R
  with seeds [(0, 0), (1, 0), (2, 0), (3, 0), (0, 1), (1, 1), (2, 1), (3, 1), (0, 2), (1, 2), (2, 2), (3, 2), (0, 3), (1, 3), (2, 3), (
  3, 3)]
```

CC: @ThomasBreuer 