### PR TITLE
Fix closure boxes and test for them in CI

### DIFF
--- a/ext/TestExt/Groups-conformance-tests.jl
+++ b/ext/TestExt/Groups-conformance-tests.jl
@@ -319,7 +319,7 @@ function test_GroupElem_interface(g::GEl, h::GEl) where {GEl<:GroupElem}
           @test g .* [g, h] == [g * g, g * h]
           G = parent(g)
           if has_gens(G)
-              @test g .* gens(G) == [g * x for x in gens(G)]
+              @test g .* gens(G) == map(Base.Fix1(*, g), gens(G))
           end
       end
   end

--- a/ext/TestExt/Rings-conformance-tests.jl
+++ b/ext/TestExt/Rings-conformance-tests.jl
@@ -706,25 +706,25 @@ function test_MatSpace_interface(S::MatSpace; reps = 10)
          end
 
          # zero matrices
-         a = zero_matrix(R, nrows(S), ncols(S))
-         @test parent(a) === S
-         @test iszero(a)
-         a = zero(S)
-         @test parent(a) === S
-         @test iszero(a)
+         z = zero_matrix(R, nrows(S), ncols(S))
+         @test parent(z) === S
+         @test iszero(z)
+         z = zero(S)
+         @test parent(z) === S
+         @test iszero(z)
 
          # (truncated) identity matrices
          if nrows(S) == ncols(S)
-            a = diagonal_matrix(one(R), nrows(S), ncols(S))
-            @test parent(a) === S
-            @test isone(a)
-            a = one(S)
-            @test parent(a) === S
-            @test isone(a)
+            e = diagonal_matrix(one(R), nrows(S), ncols(S))
+            @test parent(e) === S
+            @test isone(e)
+            e = one(S)
+            @test parent(e) === S
+            @test isone(e)
          else
-            a = diagonal_matrix(one(R), nrows(S), ncols(S))
-            @test parent(a) === S
-            @test !isone(a)
+            e = diagonal_matrix(one(R), nrows(S), ncols(S))
+            @test parent(e) === S
+            @test !isone(e)
             @test_throws DomainError one(S)
          end
       end

--- a/src/Poly.jl
+++ b/src/Poly.jl
@@ -3092,7 +3092,7 @@ function power_sums_to_polynomial(P::Vector{T}, Rx::PolyRing{T}) where T <: Ring
             last_non_zero = k
         end
     end
-    E = E[1:last_non_zero + 1]
+    resize!(E, last_non_zero + 1)
     d = length(E) # the length of the resulting polynomial
     for i = 1:div(d, 2)
         E[i], E[d - i + 1] = (-1)^(d - i)*E[d - i + 1], (-1)^(i - 1)*E[i]

--- a/src/algorithms/MPolyFactor.jl
+++ b/src/algorithms/MPolyFactor.jl
@@ -441,7 +441,7 @@ function hlift_with_lcc(
     end
   end
 
-  lcs = [divs[j]*m for j in 1:r]
+  lcs = divs .* m
   ok, fac = hlift_have_lcs(A*m^(r - 1), Auf, lcs, mainvar, minorvars, alphas)
 
   if !ok
@@ -500,7 +500,7 @@ function hlift_have_lcs(
   liftdegs = [tdegs[minorvars[i]] for i in 1:n]
 
   for i in 2:n+1
-    tfac = [set_lc(fac[j], mainvar, lc_evals[i, j]) for j in 1:r]
+    tfac = [set_lc(f, mainvar, lc_evals[i, j]) for (j, f) in enumerate(fac)]
     ok, fac = hliftstep(tfac, mainvar, minorvars[1:i-1], liftdegs, alphas,
                                                               A_evals[i], true)
     if !ok

--- a/src/exercise.jl
+++ b/src/exercise.jl
@@ -753,7 +753,7 @@ function exercise_MatSpace_interface(S::MatSpace)
          end
       end
 
-      begin
+      let # `a` must not share scope with the loops above (closure boxes)
           a = matrix(R, [1 2 ; 3 4])
           b = swap_rows(a, 1, 2)
           @assert b == matrix(R, [3 4 ; 1 2])

--- a/src/generic/AbsMSeries.jl
+++ b/src/generic/AbsMSeries.jl
@@ -519,7 +519,7 @@ function Base.inv(a::AbsMSeries)
         # Therefore, with max_n = sum(a.prec), we are done if cur_n >= max_n
         while true
             cur_n *= 2
-            trunc = [min(a.prec[i], cur_n) for i in 1:nvars(R)]
+            trunc = min.(a.prec, cur_n)
             set_precision!(ainv, trunc)
             e = 2 - truncate(a, trunc)*ainv
             (trunc == a.prec && isone(e)) && break

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -596,13 +596,11 @@ end
 
    function EuclideanRingResidueRing{T}(modulus::T, cached::Bool = true) where T <: RingElement
       c = canonical_unit(modulus)
-      if !isone(c)
-        modulus = divexact(modulus, c)
-      end
-      R = parent(modulus)
+      m = isone(c) ? modulus : divexact(modulus, c)
+      R = parent(m)
 
-      return get_cached!(ModulusDict, (R, modulus), cached) do
-         new{T}(R, modulus)
+      return get_cached!(ModulusDict, (R, m), cached) do
+         new{T}(R, m)
       end::EuclideanRingResidueRing{T}
    end
 end
@@ -628,12 +626,10 @@ end
 
    function EuclideanRingResidueField{T}(modulus::T, cached::Bool = true) where T <: RingElement
       c = canonical_unit(modulus)
-      if !isone(c)
-        modulus = divexact(modulus, c)
-      end
-      R = parent(modulus)
-      return get_cached!(ModulusFieldDict, (R, modulus), cached) do
-         new{T}(R, modulus)
+      m = isone(c) ? modulus : divexact(modulus, c)
+      R = parent(m)
+      return get_cached!(ModulusFieldDict, (R, m), cached) do
+         new{T}(R, m)
       end::EuclideanRingResidueField{T}
    end
 end

--- a/src/generic/Ideal.jl
+++ b/src/generic/Ideal.jl
@@ -1437,7 +1437,7 @@ end
    B = [divexact(d, canonical_unit(d)) for d in B]
    # do tail reduction if requested
    if complete_reduction
-      B = [tail_reduce(d, B) for d in B]
+      B = tail_reduce.(B, Ref(B))
    end
    # sort by leading monomial then leading coefficient
    B = sort!(B, lt = isless_monomial_lc)

--- a/src/generic/InvariantFactorDecomposition.jl
+++ b/src/generic/InvariantFactorDecomposition.jl
@@ -144,6 +144,15 @@ end
 #
 ###############################################################################
 
+# Number of leading diagonal entries of `S` that are units
+function _num_leading_unit_entries(S::MatElem)
+   n = min(nrows(S), ncols(S))
+   for i in 1:n
+      is_unit(S[i, i]) || return i - 1
+   end
+   return n
+end
+
 @doc raw"""
     snf(m::FPModule{T}) where T <: RingElement
 
@@ -161,29 +170,20 @@ function snf(m::AbstractAlgebra.FPModule{T}) where T <: RingElement
    A = matrix(R, r, s, T[old_rels[i][1, j] for i in 1:r for j in 1:s])
    # compute the snf
    S, U, K = snf_with_transform(A)
-   # count unit invariant factors
-   nunits = 0
-   while nunits < min(nrows(S), ncols(S))
-      nunits += 1
-      if !is_unit(S[nunits, nunits])
-         nunits -= 1
-         break
-      end
-   end
+   nunits = _num_leading_unit_entries(S)
    num_gens = nrows(S) - nunits
    # Make matrix for inverse isomorphism
    mat_inv = matrix(R, nrows(K), ncols(A) - nunits,
         T[K[i, j + nunits] for i in 1:nrows(K) for j in 1:ncols(A) - nunits])
-   # compute K^-1
-   K = inv(K)
-   # Make generators out of cols of matrix K
+   Kinv = inv(K)
+   # Make generators out of cols of matrix Kinv
    # throwing away ones corresponding to unit invariant factors
    T2 = elem_type(m)
    gens = Vector{T2}(undef, ncols(A) - nunits)
    for i = 1:ncols(A) - nunits
-      gens[i] = m(matrix(R, 1, ncols(K),
-                    T[K[i + nunits, j]
-                       for j in 1:ncols(K)]))
+      gens[i] = m(matrix(R, 1, ncols(Kinv),
+                    T[Kinv[i + nunits, j]
+                       for j in 1:ncols(Kinv)]))
    end
    # extract invariant factors from S
    invariant_factors = T[S[i + nunits, i + nunits] for i in 1:num_gens]
@@ -191,8 +191,8 @@ function snf(m::AbstractAlgebra.FPModule{T}) where T <: RingElement
       push!(invariant_factors, zero(R))
    end
    # make matrix from gens
-   mat = matrix(R, ncols(A) - nunits, ncols(K),
-        T[gens[i][j] for i in 1:ncols(A) - nunits for j in 1:ncols(K)])
+   mat = matrix(R, ncols(A) - nunits, ncols(Kinv),
+        T[gens[i][j] for i in 1:ncols(A) - nunits for j in 1:ncols(Kinv)])
    M = SNFModule{T}(m, gens, invariant_factors)
    f = ModuleIsomorphism{T}(M, m, mat, mat_inv)
    M.map = f
@@ -212,15 +212,7 @@ function invariant_factors(m::AbstractAlgebra.FPModule{T}) where T <: RingElemen
    A = matrix(R, r, s, T[old_rels[i][1, j] for i in 1:r for j in 1:s])
    # compute the snf
    S = snf(A)
-   # count unit invariant factors
-   nunits = 0
-   while nunits < min(nrows(S), ncols(S))
-      nunits += 1
-      if !is_unit(S[nunits, nunits])
-         nunits -= 1
-         break
-      end
-   end
+   nunits = _num_leading_unit_entries(S)
    num_gens = nrows(S) - nunits
    # extract invariant factors from S
    invariant_factors = T[S[i + nunits, i + nunits] for i in 1:num_gens]

--- a/src/generic/QuotientModule.jl
+++ b/src/generic/QuotientModule.jl
@@ -238,11 +238,10 @@ function make_direct_sub(m::Submodule{T}, subm::Submodule{T}) where T <: RingEle
   found = false
   while isa(up, Submodule)
      push!(chain_s, up.map)
-     up = codomain(up.map)
-     if any(x->codomain(x) === up, chain_m)
-        found = true
-        break
-     end
+     cod = codomain(up.map)
+     found = any(x->codomain(x) === cod, chain_m)
+     found && break
+     up = cod
   end
 
   found || error("module is not a submodule")
@@ -269,35 +268,29 @@ function quo(m::AbstractAlgebra.FPModule{T}, subm::Submodule{T}) where T <: Ring
      @assert is_submodule(m, subm)
    end
 
+   subm === m && return _quo_by_itself(m)
+
    R = base_ring(m)
-   if subm === m # quotient of submodule by itself
-      srels = dense_matrix_type(T)[_matrix(v) for v in gens(subm)]
-      combined_rels = compute_combined_rels(m, srels)
-      M = QuotientModule{T}(m, combined_rels)
-      f = ModuleHomomorphism(m, M,
-          matrix(R, ngens(m), 0, T[]))
-   else
+   G = generators(subm)
+   S = subm
+   if supermodule(S) !== m
+      while supermodule(S) !== m
+         G = elem_type(typeof(supermodule(S.m)))[S.m.map(v) for v in G]
+         S = supermodule(S)
+      end
+      subm, v = sub(m, G)
       G = generators(subm)
-      S = subm
-      if supermodule(S) !== m
-         while supermodule(S) !== m
-            G = elem_type(typeof(supermodule(S.m)))[S.m.map(v) for v in G]
-            S = supermodule(S)
-         end
-         subm, v = sub(m, G)
-         G = generators(subm)
-      end
-      nrels = ngens(subm)
-      srels = Vector{dense_matrix_type(T)}(undef, nrels)
-      for i = 1:nrels
-         srels[i] = _matrix(G[i])
-      end
-      combined_rels = compute_combined_rels(m, srels)
-      M = QuotientModule{T}(m, combined_rels)
-      hvecs = dense_matrix_type(T)[projection(_matrix(x), combined_rels, M) for x in gens(m)]
-      hmat = T[hvecs[i][1, j] for i in 1:ngens(m) for j in 1:ngens(M)]
-      f = ModuleHomomorphism(m, M, matrix(R, ngens(m), ngens(M), hmat))
    end
+   nrels = ngens(subm)
+   srels = Vector{dense_matrix_type(T)}(undef, nrels)
+   for i = 1:nrels
+      srels[i] = _matrix(G[i])
+   end
+   combined_rels = compute_combined_rels(m, srels)
+   M = QuotientModule{T}(m, combined_rels)
+   hvecs = dense_matrix_type(T)[projection(_matrix(x), combined_rels, M) for x in gens(m)]
+   hmat = T[hvecs[i][1, j] for i in 1:ngens(m) for j in 1:ngens(M)]
+   f = ModuleHomomorphism(m, M, matrix(R, ngens(m), ngens(M), hmat))
    M.map = f
    return M, f
 end
@@ -306,11 +299,16 @@ function quo(m::AbstractAlgebra.FPModule{T}, subm::AbstractAlgebra.FPModule{T}) 
    # The only case we need to deal with here is where `m == subm`. In all other
    # cases, subm will be of type Submodule.
    m !== subm && error("Not a submodule in QuotientModule constructor")
-   srels = dense_matrix_type(T)[_matrix(v) for v in gens(subm)]
+   return _quo_by_itself(m)
+end
+
+# quotient of a module by itself
+function _quo_by_itself(m::AbstractAlgebra.FPModule{T}) where T <: RingElement
+   srels = dense_matrix_type(T)[_matrix(v) for v in gens(m)]
    combined_rels = compute_combined_rels(m, srels)
    M = QuotientModule{T}(m, combined_rels)
    R = base_ring(m)
-   f = ModuleHomomorphism(m, M, matrix(R, ngens(m), 0, []))
+   f = ModuleHomomorphism(m, M, matrix(R, ngens(m), 0, T[]))
    M.map = f
    return M, f
 end

--- a/test/ClosureBoxes.jl
+++ b/test/ClosureBoxes.jl
@@ -1,0 +1,13 @@
+# Captured variables that are reassigned force Julia to allocate a `Core.Box`,
+# which defeats type inference. `Test.detect_closure_boxes` exists since
+# Julia 1.14.
+if isdefined(Test, :detect_closure_boxes)
+  @testset "Closure boxes" begin
+    mods = [AbstractAlgebra, Base.get_extension(AbstractAlgebra, :TestExt)]
+    boxes = Test.detect_closure_boxes(mods...)
+    for (m, vars) in boxes
+      println("Boxed variable(s) ", join(vars, ", "), " in ", m)
+    end
+    @test length(boxes) == 0
+  end
+end

--- a/test/algorithms/MPolyFactor-test.jl
+++ b/test/algorithms/MPolyFactor-test.jl
@@ -14,6 +14,20 @@
       @test f == fac
    end
 
+   @testset "hlift_with_lcc" begin
+
+      R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
+
+      fac = [y*x^2+z, (z+1)*x^3+x*y+z, (y*z+1)*x^2+1]
+
+      ok, f = AbstractAlgebra.MPolyFactor.hlift_with_lcc(prod(fac),
+                                          [x^2+1, 2*x^3+x+1, 2*x^2+1],
+                                          [y, z+1, y*z+1],
+                                          1, [2, 3], [QQ(1), QQ(1)])
+      @test ok
+      @test f == fac
+   end
+
    @testset "hlift_bivar_combine" begin
 
       R, (x, y) = polynomial_ring(QQ, ["x", "y"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,5 +28,6 @@ end
 include("utils/Banners/banners.jl")
 
 include("Aqua.jl")
+include("ClosureBoxes.jl")
 include("rand.jl")
 include("AbstractAlgebra-test.jl")


### PR DESCRIPTION
Julia 1.14 adds `Test.detect_closure_boxes` (JuliaLang/julia#60478). It lists methods whose lowered code allocates `Core.Box`, which happens when a closure captures a variable that is assigned more than once. Such boxes defeat type inference for that variable.

Running it on AbstractAlgebra and its Test extension found 13 methods. Note that a typed comprehension with a single range (`T[f(i) for i in 1:n]`) is lowered to a plain loop and creates no closure; only untyped, multi-dimensional or nested comprehensions, generators, `do` blocks and anonymous functions do.

### Fixes

Each keeps the captured variable single-assigned.

- `power_sums_to_polynomial`: `resize!` instead of rebinding `E`.
- `MPolyFactor.hlift_with_lcc` / `hlift_have_lcs`: broadcast, and iterate with `enumerate` so the comprehension no longer references the reassigned vector.
- `EuclideanRingResidueRing` / `EuclideanRingResidueField` constructors: normalised modulus goes into a fresh local for the `do` closure.
- `inv(::AbsMSeries)`: `min.(a.prec, cur_n)`.
- `Ideal.reduce_gens`: `tail_reduce.(B, Ref(B))`.
- `snf`: inverse matrix gets its own name; the unit-counting loop became `_num_leading_unit_entries`, also used by `invariant_factors`.
- `make_direct_sub`: closure captures a per-iteration local.
- `quo(::FPModule, ::Submodule)`: the quotient-by-itself branch duplicated the sibling `quo` method, so both now call `_quo_by_itself` and the main path returns early.
- `exercise_MatSpace_interface` and the conformance tests in `TestExt`: scoping and renames in test code.

### CI

`test/ClosureBoxes.jl` runs the detector on the package and its Test extension and requires zero hits, printing any offenders first. It is skipped where the function is missing, so only the `nightly` job covers it until Julia 1.14 is released.

Full test suite passes locally on Julia 1.10 and nightly (1.14.0-DEV.3112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
