### PR TITLE
Fix evaluate of factored fractions over non-fields

### DIFF
--- a/src/generic/FactoredFraction.jl
+++ b/src/generic/FactoredFraction.jl
@@ -404,21 +404,33 @@ end
 #
 ##############################################################################
 
-function evaluate(f::FactoredFracFieldElem, v::Vector{<:RingElement})
-    z = evaluate(unit(f), v)
+# Split the factors by the sign of their exponent, as `numerator` and
+# `denominator` do, and divide only at the end: the values need not be
+# invertible, so `b^e` with `e < 0` would throw. Thus x//(x+y)^2 at (2, 3)
+# evaluates as 2//5^2, not as 2*5^-2.
+function _evaluate(f::FactoredFracFieldElem, v)
+    n = evaluate(unit(f), v)
+    d = one(n)
     for (b, e) in f
-        z *= evaluate(b, v)^e
+        if e < 0
+            d *= evaluate(b, v)^Base.checked_neg(e)
+        else
+            n *= evaluate(b, v)^e
+        end
     end
-    return z
+    return n//d
 end
 
-function evaluate(f::FactoredFracFieldElem, v::RingElement)
-    z = evaluate(unit(f), v)
-    for (b, e) in f
-        z *= evaluate(b, v)^e
-    end
-    return z
-end
+evaluate(f::FactoredFracFieldElem, v::Vector{<:RingElement}) = _evaluate(f, v)
+
+evaluate(f::FactoredFracFieldElem, v::RingElement) = _evaluate(f, v)
+
+# Neither the method above nor `evaluate(::FracElem{<:PolyRingElem}, ::Integer)`
+# in Fraction.jl is more specific than the other, so their intersection needs
+# its own method. Route it through `_evaluate` too: going via
+# `numerator(f)//denominator(f)` instead would multiply the factorisation out,
+# which is precisely what this type exists to avoid.
+evaluate(f::FactoredFracFieldElem{<:PolyRingElem}, v::Integer) = _evaluate(f, v)
 
 function (a::FactoredFracFieldElem)(val::RingElement)
    return evaluate(a, val)

--- a/test/generic/FactoredFraction-test.jl
+++ b/test/generic/FactoredFraction-test.jl
@@ -56,6 +56,19 @@ end
     @test evaluate(f, 2//3) == 2//5
     @test f(2//3) == 2//5
 
+    # a point in a ring that is not a field: the factor (x+1)^-1 must become a
+    # denominator, not a negative power. Integer points additionally sit in the
+    # ambiguity between evaluate(::FracElem{<:PolyRingElem}, ::Integer) and
+    # evaluate(::FactoredFracFieldElem, ::RingElement).
+    @test evaluate(f, 2) == 2//3
+    @test f(2) == 2//3
+    @test evaluate(f, big(2)) == 2//3
+    @test evaluate(f, ZZ(2)) == 2//3
+
+    # only non-negative exponents, so nothing lands in the denominator
+    @test evaluate(x*(x+1), 2) == 6
+    @test evaluate(x*(x+1), 2//3) == 10//9
+
     # multivariate
     Zxy, (x, y) = polynomial_ring(ZZ, ["x", "y"])
     F = factored_fraction_field(Zxy)
@@ -66,6 +79,15 @@ end
 
     @test evaluate(f, [1//3, 1//2]) == 12//25
     @test f(1//3, 1//2) == 12//25
+
+    # a point in a ring that is not a field
+    @test evaluate(f, [2, 3]) == 2//25
+    @test f(2, 3) == 2//25
+    @test evaluate(f, [ZZ(2), ZZ(3)]) == 2//25
+
+    # a unit other than one, and a denominator dividing the numerator
+    @test evaluate(-2*x^2//(x+y), [2, 3]) == -8//5
+    @test evaluate(x^2//x, [2, 3]) == 2
 end
 
 @testset "Generic.FactoredFracFieldElem.ZZ.valuation" begin


### PR DESCRIPTION
Raising a base to a negative exponent throws a `DomainError` whenever the values do not live in a field, as in `evaluate(X//(X+Y)^2, [2, 3])` over `ZZ`. Split the factors by the sign of their exponent, the way numerator and denominator do, and divide once at the end.

`evaluate(::FracElem{<:PolyRingElem}, ::Integer)` in `Fraction.jl` and `evaluate(::FactoredFracFieldElem, ::RingElement)` are ambiguous, so their intersection needs a method of its own. It delegates to the same routine rather than to numerator(f)//denominator(f), which would multiply the factorisation out.

Assisted-by: Claude Code (Opus 5)