### PR TITLE
Change `matrix_repr` for `Perm` and `YoungTableau` to return a dense matrix by default (can be overridden with new first argument); make SparseArrays a weak dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,15 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extensions]
 IJuliaExt = "IJulia"
+SparseArraysExt = "SparseArrays"
 TestExt = "Test"
 
 [compat]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Documenter = "1.16"

--- a/ext/SparseArraysExt/SparseArraysExt.jl
+++ b/ext/SparseArraysExt/SparseArraysExt.jl
@@ -1,0 +1,35 @@
+module SparseArraysExt
+
+using AbstractAlgebra
+using AbstractAlgebra.Generic: YoungTableau, SkewDiagram
+using SparseArrays: sparse, spzeros
+
+import AbstractAlgebra: matrix_repr
+
+# Docstrings for these methods are in src/generic/PermGroups.jl and
+# src/generic/YoungTabs.jl.
+
+matrix_repr(a::Perm{T}) where {T<:Integer} = sparse(collect(T, 1:length(a.d)), a.d, ones(T, length(a.d)))
+
+function matrix_repr(Y::YoungTableau{T}) where {T<:Integer}
+   tab = spzeros(T, length(Y.part), Y.part[1])
+   k = 1
+   for (idx, p) in enumerate(Y.part)
+      tab[idx, 1:p] = Y.fill[k:k+p-1]
+      k += p
+   end
+   return tab
+end
+
+function matrix_repr(xi::SkewDiagram)
+   skdiag = spzeros(eltype(xi), size(xi)...)
+   for i in 1:length(xi.mu)
+      skdiag[i, xi.mu[i]+1:xi.lam[i]] .= 1
+   end
+   for i in length(xi.mu)+1:length(xi.lam)
+      skdiag[i, 1:xi.lam[i]] .= 1
+   end
+   return skdiag
+end
+
+end # module

--- a/ext/SparseArraysExt/SparseArraysExt.jl
+++ b/ext/SparseArraysExt/SparseArraysExt.jl
@@ -1,35 +1,14 @@
 module SparseArraysExt
 
 using AbstractAlgebra
-using AbstractAlgebra.Generic: YoungTableau, SkewDiagram
-using SparseArrays: sparse, spzeros
+using SparseArrays: SparseMatrixCSC, sparse
 
 import AbstractAlgebra: matrix_repr
 
-# Docstrings for these methods are in src/generic/PermGroups.jl and
-# src/generic/YoungTabs.jl.
-
-matrix_repr(a::Perm{T}) where {T<:Integer} = sparse(collect(T, 1:length(a.d)), a.d, ones(T, length(a.d)))
-
-function matrix_repr(Y::YoungTableau{T}) where {T<:Integer}
-   tab = spzeros(T, length(Y.part), Y.part[1])
-   k = 1
-   for (idx, p) in enumerate(Y.part)
-      tab[idx, 1:p] = Y.fill[k:k+p-1]
-      k += p
-   end
-   return tab
-end
-
-function matrix_repr(xi::SkewDiagram)
-   skdiag = spzeros(eltype(xi), size(xi)...)
-   for i in 1:length(xi.mu)
-      skdiag[i, xi.mu[i]+1:xi.lam[i]] .= 1
-   end
-   for i in length(xi.mu)+1:length(xi.lam)
-      skdiag[i, 1:xi.lam[i]] .= 1
-   end
-   return skdiag
+# Documented in src/generic/PermGroups.jl
+function matrix_repr(::Type{M}, a::Perm{T}) where {M<:SparseMatrixCSC, T}
+   n = length(a.d)
+   return convert(M, sparse(1:n, a.d, ones(T, n)))
 end
 
 end # module

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -687,13 +687,17 @@ is_abelian(G::SymmetricGroup) = G.n <= 2
 Return the permutation matrix as a sparse matrix representing `a` via natural
 embedding of the permutation group into the general linear group over $\mathbb{Z}$.
 
+Requires `SparseArrays` to be loaded.
+
 # Examples
 ```jldoctest
+julia> using SparseArrays
+
 julia> p = Perm([2,3,1])
 (1,2,3)
 
 julia> matrix_repr(p)
-3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 3 stored entries:
+3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
  ⋅  1  ⋅
  ⋅  ⋅  1
  1  ⋅  ⋅
@@ -705,7 +709,12 @@ julia> Array(ans)
  1  0  0
 ```
 """
-matrix_repr(a::Perm{T}) where {T<:Integer} = sparse(collect(T, 1:length(a.d)), a.d, ones(T,length(a.d)))
+matrix_repr(::Perm)
+
+# The actual methods live in the SparseArraysExt package extension.
+function matrix_repr(::Union{Perm, YoungTableau, SkewDiagram})
+   throw(ArgumentError("`matrix_repr` requires `using SparseArrays`"))
+end
 
 @doc raw"""
     emb!(result::Perm, p::Perm, V)

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -682,38 +682,46 @@ order(::Type{T}, g::Perm) where {T} =
 is_abelian(G::SymmetricGroup) = G.n <= 2
 
 @doc raw"""
-    matrix_repr(a::Perm)
+    matrix_repr(a::Perm{T}) -> Matrix{T}
+    matrix_repr(M::Type{<:Matrix}, a::Perm)
+    matrix_repr(M::Type{<:SparseMatrixCSC}, a::Perm)
 
-Return the permutation matrix as a sparse matrix representing `a` via natural
-embedding of the permutation group into the general linear group over $\mathbb{Z}$.
+Return the permutation matrix representing `a` via the natural embedding of
+the permutation group into the general linear group over $\mathbb{Z}$.
 
-Requires `SparseArrays` to be loaded.
+The result type can be chosen via `M`; if `M` has no element type, the
+integer type of `a` is used. The sparse variant requires `SparseArrays`
+to be loaded.
 
 # Examples
 ```jldoctest
-julia> using SparseArrays
-
 julia> p = Perm([2,3,1])
 (1,2,3)
 
 julia> matrix_repr(p)
-3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
- ⋅  1  ⋅
- ⋅  ⋅  1
- 1  ⋅  ⋅
-
-julia> Array(ans)
 3×3 Matrix{Int64}:
  0  1  0
  0  0  1
  1  0  0
+
+julia> using SparseArrays
+
+julia> matrix_repr(SparseMatrixCSC, p)
+3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
+ ⋅  1  ⋅
+ ⋅  ⋅  1
+ 1  ⋅  ⋅
 ```
 """
-matrix_repr(::Perm)
+matrix_repr(a::Perm{T}) where T = matrix_repr(Matrix{T}, a)
 
-# The actual methods live in the SparseArraysExt package extension.
-function matrix_repr(::Union{Perm, YoungTableau, SkewDiagram})
-   throw(ArgumentError("`matrix_repr` requires `using SparseArrays`"))
+function matrix_repr(::Type{M}, a::Perm{T}) where {M<:Matrix, T}
+   n = length(a.d)
+   P = zeros(T, n, n)
+   for (i, j) in enumerate(a.d)
+      P[i, j] = 1
+   end
+   return convert(M, P)
 end
 
 @doc raw"""

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -529,27 +529,22 @@ end
 
 Construct sparse integer matrix representing the tableau.
 
+Requires `SparseArrays` to be loaded.
+
 # Examples
 ```jldoctest
+julia> using SparseArrays
+
 julia> y = YoungTableau([4,3,1]);
 
-
 julia> matrix_repr(y)
-3×4 SparseArrays.SparseMatrixCSC{Int64, Int64} with 8 stored entries:
+3×4 SparseMatrixCSC{Int64, Int64} with 8 stored entries:
  1  2  3  4
  5  6  7  ⋅
  8  ⋅  ⋅  ⋅
 ```
 """
-function matrix_repr(Y::YoungTableau{T}) where T
-   tab = spzeros(T, length(Y.part), Y.part[1])
-   k=1
-   for (idx, p) in enumerate(Y.part)
-      tab[idx, 1:p] = Y.fill[k:k+p-1]
-      k += p
-   end
-   return tab
-end
+matrix_repr(::YoungTableau)
 
 @doc raw"""
     fill!(Y::YoungTableaux, V::Vector{<:Integer})
@@ -817,17 +812,10 @@ end
 
 Return a sparse representation of the diagram `xi`, i.e. a sparse array `A`
 where `A[i,j] == 1` if and only if `(i,j)` is in `xi.lam` but not in `xi.mu`.
+
+Requires `SparseArrays` to be loaded.
 """
-function matrix_repr(xi::SkewDiagram)
-   skdiag = spzeros(eltype(xi), size(xi)...)
-   for i in 1:length(xi.mu)
-      skdiag[i, xi.mu[i]+1:xi.lam[i]] .= 1
-   end
-   for i in length(xi.mu)+1:length(xi.lam)
-      skdiag[i,1:xi.lam[i]] .= 1
-   end
-   return skdiag
-end
+matrix_repr(::SkewDiagram)
 
 @doc raw"""
     has_left_neighbor(xi::SkewDiagram, i::Integer, j::Integer)

--- a/src/generic/YoungTabs.jl
+++ b/src/generic/YoungTabs.jl
@@ -525,26 +525,25 @@ end
 ##############################################################################
 
 @doc raw"""
-    matrix_repr(Y::YoungTableau)
+    matrix_repr(Y::YoungTableau{T}) -> Matrix{T}
+    matrix_repr(M::Type{<:AbstractMatrix}, Y::YoungTableau) -> M
 
-Construct sparse integer matrix representing the tableau.
-
-Requires `SparseArrays` to be loaded.
+Construct an integer matrix representing the tableau; equivalent to `M(Y)`.
 
 # Examples
 ```jldoctest
-julia> using SparseArrays
-
 julia> y = YoungTableau([4,3,1]);
 
 julia> matrix_repr(y)
-3×4 SparseMatrixCSC{Int64, Int64} with 8 stored entries:
+3×4 Matrix{Int64}:
  1  2  3  4
- 5  6  7  ⋅
- 8  ⋅  ⋅  ⋅
+ 5  6  7  0
+ 8  0  0  0
 ```
 """
-matrix_repr(::YoungTableau)
+matrix_repr(Y::YoungTableau{T}) where T = matrix_repr(Matrix{T}, Y)
+
+matrix_repr(::Type{M}, Y::YoungTableau) where {M<:AbstractMatrix} = M(Y)
 
 @doc raw"""
     fill!(Y::YoungTableaux, V::Vector{<:Integer})
@@ -808,14 +807,15 @@ end
 ##############################################################################
 
 @doc raw"""
-    matrix_repr(xi::SkewDiagram)
+    matrix_repr(xi::SkewDiagram{T}) -> Matrix{T}
+    matrix_repr(M::Type{<:AbstractMatrix}, xi::SkewDiagram) -> M
 
-Return a sparse representation of the diagram `xi`, i.e. a sparse array `A`
-where `A[i,j] == 1` if and only if `(i,j)` is in `xi.lam` but not in `xi.mu`.
-
-Requires `SparseArrays` to be loaded.
+Return a matrix `A` representing the diagram `xi`, i.e. `A[i,j] == 1` if and
+only if `(i,j)` is in `xi.lam` but not in `xi.mu`; equivalent to `M(xi)`.
 """
-matrix_repr(::SkewDiagram)
+matrix_repr(xi::SkewDiagram{T}) where T = matrix_repr(Matrix{T}, xi)
+
+matrix_repr(::Type{M}, xi::SkewDiagram) where {M<:AbstractMatrix} = M(xi)
 
 @doc raw"""
     has_left_neighbor(xi::SkewDiagram, i::Integer, j::Integer)

--- a/src/generic/imports.jl
+++ b/src/generic/imports.jl
@@ -4,7 +4,6 @@ import LinearAlgebra: tr
 
 using Random: Random, AbstractRNG, randperm!, SamplerTrivial
 using RandomExtensions: RandomExtensions, make, Make, Make2, Make3, Make4
-using SparseArrays: sparse, spzeros
 
 import Base: !=
 import Base: &

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,10 +2,12 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.2"
 Pkg = "1.6"
 REPL = "1.6"
+SparseArrays = "1.6"
 Test = "1.6"

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -291,6 +291,11 @@ end
    @test order(a) == 6
    @test a^6 == one(G)
 
+   M = matrix_repr(a)
+   @test M isa SparseMatrixCSC{T}
+   @test all(M[i, a[i]] == 1 for i in 1:10)
+   @test count(!iszero, M) == 10
+
    p = G([9,5,4,7,3,8,2,10,1,6])
 
    @test collect(cycles(p)) == [T[1,9],T[2,5,3,4,7],T[6,8,10]]

--- a/test/generic/Perm-test.jl
+++ b/test/generic/Perm-test.jl
@@ -292,9 +292,14 @@ end
    @test a^6 == one(G)
 
    M = matrix_repr(a)
-   @test M isa SparseMatrixCSC{T}
+   @test M isa Matrix{T}
    @test all(M[i, a[i]] == 1 for i in 1:10)
    @test count(!iszero, M) == 10
+   @test matrix_repr(Matrix{Int}, a) isa Matrix{Int}
+   @test matrix_repr(Matrix{Int}, a) == M
+   @test matrix_repr(SparseMatrixCSC, a) isa SparseMatrixCSC{T}
+   @test matrix_repr(SparseMatrixCSC, a) == M
+   @test matrix_repr(SparseMatrixCSC{Int}, a) isa SparseMatrixCSC{Int}
 
    p = G([9,5,4,7,3,8,2,10,1,6])
 

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -75,6 +75,10 @@ end
    @test Z isa Generic.YoungTableau
    @test Y == Z
    @test Z.fill !== Y.fill
+
+   M = matrix_repr(Y)
+   @test M isa SparseMatrixCSC{Int}
+   @test M == [1 2 3 4; 5 6 7 0; 8 0 0 0]
 end
 
 @testset "youngtabs.conjugation" begin

--- a/test/generic/YoungTabs-test.jl
+++ b/test/generic/YoungTabs-test.jl
@@ -77,8 +77,11 @@ end
    @test Z.fill !== Y.fill
 
    M = matrix_repr(Y)
-   @test M isa SparseMatrixCSC{Int}
+   @test M isa Matrix{Int}
    @test M == [1 2 3 4; 5 6 7 0; 8 0 0 0]
+   @test matrix_repr(Matrix{Int8}, Y) isa Matrix{Int8}
+   @test matrix_repr(SparseMatrixCSC, Y) isa SparseMatrixCSC{Int}
+   @test matrix_repr(SparseMatrixCSC, Y) == M
 end
 
 @testset "youngtabs.conjugation" begin
@@ -207,6 +210,9 @@ end
 
    @test matrix_repr(Partition([1], false)/Partition(Int[], false)) == ones(Int, 1,1)
    @test matrix_repr(xi) == [((i,j) in xi ? 1 : 0) for i in 1:size(xi.lam,1), j in 1:maximum(xi.lam)]
+   @test matrix_repr(xi) isa Matrix{Int}
+   @test matrix_repr(SparseMatrixCSC, xi) isa SparseMatrixCSC{Int}
+   @test matrix_repr(SparseMatrixCSC, xi) == matrix_repr(xi)
 
    @test has_left_neighbor(xi, 1, 5) == true
    @test has_left_neighbor(xi, 1, 3) == false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using AbstractAlgebra
 
 using Test
+using SparseArrays  # loads the SparseArraysExt extension
 
 
 # disable until we encounter GC problems again


### PR DESCRIPTION
Motivated by the discussion in thofma/Hecke.jl#1991: `using SparseArrays` adds noticeable load time to `using AbstractAlgebra` and everything downstream, yet AbstractAlgebra only uses it for the `matrix_repr` methods of `Perm`, `YoungTableau` and `SkewDiagram`.

### Changes

- `matrix_repr(x)` now returns a dense `Matrix{T}`.
- The result type is selectable via a leading type argument: `matrix_repr(Matrix{S}, x)` or `matrix_repr(SparseMatrixCSC{S}, x)` (element type optional; defaults to the integer type of `x`).
- `SparseArrays` becomes a weak dependency. Only the sparse `Perm` variant needs it and lives in the new `SparseArraysExt`; tableaux and skew diagrams are `AbstractMatrix` already, so `matrix_repr(M, x)` is just `M(x)`.
- New tests for `matrix_repr` on permutations and Young tableaux (previously untested).

### Breaking

`matrix_repr(x)` returns `Matrix` instead of `SparseMatrixCSC`. Use `matrix_repr(SparseMatrixCSC, x)` (with `using SparseArrays`) for the old result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Put the triage label on this as it is somewhat breaking, though I doubt it'll affect any of our code, and I hope it won't affect other people's code seriously. Still, a decision triage should make.