### PR TITLE
Fix rand(R) and rand(R, dims...) for residue rings

### DIFF
--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -415,18 +415,22 @@ function rand(rng::AbstractRNG,
    S(rand(rng, v))
 end
 
-function RandomExtensions.make(S::ResidueRing, vs...)
+function RandomExtensions.make(S::ResidueRing, v, vs...)
    R = base_ring(S)
-   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      Make(S, vs[1])
+   if isempty(vs) && elem_type(R) == Random.gentype(v)
+      Make(S, v)
    else
-      Make(S, make(R, vs...))
+      Make(S, make(R, v, vs...))
    end
 end
 
-rand(rng::AbstractRNG, S::ResidueRing, v...) = rand(rng, make(S, v...))
+# `v, vs...` describe how to sample from the base ring. With no such
+# specification at all, `rand(S)` and `rand(S, dims...)` keep their `Base`
+# meaning -- one resp. an array of uniformly random elements -- which is served
+# by whatever `Random.Sampler` the concrete residue ring provides.
+rand(rng::AbstractRNG, S::ResidueRing, v, vs...) = rand(rng, make(S, v, vs...))
 
-rand(S::ResidueRing, v...) = rand(Random.default_rng(), S, v...)
+rand(S::ResidueRing, v, vs...) = rand(Random.default_rng(), S, v, vs...)
 
 ###############################################################################
 #

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -432,6 +432,16 @@ rand(rng::AbstractRNG, S::ResidueRing, v, vs...) = rand(rng, make(S, v, vs...))
 
 rand(S::ResidueRing, v, vs...) = rand(Random.default_rng(), S, v, vs...)
 
+# An integer (or tuple of integers) is an array size, never a sampling
+# specification; saying so resolves the ambiguity with `Base.rand(X, dims...)`.
+rand(rng::AbstractRNG, S::ResidueRing, dims::Dims) = rand(rng, make(S), dims)
+
+rand(S::ResidueRing, dims::Dims) = rand(Random.default_rng(), S, dims)
+
+rand(rng::AbstractRNG, S::ResidueRing, d::Integer, dims::Integer...) = rand(rng, S, Dims((d, dims...)))
+
+rand(S::ResidueRing, d::Integer, dims::Integer...) = rand(Random.default_rng(), S, Dims((d, dims...)))
+
 ###############################################################################
 #
 #   residue_ring constructor

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -420,7 +420,7 @@ function RandomExtensions.make(S::ResidueRing, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1])
    else
-      Make(S, make(base_ring(S), vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -402,18 +402,22 @@ function rand(rng::AbstractRNG,
    S(rand(rng, v))
 end
 
-function RandomExtensions.make(S::ResidueField, vs...)
+function RandomExtensions.make(S::ResidueField, v, vs...)
    R = base_ring(S)
-   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      Make(S, vs[1])
+   if isempty(vs) && elem_type(R) == Random.gentype(v)
+      Make(S, v)
    else
-      Make(S, make(R, vs...))
+      Make(S, make(R, v, vs...))
    end
 end
 
-rand(rng::AbstractRNG, S::ResidueField, v...) = rand(rng, make(S, v...))
+# `v, vs...` describe how to sample from the base ring. With no such
+# specification at all, `rand(S)` and `rand(S, dims...)` keep their `Base`
+# meaning -- one resp. an array of uniformly random elements -- which is served
+# by whatever `Random.Sampler` the concrete residue ring provides.
+rand(rng::AbstractRNG, S::ResidueField, v, vs...) = rand(rng, make(S, v, vs...))
 
-rand(S::ResidueField, v...) = rand(Random.default_rng(), S, v...)
+rand(S::ResidueField, v, vs...) = rand(Random.default_rng(), S, v, vs...)
 
 ###############################################################################
 #

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -419,6 +419,16 @@ rand(rng::AbstractRNG, S::ResidueField, v, vs...) = rand(rng, make(S, v, vs...))
 
 rand(S::ResidueField, v, vs...) = rand(Random.default_rng(), S, v, vs...)
 
+# An integer (or tuple of integers) is an array size, never a sampling
+# specification; saying so resolves the ambiguity with `Base.rand(X, dims...)`.
+rand(rng::AbstractRNG, S::ResidueField, dims::Dims) = rand(rng, make(S), dims)
+
+rand(S::ResidueField, dims::Dims) = rand(Random.default_rng(), S, dims)
+
+rand(rng::AbstractRNG, S::ResidueField, d::Integer, dims::Integer...) = rand(rng, S, Dims((d, dims...)))
+
+rand(S::ResidueField, d::Integer, dims::Integer...) = rand(Random.default_rng(), S, Dims((d, dims...)))
+
 ###############################################################################
 #
 #   residue_field constructor

--- a/src/ResidueField.jl
+++ b/src/ResidueField.jl
@@ -407,7 +407,7 @@ function RandomExtensions.make(S::ResidueField, vs...)
    if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
       Make(S, vs[1])
    else
-      Make(S, make(base_ring(S), vs...))
+      Make(S, make(R, vs...))
    end
 end
 

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -72,6 +72,6 @@ function RandomExtensions.make(S::EuclideanRingResidueField{Poly{Rational{BigInt
       Make(S, vs[1])
    else
       n = degree(S.modulus)
-      Make(S, make(base_ring(S), n - 1:n - 1, vs...))
+      Make(S, make(R, n - 1:n - 1, vs...))
    end
 end

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -66,12 +66,12 @@ end
 #
 ################################################################################
 
-function RandomExtensions.make(S::EuclideanRingResidueField{Poly{Rational{BigInt}}}, vs...)
+function RandomExtensions.make(S::EuclideanRingResidueField{Poly{Rational{BigInt}}}, v, vs...)
    R = base_ring(S)
-   if length(vs) == 1 && elem_type(R) == Random.gentype(vs[1])
-      Make(S, vs[1])
+   if isempty(vs) && elem_type(R) == Random.gentype(v)
+      Make(S, v)
    else
       n = degree(S.modulus)
-      Make(S, make(R, n - 1:n - 1, vs...))
+      Make(S, make(R, n - 1:n - 1, v, vs...))
    end
 end

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -138,6 +138,14 @@ end
       @test 1 <= f.data <= 9
    end
 
+   # Carrying no sampling specification, `rand(R)` and `rand(R, dims...)` keep
+   # their `Base` meaning and must not be forwarded to the base ring: they ask
+   # `R` itself for a `Random.Sampler` (which AbstractAlgebra does not provide).
+   @test make(R) isa RandomExtensions.MakeWrap
+   @test which(rand, Tuple{typeof(R), Int}) isa Method       # i.e. unambiguous
+   @test which(rand, Tuple{typeof(R), Int, Int}) isa Method
+   @test which(rand, Tuple{typeof(R), Tuple{Int, Int}}) isa Method
+
    # make with 3 arguments
    P, x = polynomial_ring(RealField, "x")
    R, = Generic.residue_ring(P, x^3)

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -85,6 +85,14 @@ end
    test_rand(R, 1:9) do f
       @test 1 <= f.data <= 9
    end
+
+   # Carrying no sampling specification, `rand(R)` and `rand(R, dims...)` keep
+   # their `Base` meaning and must not be forwarded to the base ring: they ask
+   # `R` itself for a `Random.Sampler` (which AbstractAlgebra does not provide).
+   @test make(R) isa RandomExtensions.MakeWrap
+   @test which(rand, Tuple{typeof(R), Int}) isa Method       # i.e. unambiguous
+   @test which(rand, Tuple{typeof(R), Int, Int}) isa Method
+   @test which(rand, Tuple{typeof(R), Tuple{Int, Int}}) isa Method
 end
 
 @testset "EuclideanRingResidueFieldElem.manipulation" begin


### PR DESCRIPTION
`rand(S::ResidueRing, v...)` and its `ResidueField` twin also match the calls that carry no sampling specification at all, i.e. `rand(S)` and `rand(S, dims...)`. Both are then forwarded to the base ring, which has no sampler of its own:

```julia
julia> R, = residue_ring(ZZ, 49);

julia> rand(R)
ERROR: MethodError: no method matching Random.Sampler(::Type{TaskLocalRNG}, ::Random.SamplerTrivial{Integers{BigInt}, Any}, ::Val{1})

julia> rand(R, 2)
ERROR: MethodError: rand(::EuclideanRingResidueRing{BigInt}, ::Int64) is ambiguous.
```

This PR requires at least one sampling specification, and spells out the array forms so they resolve against `Base.rand(X, dims...)`. Residue rings that do provide a `Random.Sampler` are then reached instead of the base ring.

That is what Nemo needs for https://github.com/Nemocas/Nemo.jl/pull/1819, which makes `zzModRing` and `ZZModRing` `ResidueRing` subtypes: both already carry a `Random.Sampler` sampling the whole ring, but the generic methods above intercepted every `rand(R)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)