### PR TITLE
Hash a universal polynomial without copying exponents

### DIFF
--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -178,7 +178,7 @@ function Base.hash(p::UniversalRingElem{<:MPolyRingElem}, h::UInt)
       while l > 0 && iszero(v[l])
          l -= 1
       end
-      b = xor(b, xor(Base.hash(v[1:l], h), h))
+      b = xor(b, xor(Base.hash(view(v, 1:l), h), h))
       b = xor(b, xor(hash(c, h), h))
       b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
    end


### PR DESCRIPTION
Trailing zeros have to be dropped from an exponent vector so that the hash does not depend on how many variables happen to be materialised, but slicing allocates a fresh vector per term. A view hashes the same.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>