### PR TITLE
Fix ambiguous `promote_rule` for `LaurentPolyWrap`

### DIFF
--- a/src/generic/LaurentPoly.jl
+++ b/src/generic/LaurentPoly.jl
@@ -472,7 +472,8 @@ end
 
 # TODO: add tests
 
-promote_rule(::Type{L}, ::Type{L}) where {L <: LaurentPolyWrap} = L
+promote_rule(::Type{LaurentPolyWrap{S, T, V}},
+             ::Type{LaurentPolyWrap{S, T, V}}) where {S, T, V} = LaurentPolyWrap{S, T, V}
 
 function promote_rule(::Type{LaurentPolyWrap{S, T, V}}, ::Type{U}) where {S, T, U, V}
    promote_rule(T, U) == T ? LaurentPolyWrap{S, T, V} : Union{}


### PR DESCRIPTION
`promote_rule(::Type{L}, ::Type{L}) where L <: LaurentPolyWrap` does not cover the intersection of `promote_rule(::Type{T}, ::Type{T})` from NCRings.jl with the `LaurentPolyWrap{S, T, V}` rule below it. Spell the parameters out.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
