### PR TITLE
Handle `MatRingElem` in separate `lu` and `fflu` methods

### DIFF
--- a/docs/src/matrix_normal_forms.md
+++ b/docs/src/matrix_normal_forms.md
@@ -14,8 +14,8 @@ matrices which certify the result.
 ## LU factorisation
 
 ```@docs
-lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
-fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+lu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+fflu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
 ```
 
 

--- a/src/MatRing.jl
+++ b/src/MatRing.jl
@@ -493,6 +493,18 @@ function charpoly(S::PolyRing{T}, A::MatRingElem{T}) where {T <: RingElement}
   return charpoly(S, matrix(A))
 end
 
+function lu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+  S = parent(A)
+  r, p, L, U = lu(matrix(A), P)
+  return r, p, S(L), S(U)
+end
+
+function fflu(A::MatRingElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+  S = parent(A)
+  r, d, p, L, U = fflu(matrix(A), P)
+  return r, d, p, S(L), S(U)
+end
+
 ###############################################################################
 #
 #   Random generation

--- a/src/Matrix.jl
+++ b/src/Matrix.jl
@@ -2162,7 +2162,7 @@ julia> r, p, L, U = lu(M)
 (3, (), [1 0 0; 4 1 0; 0 0 1], [1 2 3; 0 -3 -6; 0 0 1])
 ```
 """
-function lu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
+function lu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: FieldElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")
@@ -2334,7 +2334,7 @@ julia> r, d, p, L, U = fflu(M)
 (3, -3//1, (), [1 0 0; 4 -3 0; 0 0 -3], [1 2 3; 0 -3 -6; 0 0 -3])
 ```
 """
-function fflu(A::MatrixElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
+function fflu(A::MatElem{T}, P = SymmetricGroup(nrows(A))) where {T <: RingElement}
    m = nrows(A)
    n = ncols(A)
    P.n != m && error("Permutation does not match matrix")


### PR DESCRIPTION
Split off from #2283, which needs this before it can drop the rectangular `similar(x::MatRingElem, m, n)`.

The generic `lu` and `fflu` build their `L` factor with `similar(A, m, m)`, which does not belong on `MatRingElem`. Restrict them to `MatElem` and let `MatRingElem` delegate to the underlying matrix, alongside the other `MatRing` delegations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)