### PR TITLE
Fix `is_loaded_directly` for julia nightly

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,10 +53,17 @@ function is_loaded_directly()
       # 1.12.0-DEV.896:   78 /  61 # ignored
       # 1.12.0-DEV.1322:  88 /  72 # ignored
       # 1.12.0-DEV.1506: 106 /  93
+      # 1.12.7:          106 /  93
+      # 1.13.0-rc3:      106 /  93
+      # 1.14.0-DEV.3081: 105 /  92
+      # 1.14.0-DEV.3083: 114 / 101
+      # 1.14.0-DEV.3089: 117 / 104
       @static if v"1.11.0-" < VERSION < v"1.12.0-DEV.1506"
         return line_difference >= 73
-      else # v"1.12.0-DEV.1506" <= VERSION
+      elseif v"1.12.0-DEV.1506" <= VERSION < v"1.14.0-DEV.3083"
         return line_difference >= 100
+      else # v"1.14.0-DEV.3083" <= VERSION
+        return line_difference >= 110
       end
     end
   catch e

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,7 +57,6 @@ function is_loaded_directly()
       # 1.13.0-rc3:      106 /  93
       # 1.14.0-DEV.3081: 105 /  92
       # 1.14.0-DEV.3083: 114 / 101
-      # 1.14.0-DEV.3089: 117 / 104
       @static if v"1.11.0-" < VERSION < v"1.12.0-DEV.1506"
         return line_difference >= 73
       elseif v"1.12.0-DEV.1506" <= VERSION < v"1.14.0-DEV.3083"


### PR DESCRIPTION
Closes https://github.com/Nemocas/AbstractAlgebra.jl/pull/2495.

Fixes the `Banners` test failures on julia nightly (see e.g. https://github.com/Nemocas/AbstractAlgebra.jl/actions/runs/33739160823/job/101039283916?pr=2474#step:6:140).

Two recent commits to julia's `base/loading.jl` (JuliaLang/julia#62586 and JuliaLang/julia#62584) added lines to `_require_search_from_serialized`. The line offsets of the two `_include_from_serialized` calls relative to the function start moved from 92/105 to 101/114 (1.14.0-DEV.3083) and then to 104/117 (1.14.0-DEV.3089). The old threshold of 100 thus classified loading as a dependency as a direct load, so the banners of dependencies were shown.

This adds a new version branch (`VERSION >= v"1.14.0-DEV.3083"`) with threshold 110, which lies between the two offsets for both new layouts.

Verified locally: the `Banners` testset passes on julia 1.14.0-DEV.3114 (the build used in the failing CI run) and on julia 1.12.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
