### PR TITLE
Adjust banner heuristic for Julia 1.14

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,10 +53,14 @@ function is_loaded_directly()
       # 1.12.0-DEV.896:   78 /  61 # ignored
       # 1.12.0-DEV.1322:  88 /  72 # ignored
       # 1.12.0-DEV.1506: 106 /  93
+      # 1.13.0-rc3:      106 /  93
+      # 1.14.0-DEV.3105: 117 / 104
       @static if v"1.11.0-" < VERSION < v"1.12.0-DEV.1506"
         return line_difference >= 73
-      else # v"1.12.0-DEV.1506" <= VERSION
+      elseif VERSION < v"1.14.0-DEV"
         return line_difference >= 100
+      else # v"1.14.0-DEV" <= VERSION
+        return line_difference >= 110
       end
     end
   catch e


### PR DESCRIPTION
Closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/2496.

The call to `_include_from_serialized` inside `_require_search_from_serialized` moved down by 11 lines, which pushed the indirect-load case above the previous threshold.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>