### PR TITLE
Revise doc for is_square_with_sqrt

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -228,12 +228,18 @@ function Base.sqrt(a::FieldElem; check::Bool=true)
   error("Element $a does not have a square root")
 end
 
-# assumes the existence of is_square and sqrt for input
+@doc raw"""
+    is_square_with_sqrt(a::T) where T <: RingElement
+
+Return `(true, s)` if $a$ is a perfect square, where $s^2 = a$. Otherwise
+return `(false, ...)` where `...` is some element of `parent(a)`.
+"""
 function is_square_with_sqrt(a::RingElem)
+  # assumes the existence of is_square and sqrt for input
   if is_square(a)
      return true, sqrt(a)
   else
-     return false, parent(a)()
+     return false, a
   end
 end
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -277,12 +277,6 @@ function sqrt(a::T; check::Bool=true) where T <: Integer
    return s
 end
 
-@doc raw"""
-    is_square_with_sqrt(a::T) where T <: Integer
-
-Return `(true, s)` if $a$ is a perfect square, where $s^2 = a$. Otherwise
-return `(false, 0)`.
-"""
 function is_square_with_sqrt(a::T) where T <: Integer
    if a < 0
       return false, zero(T)


### PR DESCRIPTION
Simplify & unify doc for `is_square_with_sqrt`
Raises a question about the design evidenced by the impl of `is_square_with_sqrt` in `src/Rings.jl` near line 375

_Prompted by_  (cross-ref) Nemocas/Nemo.jl#2350