### PR TITLE
Fix ambiguous InjProjMat methods

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -185,7 +185,7 @@ function Base.getindex(K::InjProjMat{T}, i::Int, j::Int) where T
   return zero(base_ring(K))::T
 end
 
-function Base.setindex!(K::InjProjMat, i::Any, j::Any, val::Any)
+function Base.setindex!(K::InjProjMat, ::NCRingElement, ::Int, ::Int)
   error("InjProjMat is read-only")
 end
 
@@ -216,7 +216,7 @@ function *(b::MatElem{T}, c::InjProjMat{T}) where {T <: NCRingElement}
   end
 end
 
-function *(a::InjProjMat, b::InjProjMat)
+function *(a::InjProjMat{T}, b::InjProjMat{T}) where {T <: NCRingElement}
    @assert base_ring(a) === base_ring(b)
    R = base_ring(a)
    @assert ncols(a) == nrows(b)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -4397,7 +4397,13 @@ end
       end
    end
 
+   @test_throws ErrorException("InjProjMat is read-only") (M[1, 1] = 1)
+   @test_throws ErrorException("InjProjMat is read-only") (M[:, :] = zero_matrix(QQ, 4, 2))
+
    # Multiplication
+   @test !Base.isambiguous(
+      which(*, Tuple{typeof(M), MatElem{eltype(M)}}),
+      which(*, Tuple{MatElem{eltype(M)}, typeof(M)}))
    @test_throws AssertionError M*identity_matrix(QQ, 1)
    @test_throws AssertionError identity_matrix(QQ, 1)*M
    for iter in 1:10


### PR DESCRIPTION
`setindex!` took three untyped arguments, which made it ambiguous with every generic slice assignment on `MatrixElem` -- 16 ambiguities. Declare it like the primitive setter, `(::NCRingElement, ::Int, ::Int)`; the generic methods route through that one, so a slice assignment still reports the matrix as read-only.

`*(::InjProjMat, ::InjProjMat)` was unparametrised and hence not more specific than the mixed `InjProjMat`/`MatElem{T}` methods it exists to resolve.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
