### PR TITLE
Widen the identity special case of compose

### DIFF
--- a/src/generic/PolyRingHom.jl
+++ b/src/generic/PolyRingHom.jl
@@ -141,7 +141,8 @@ function compose(F::PolyRingAnyMap{D, C, <: Map, <: Any}, G::S) where {D, C, S <
 end
 
 # Special case for composing with the identity
-function compose(F::PolyRingAnyMap{D, C, <: Map, <: Any}, G::S) where {D, C, S <: IdentityMap{C}}
+function compose(F::PolyRingAnyMap{D, C, <: Map, <: Any}, G::S) where
+                {D, C, S <: AbstractAlgebra.Map(AbstractAlgebra.IdentityMap){C, C}}
   codomain(F) === domain(G) || error("Incompatible (co)domain in composition")
   f = _coefficient_map(F)
   if typeof(codomain(f)) === C


### PR DESCRIPTION
The special case for composing a `PolyRingAnyMap` with an identity map only covers `Generic.IdentityMap{C}`, while the method it disambiguates accepts any `Map{C, C, <:IdentityMap}`. Match the latter, so the whole intersection of the two candidates is covered.

Assisted-by: Claude Code (Opus 5)
