### PR TITLE
Skip dividing by a trivial canonical unit in a fraction

### DIFF
--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -27,6 +27,7 @@ base_ring(a::FracField{T}) where T <: RingElem = a.base_ring::base_ring_type(a)
 function Base.numerator(a::FracFieldElem, canonicalise::Bool=true)
    if canonicalise
       u = canonical_unit(a.den)
+      isone(u) && return a.num
       return divexact(a.num, u)
    else
       return a.num
@@ -36,6 +37,7 @@ end
 function Base.denominator(a::FracFieldElem, canonicalise::Bool=true)
    if canonicalise
       u = canonical_unit(a.den)
+      isone(u) && return a.den
       return divexact(a.den, u)
    else
       return a.den


### PR DESCRIPTION
`numerator` and `denominator` divide out `canonical_unit(a.den)` on every call, and `hash(::FracElem)` calls both, so this runs on every dictionary lookup keyed by a fraction. Denominators are usually already canonical, in which case the division only copies.

Note that the result is then the stored numerator or denominator rather than a copy of it, as it already was for `canonicalise = false`.

For a fraction of multivariate polynomials over QQ in 49 variables the division costs around 150ns.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>